### PR TITLE
Fix main display height jumping issue

### DIFF
--- a/src/components/gymView.html
+++ b/src/components/gymView.html
@@ -1,6 +1,6 @@
 <div id="gymView" data-bind="if: Game.gameState() === GameConstants.GameState.gym">
 
-    <div style="position:relative; height: 220px;">
+    <div style="position:relative">
         <div id="gymCountdownView">
                 <div class="row" style="display: inline-block; vertical-align: middle;">
                     <div class="col-sm-6 offset-sm-3">
@@ -55,16 +55,4 @@
             </div>
         </div>
     </div>
-    <div class="card">
-        <table width="100%">
-            <tr>
-                <td width="50%"><span style="display: inline;">Pokémon Attack: <span
-                        data-bind="text: player.pokemonAttackObservable"></span></span></td>
-                <td width="50%"><span style="display: inline;">Click Attack: <span
-                        data-bind="text: player.clickAttackObservable"></span></span>
-                </td>
-            </tr>
-        </table>
-    </div>
-
 </div>

--- a/src/components/shopView.html
+++ b/src/components/shopView.html
@@ -1,19 +1,19 @@
 <div id="shopView"
      data-bind="if: Game.gameState() === GameConstants.GameState.shop">
-<div class="row justify-content-center" data-bind="foreach: ShopHandler.shopObservable().items">
-   <div class="col-sm-3"  data-bind="visible: ShopHandler.ownKeyItem(name())">
-       <div
-               data-bind="click: function() {ShopHandler.setSelected($index())}, attr: {class: ShopHandler.calculateCss($index())}">
-           <img src="" height="36px"
-                data-bind="attr:{ src: '/assets/images/items/' + name() + '.png' }">
-           <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
-           <p>
-               <img src="" class="currencyImage"
-                    data-bind="attr:{ src: '/assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
-               <span data-bind="text: totalPrice">Price</span>
-           </p>
-       </div>
-   </div>
+<div style="height: 140px; overflow-x: hidden; overflow-y: auto">
+    <div class="row justify-content-center" data-bind="foreach: ShopHandler.shopObservable().items">
+        <div class="col-4 col-md-2" data-bind="visible: ShopHandler.ownKeyItem(name())">
+            <div data-bind="click: function() {ShopHandler.setSelected($index())}, attr: {class: ShopHandler.calculateCss($index())}">
+                <img src="" height="36px" data-bind="attr:{ src: '/assets/images/items/' + name() + '.png' }">
+                <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
+                <p>
+                    <img src="" class="currencyImage"
+                            data-bind="attr:{ src: '/assets/images/currency/' + GameConstants.Currency[currency]+ '.png' }">
+                    <span data-bind="text: totalPrice">Price</span>
+                </p>
+            </div>
+        </div>
+    </div>
 </div>
 <div class="row justify-content-center">
    <div class="col-11 col-sm-10 col-md-11">

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -64,29 +64,29 @@
            </div>
        </ul>
    </div>
-   <div class="col-7 no-gutters">
+   <div class="col-6 no-gutters">
        <h2 class="pageItemTitle" data-bind="text: player.town().name()">Town Name</h2>
        <img class="townImage no-select" src=""
             data-bind="attr:{ src: '/assets/images/towns/' + player.town().name() + '.png' }"/>
    </div>
-   <div class="col no-gutters"></div>
-
-</div>
-<div data-bind="if: (player.town().dungeon() && player.town() instanceof DungeonTown)">
-   <div class="card">
-       <!--Display all available Pokémon in this dungeon-->
-       <ul class="list-inline"
-           data-bind="foreach: player.town().dungeon().allPokemonNames">
-           <li class="list-inline-item" data-bind="if: player.alreadyCaughtPokemon($data)">
-               <img class="dungeon-pokemon-preview" src=""
-                    data-bind="attr:{ src: '/assets/images/pokemon/' + pokemonMap[$data].id + '.png' }"/>
-           </li>
-           <li class="list-inline-item"
-               data-bind="ifnot: player.alreadyCaughtPokemon($data)">
-               <img class="dungeon-pokemon-preview dungeon-pokemon-locked" src=""
-                    data-bind="attr:{ src: '/assets/images/pokemon/' + pokemonMap[$data].id + '.png' }"/>
-           </li>
-       </ul>
+   <div class="col no-gutters">
+        <div data-bind="if: (player.town().dungeon() && player.town() instanceof DungeonTown)">
+            <div class="card" style="border:none; height:240px; overflow-y: auto">
+                <!--Display all available Pokémon in this dungeon-->
+                <ul class="list-inline"
+                    data-bind="foreach: player.town().dungeon().allPokemonNames">
+                    <li class="list-inline-item" data-bind="if: player.alreadyCaughtPokemon($data)">
+                        <img class="dungeon-pokemon-preview" src=""
+                                data-bind="attr:{ src: '/assets/images/pokemon/' + pokemonMap[$data].id + '.png' }"/>
+                    </li>
+                    <li class="list-inline-item"
+                        data-bind="ifnot: player.alreadyCaughtPokemon($data)">
+                        <img class="dungeon-pokemon-preview dungeon-pokemon-locked" src=""
+                                data-bind="attr:{ src: '/assets/images/pokemon/' + pokemonMap[$data].id + '.png' }"/>
+                    </li>
+                </ul>
+            </div>
+        </div>
    </div>
 </div>
 </div>

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -10,7 +10,7 @@
         src="assets/images/questionmark.png">
 </div>
 
-<div class="row justify-content-center no-gutters" style="min-height: 100px;">
+<div class="row justify-content-center no-gutters">
    <div class="col no-gutters">
        <div data-bind="if: player.town() instanceof PokemonLeague">
            <ul class="nav flex-sm-column featureList pokemonLeagueList"

--- a/src/index.html
+++ b/src/index.html
@@ -124,45 +124,37 @@
         <!--Middle column-->
         <div class="col-lg-6 push-lg-3">
             <div id="interactionView" class="page-item" style="background-color: white">
-
-                <div data-bind="if: (Game.gameState() === GameConstants.GameState.fighting ||
-                                     Game.gameState() === GameConstants.GameState.dungeon ||
-                                     Game.gameState() === GameConstants.GameState.paused ||
-                                     Game.gameState() === GameConstants.GameState.town ||
-                                     Game.gameState() === GameConstants.GameState.shop)">
-                    <div class="card">
-                        <table width="100%">
-                            <tr>
-                                <td width="33.33%">
-                                    <span style="display: inline;">
-                                        <img title="Money" src="assets/images/currency/money.png">
-                                        <span id="playerMoney" data-bind="text: player.money">0</span>
-                                    </span>
-                                </td>
-                                <td width="33.33%">
-                                    <span style="display: inline;">
-                                        <img title="Dungeon Tokens" src="assets/images/currency/dungeonToken.png">
-                                        <span id="playerMoneyDungeon" data-bind="text: player.dungeonTokens">Not yet</span>
-                                    </span>
-                                </td>
-                                <td width="33.33%">
-                                    <span style="display: inline;">
-                                        <img title="Quest points" src="assets/images/currency/questPoint.png">
-                                        <span id="playerMoneyQuest" data-bind="text: player.questPoints">Not yet</span>
-                                    </span>
-                                </td>
-                            </tr>
-                        </table>
-                    </div>
+                <div class="card">
+                    <table width="100%">
+                        <tr>
+                            <td width="33.33%">
+                                <span style="display: inline;">
+                                    <img title="Money" src="assets/images/currency/money.png">
+                                    <span id="playerMoney" data-bind="text: player.money">0</span>
+                                </span>
+                            </td>
+                            <td width="33.33%">
+                                <span style="display: inline;">
+                                    <img title="Dungeon Tokens" src="assets/images/currency/dungeonToken.png">
+                                    <span id="playerMoneyDungeon" data-bind="text: player.dungeonTokens">Not yet</span>
+                                </span>
+                            </td>
+                            <td width="33.33%">
+                                <span style="display: inline;">
+                                    <img title="Quest points" src="assets/images/currency/questPoint.png">
+                                    <span id="playerMoneyQuest" data-bind="text: player.questPoints">Not yet</span>
+                                </span>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
 
                 <!--RouteBattleView-->
                 <!--Use the base battle layout for fighting and dungeons.-->
-                <div data-bind="if: (Game.gameState() === GameConstants.GameState.fighting || Game.gameState() === GameConstants.GameState.dungeon || Game.gameState() === GameConstants.GameState.paused || Game.gameState() === GameConstants.GameState.town)"
-                     id="routeBattleView">
+                <div id="routeBattleView" style="height:240px">
 
                     <div data-bind="if: Game.gameState() === GameConstants.GameState.fighting">
-                        <div style="height: 220px; display: block;" class="col-lg-12">
+                        <div style="display: block;" class="col-lg-12">
                             <div class="col-lg-12" style="display: block;">
                                 Route
                                 <span data-bind="text: player.route">number</span>
@@ -230,7 +222,7 @@
 
                     <!--If the player is in a dungeon-->
                     <div data-bind="if: Game.gameState() === GameConstants.GameState.dungeon">
-                        <div class="col-lg-12" style="display: block; height: 220px">
+                        <div class="col-lg-12" style="display: block">
                             <div>
                                 <span data-bind="text: DungeonRunner.dungeon.name()">Dungeon name</span>
                                 <!--If all Pokémon on the route are caught-->
@@ -308,38 +300,36 @@
                             </div>
                         </div>
                     </div>
-                    <div data-bind="ifnot: Game.gameState() === GameConstants.GameState.town">
-                        <div class="card">
-                            <table width="100%">
-                                <tr>
 
-                                    <td width="50%">
-                                    <span style="display: inline;">Pokémon Attack:
-                                        <span
-                                                data-bind="text: player.pokemonAttackObservable"></span>
-                                    </span>
-                                    </td>
-                                    <td width="50%">
-                                    <span style="display: inline;">Click Attack:
-                                        <span
-                                                data-bind="text: player.clickAttackObservable"></span>
-                                    </span>
-                                    </td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
+                    <!--TownView-->
+                    @import "townView.html"
+
+                    <!--GymView-->
+                    @import "gymView.html"
+
+                    <!--ShopView-->
+                    @import "shopView.html"
+
                 </div>
 
-                <!--TownView-->
 
-                @import "townView.html"
-
-                <!--GymView-->
-                @import "gymView.html"
-
-                <!--ShopView-->
-                @import "shopView.html"
+                
+                <div class="card">
+                    <table width="100%">
+                        <tr>
+                            <td width="50%">
+                            <span style="display: inline;">Pokémon Attack:
+                                <span data-bind="text: player.pokemonAttackObservable"></span>
+                            </span>
+                            </td>
+                            <td width="50%">
+                            <span style="display: inline;">Click Attack:
+                                <span data-bind="text: player.clickAttackObservable"></span>
+                            </span>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
             </div>
 
             <div data-bind="if: Game.gameState() === GameConstants.GameState.dungeon">

--- a/src/index.html
+++ b/src/index.html
@@ -151,7 +151,7 @@
 
                 <!--RouteBattleView-->
                 <!--Use the base battle layout for fighting and dungeons.-->
-                <div id="routeBattleView" style="height:240px">
+                <div id="routeBattleView" style="height:240px; overflow:hidden">
 
                     <div data-bind="if: Game.gameState() === GameConstants.GameState.fighting">
                         <div style="display: block;" class="col-lg-12">

--- a/src/styles/town.less
+++ b/src/styles/town.less
@@ -1,6 +1,6 @@
 .townImage {
   width: 100%;
-  height: 100%;
+  height: 240px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
The idea is simple: have the currencies bar and attack statistic bar appear at all times. Then, it's a simple matter of regulating the middle chunk to have a fixed height and have the images scale to it.

To this end, I made the following adjustments:
- Reorganized code so all the different views occur between the Currency and Attack bars.
- Made the views a little taller (at 240px) because I have to make room for 6 stacking buttons in the Pokemon League.
- Have all town images have the same height (240px).
- Moved dungeon Pokemon list to the side, so the dungeon image can take the full height. I had to make the image panel a tiny bit narrower to make the Pokemon list render well.

**In town:**
![image](https://user-images.githubusercontent.com/36806183/55048466-a3459c80-501e-11e9-8a9f-d36f763870b8.png)

**Dungeon (Pokemon list doesn't need scrolling)**
![image](https://user-images.githubusercontent.com/36806183/55048493-beb0a780-501e-11e9-9d65-842c45c4ed01.png)

**Dungeon (Pokemon list needs scrolling)**
![image](https://user-images.githubusercontent.com/36806183/55048508-cff9b400-501e-11e9-8b62-0aa940cf8d27.png)

One small issue I wasn't able to resolve, is that when fighting gyms, the display grows by a couple of pixels. I think it has to do with the `position:relative` style put into `gymView.html`. Maybe another dev may have ideas on fixing that.

#74 