### PR TITLE
Add linter (eslint)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  'env': {
+    'browser': true,
+    'es6': true
+  },
+  'globals': {
+    'Atomics': 'readonly',
+    'SharedArrayBuffer': 'readonly'
+  },
+  'parser': '@typescript-eslint/parser',
+  'parserOptions': {
+      'project': './tsconfig.json'
+  },
+  'extends': ['plugin:@typescript-eslint/recommended'],
+  'rules': {
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "start": "gulp",
     "website": "gulp website",
-    "test": "eslint --config ./.eslintrc.js --ext ts ./src/scripts ",
-    "test-fix": "eslint --config ./.eslintrc.js --ext ts --fix ./src/scripts "
+    "test": "eslint --config ./.eslintrc.js --ext ts ./src/scripts",
+    "test-error": "eslint --config ./.eslintrc.js --ext ts --quiet ./src/scripts",
+    "test-fix": "eslint --config ./.eslintrc.js --ext ts --fix ./src/scripts"
   },
   "repository": {
     "type": "git",
@@ -59,7 +60,7 @@
     "natives": "^1.1.6",
     "run-sequence": "^1.1.4",
     "tslint": "^3.15.1",
-    "typescript": "^2.7.1"
+    "typescript": "^3.5.1"
   },
   "dependencies": {
     "@types/bootstrap": "^3.3.37",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "gulp",
     "website": "gulp website",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint --config ./.eslintrc.js --ext ts ./src/scripts ",
+    "test-fix": "eslint --config ./.eslintrc.js --ext ts --fix ./src/scripts "
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,8 @@
   "homepage": "https://github.com/Ishadijcks/pokeclicker#readme",
   "devDependencies": {
     "@types/jquery": "^3.3.0",
+    "@typescript-eslint/eslint-plugin": "^1.9.0",
+    "@typescript-eslint/parser": "^1.9.0",
     "babel-core": "^6.26.3",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
@@ -32,6 +35,7 @@
     "browser-sync": "^2.24.4",
     "del": "^2.2.2",
     "es6-promise": "^4.2.4",
+    "eslint": "^5.16.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-bootstrap-configurator": "^0.4.1",

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -323,7 +323,7 @@ namespace GameConstants {
     }
 
     export class Option {
-        text: String;
+        text: string;
         value: any;
 
         constructor(text, value) {

--- a/src/scripts/Main.ts
+++ b/src/scripts/Main.ts
@@ -229,8 +229,8 @@ class Game {
             top: -100,
             opacity: 0
         }, 250 * Math.log(money) + 150,"linear",
-            function() {
-        $(this).remove();
+        function() {
+            $(this).remove();
         });
     }
 }

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -14,17 +14,17 @@ class Player {
     private _route: KnockoutObservable<number>;
     private _caughtPokemonList: KnockoutObservableArray<CaughtPokemon>;
 
-    private _defeatedAmount: Array<KnockoutObservable<number>>;
+    private _defeatedAmount: KnockoutObservable<number>[];
 
-    get defeatedAmount(): Array<KnockoutObservable<number>> {
+    get defeatedAmount(): KnockoutObservable<number>[] {
         return this._defeatedAmount;
     }
 
-    private _routeKills: Array<KnockoutObservable<number>>;
+    private _routeKills: KnockoutObservable<number>[];
     private _routeKillsNeeded: KnockoutObservable<number>;
     private _region: KnockoutObservable<GameConstants.Region>;
     private _gymBadges: KnockoutObservableArray<GameConstants.Badge>;
-    private _pokeballs: Array<KnockoutObservable<number>>;
+    private _pokeballs: KnockoutObservable<number>[];
     private _notCaughtBallSelection: KnockoutObservable<GameConstants.Pokeball>;
     private _alreadyCaughtBallSelection: KnockoutObservable<GameConstants.Pokeball>;
     private _sortOption: KnockoutObservable<GameConstants.SortOptionsEnum>;
@@ -32,9 +32,9 @@ class Player {
     private _town: KnockoutObservable<Town>;
     private _currentTown: KnockoutObservable<string>;
     private _starter: GameConstants.Starter;
-    private _oakItemExp: Array<KnockoutObservable<number>>;
+    private _oakItemExp: KnockoutObservable<number>[];
     private _oakItemsEquipped: string[];
-    private _eggList: Array<KnockoutObservable<Egg | void>>;
+    private _eggList: KnockoutObservable<Egg | void>[];
     private _eggSlots: KnockoutObservable<number>;
 
     constructor(savedPlayer?) {
@@ -203,8 +203,8 @@ class Player {
     private _maxUndergroundItems: KnockoutObservable<number>;
     private _mineEnergyRegenTime: KnockoutObservable<number>;
 
-    private _shardUpgrades: Array<Array<KnockoutObservable<number>>>;
-    private _shardsCollected: Array<KnockoutObservable<number>>;
+    private _shardUpgrades: KnockoutObservable<number>[][];
+    private _shardsCollected: KnockoutObservable<number>[];
 
     private _keyItems: KnockoutObservableArray<string> = ko.observableArray<string>();
     public clickAttackObservable: KnockoutComputed<number>;
@@ -217,7 +217,7 @@ class Player {
 
     public statistics: Statistics;
 
-    public completedQuestList: Array<KnockoutObservable<boolean>>;
+    public completedQuestList: KnockoutObservable<boolean>[];
     public questRefreshes: number;
     public _questPoints: KnockoutObservable<number>;
     public _questXP: KnockoutObservable<number>;
@@ -277,7 +277,7 @@ class Player {
         return false;
     }
 
-    set defeatedAmount(value: Array<KnockoutObservable<number>>) {
+    set defeatedAmount(value: KnockoutObservable<number>[]) {
         this._defeatedAmount = value;
     }
 
@@ -317,7 +317,7 @@ class Player {
         return this.oakItemExp[item]();
     }
 
-    private _caughtAmount: Array<KnockoutObservable<number>>;
+    private _caughtAmount: KnockoutObservable<number>[];
 
     public calculateClickAttack(): number {
         let oakItemBonus = OakItemRunner.isActive(GameConstants.OakItem.Poison_Barb) ? (1 + OakItemRunner.calculateBonus(GameConstants.OakItem.Poison_Barb) / 100) : 1;
@@ -396,7 +396,7 @@ class Player {
     }
 
     public alreadyCaughtPokemonShiny(pokemonName: string) {
-        for (let i: number = 0; i < this.caughtShinyList().length; i++) {
+        for (let i = 0; i < this.caughtShinyList().length; i++) {
             if (this.caughtShinyList()[i] == pokemonName) {
                 return true;
             }
@@ -565,13 +565,13 @@ class Player {
         return cost;
     }
 
-    public sortedPokemonList(): KnockoutComputed<Array<CaughtPokemon>> {
+    public sortedPokemonList(): KnockoutComputed<CaughtPokemon[]> {
         return ko.pureComputed(function () {
             return this._caughtPokemonList().sort(PokemonHelper.compareBy(GameConstants.SortOptionsEnum[player._sortOption()], player._sortDescending()));
         }, this).extend({rateLimit: player.calculateCatchTime()})
     }
 
-    public maxLevelPokemonList(): KnockoutComputed<Array<CaughtPokemon>> {
+    public maxLevelPokemonList(): KnockoutComputed<CaughtPokemon[]> {
         return ko.pureComputed(function () {
             return this._caughtPokemonList().filter((pokemon) => {
                 return pokemon.levelObservable() == 100 && !pokemon.breeding();
@@ -579,11 +579,11 @@ class Player {
         }, this)
     }
 
-    get caughtAmount(): Array<KnockoutObservable<number>> {
+    get caughtAmount(): KnockoutObservable<number>[] {
         return this._caughtAmount;
     }
 
-    set caughtAmount(value: Array<KnockoutObservable<number>>) {
+    set caughtAmount(value: KnockoutObservable<number>[]) {
         this._caughtAmount = value;
     }
 
@@ -632,11 +632,11 @@ class Player {
         Game.animateMoney(tokens,'playerMoneyDungeon');
     }
 
-    get routeKills(): Array<KnockoutObservable<number>> {
+    get routeKills(): KnockoutObservable<number>[] {
         return this._routeKills;
     }
 
-    set routeKills(value: Array<KnockoutObservable<number>>) {
+    set routeKills(value: KnockoutObservable<number>[]) {
         this._routeKills = value;
     }
 
@@ -724,19 +724,19 @@ class Player {
         this._starter = value;
     }
 
-    get oakItemExp(): Array<KnockoutObservable<number>> {
+    get oakItemExp(): KnockoutObservable<number>[] {
         return this._oakItemExp;
     }
 
-    set oakItemExp(value: Array<KnockoutObservable<number>>) {
+    set oakItemExp(value: KnockoutObservable<number>[]) {
         this._oakItemExp = value;
     }
 
-    get eggList(): Array<KnockoutObservable<Egg | void>> {
+    get eggList(): KnockoutObservable<Egg | void>[] {
         return this._eggList;
     }
 
-    set eggList(value: Array<KnockoutObservable<Egg | void>>) {
+    set eggList(value: KnockoutObservable<Egg | void>[]) {
         this._eggList = value;
     }
 
@@ -896,19 +896,19 @@ class Player {
         this.plotList[i]().isUnlocked(true);
     }
 
-    get shardUpgrades(): Array<Array<KnockoutObservable<number>>> {
+    get shardUpgrades(): KnockoutObservable<number>[][] {
         return this._shardUpgrades;
     }
 
-    set shardUpgrades(value: Array<Array<KnockoutObservable<number>>>) {
+    set shardUpgrades(value: KnockoutObservable<number>[][]) {
         this._shardUpgrades = value;
     }
 
-    get shardsCollected(): Array<KnockoutObservable<number>> {
+    get shardsCollected(): KnockoutObservable<number>[] {
         return this._shardsCollected;
     }
 
-    set shardsCollected(value: Array<KnockoutObservable<number>>) {
+    set shardsCollected(value: KnockoutObservable<number>[]) {
         this._shardsCollected = value;
     }
 

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -64,7 +64,7 @@ class Save {
      * @param       keep : string[] An array of property names that should be kept
      * @returns {Object} : The original object with only the specified properties
      */
-    public static filter(object: any, keep: string[]): Object {
+    public static filter(object: any, keep: string[]): Record<string, any> {
         let filtered = {}, prop;
         for (prop in object) {
             if (keep.indexOf(prop) > -1) {
@@ -90,8 +90,8 @@ class Save {
         return res;
     }
 
-    public static initializePlots(saved?: Array<any>): KnockoutObservable<Plot>[] {
-        let plotList: Array<KnockoutObservable<Plot>>;
+    public static initializePlots(saved?: any[]): KnockoutObservable<Plot>[] {
+        let plotList: KnockoutObservable<Plot>[];
         if (saved) {
             plotList = saved.map((p) => {
                 let berry;
@@ -114,7 +114,7 @@ class Save {
         return plotList;
     }
 
-    public static initializeShards(saved?: Array<Array<number>>): Array<Array<KnockoutObservable<number>>> {
+    public static initializeShards(saved?: number[][]): KnockoutObservable<number>[][] {
         let res;
         if (saved) {
             res = saved.map((type) => {
@@ -167,7 +167,7 @@ class Save {
         $('#saveModal').modal('hide')
     }
 
-    public static convertShinies(list: Array<string>) {
+    public static convertShinies(list: string[]) {
         let converted = [];
         for (let pokemon of list) {
             let shiny = parseInt(pokemon['shiny']);

--- a/src/scripts/achievements/AttackRequirement.ts
+++ b/src/scripts/achievements/AttackRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class AttackRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/CapturedRequirement.ts
+++ b/src/scripts/achievements/CapturedRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class CapturedRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/ClearDungeonRequirement.ts
+++ b/src/scripts/achievements/ClearDungeonRequirement.ts
@@ -3,7 +3,7 @@
 class ClearDungeonRequirement extends Requirement {
     private dungeonIndex: number; // Gym name index in array GameConstants.Gyms
 
-    constructor(value: number, dungeonIndex:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor(value: number, dungeonIndex: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
         this.dungeonIndex = dungeonIndex;
     }

--- a/src/scripts/achievements/ClearGymRequirement.ts
+++ b/src/scripts/achievements/ClearGymRequirement.ts
@@ -3,7 +3,7 @@
 class ClearGymRequirement extends Requirement {
     private gymIndex: number; // Gym name index in array GameConstants.Gyms
 
-    constructor(value: number, gymIndex:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor(value: number, gymIndex: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
         this.gymIndex = gymIndex;
     }

--- a/src/scripts/achievements/ClickRequirement.ts
+++ b/src/scripts/achievements/ClickRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class ClickRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/DefeatedRequirement.ts
+++ b/src/scripts/achievements/DefeatedRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class DefeatedRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/DiamondRequirement.ts
+++ b/src/scripts/achievements/DiamondRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class DiamondRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/DigDeeperRequirement.ts
+++ b/src/scripts/achievements/DigDeeperRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class DigDeeperRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/DigItemsRequirement.ts
+++ b/src/scripts/achievements/DigItemsRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class DigItemsRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/HatchRequirement.ts
+++ b/src/scripts/achievements/HatchRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class HatchRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/achievements/MoneyRequirement.ts
+++ b/src/scripts/achievements/MoneyRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class MoneyRequirement extends Requirement{
-    constructor( requiredValue:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( requiredValue: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(requiredValue, type);
     }
 

--- a/src/scripts/achievements/RouteKillRequirement.ts
+++ b/src/scripts/achievements/RouteKillRequirement.ts
@@ -3,7 +3,7 @@
 class RouteKillRequirement extends Requirement {
     private route: number;
 
-    constructor(value: number, route:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor(value: number, route: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
         this.route = route;
     }

--- a/src/scripts/achievements/Statistics.ts
+++ b/src/scripts/achievements/Statistics.ts
@@ -4,17 +4,17 @@ class Statistics {
     public hatchedEggs: KnockoutObservable<number>;
     public pokemonCaptured: KnockoutObservable<number>;
     public pokemonDefeated: KnockoutObservable<number>;
-    public gymsDefeated: Array<KnockoutObservable<number>>;
-    public dungeonsCleared: Array<KnockoutObservable<number>>;
+    public gymsDefeated: KnockoutObservable<number>[];
+    public dungeonsCleared: KnockoutObservable<number>[];
     public digItems: KnockoutObservable<number>; // Total treasure found in underground
     public digDeeper: KnockoutObservable<number>; // Total underground layers completed
     public totalMoney: KnockoutObservable<number>;
     public totalTokens: KnockoutObservable<number>;
     public totalQuestPoints: KnockoutObservable<number>;
-    public pokeballsUsed: Array<KnockoutObservable<number>>;
-    public pokeballsBought: Array<KnockoutObservable<number>>;
-    public totalShards: Array<KnockoutObservable<number>>;
-    public oakItemUses: Array<KnockoutObservable<number>>;
+    public pokeballsUsed: KnockoutObservable<number>[];
+    public pokeballsBought: KnockoutObservable<number>[];
+    public totalShards: KnockoutObservable<number>[];
+    public oakItemUses: KnockoutObservable<number>[];
 
     private static readonly arraySizes = {
         "gymsDefeated": GameConstants.KantoGyms.length + GameConstants.JohtoGyms.length,

--- a/src/scripts/achievements/TokenRequirement.ts
+++ b/src/scripts/achievements/TokenRequirement.ts
@@ -1,7 +1,7 @@
 ///<reference path="Requirement.ts"/>
 
 class TokenRequirement extends Requirement{
-    constructor( value:number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+    constructor( value: number, type: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, type);
     }
 

--- a/src/scripts/dungeons/DungeonMap.ts
+++ b/src/scripts/dungeons/DungeonMap.ts
@@ -113,11 +113,11 @@ class DungeonMap {
         let mapList: DungeonTile[] = [];
 
         mapList.push(new DungeonTile(GameConstants.DungeonTile.boss));
-        for (let i: number = 0; i < this.size; i++) {
+        for (let i = 0; i < this.size; i++) {
             mapList.push(new DungeonTile(GameConstants.DungeonTile.chest));
         }
 
-        for (let i: number = 0; i < this.size * 2 + 3; i++) {
+        for (let i = 0; i < this.size * 2 + 3; i++) {
             mapList.push(new DungeonTile(GameConstants.DungeonTile.enemy));
         }
 

--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -39,10 +39,10 @@ class GymRunner {
 
     public static resetGif(){
         let $img = $('#gif-go');
-            $img.show();
-            setTimeout(function() {
-                $img.attr('src', 'assets/gifs/go.gif');
-            }, 0);
+        $img.show();
+        setTimeout(function() {
+            $img.attr('src', 'assets/gifs/go.gif');
+        }, 0);
     }
 
     public static tick() {
@@ -83,9 +83,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
     $('#receiveBadgeModal').on('hidden.bs.modal', function () {
 
-       if(GymBattle.gym.badgeReward == GameConstants.Badge.Soul){
-           player.gainKeyItem("Safari ticket");
-       }
+        if(GymBattle.gym.badgeReward == GameConstants.Badge.Soul){
+            player.gainKeyItem("Safari ticket");
+        }
 
     });
 });

--- a/src/scripts/items/EvolutionStone.ts
+++ b/src/scripts/items/EvolutionStone.ts
@@ -14,7 +14,7 @@ class EvolutionStone extends Item {
         player.gainItem(GameConstants.StoneType[this.type], n)
     }
 
-    public use(pokemon?:string) {
+    public use(pokemon?: string) {
         let shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_STONE);
         let evolution = EvolutionStone.computeEvolution(this.type, pokemon);
         player.capturePokemon(evolution, shiny, false);

--- a/src/scripts/items/Item.ts
+++ b/src/scripts/items/Item.ts
@@ -38,7 +38,7 @@ abstract class Item {
 
     abstract use();
 
-    isAvailable() : boolean {
+    isAvailable(): boolean {
         return true;
     }
 

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -5,7 +5,7 @@ class ItemHandler {
     public static amountSelected: KnockoutObservable<number> = ko.observable(1);
     static amount: KnockoutObservable<number> = ko.observable(1);
 
-    public static useItem(name:string){
+    public static useItem(name: string){
         ItemList[name].use();
         player.itemList[name](player.itemList[name]-1);
     }

--- a/src/scripts/items/buyKeyItem.ts
+++ b/src/scripts/items/buyKeyItem.ts
@@ -1,25 +1,25 @@
 class buyKeyItem extends Item {
     
-        type: GameConstants.KeyItemType;
+    type: GameConstants.KeyItemType;
     
-        constructor(type: GameConstants.KeyItemType) {
-            let basePrice = GameConstants.ItemPrice[GameConstants.KeyItemType[type]];
-            let priceMultiplier = 1;
-            super(GameConstants.KeyItemType[type], basePrice, priceMultiplier, GameConstants.Currency.questPoint);
-            this.type = type;
-            this.totalPrice = ko.computed(function(){return this.basePrice}, this);
-        }
+    constructor(type: GameConstants.KeyItemType) {
+        let basePrice = GameConstants.ItemPrice[GameConstants.KeyItemType[type]];
+        let priceMultiplier = 1;
+        super(GameConstants.KeyItemType[type], basePrice, priceMultiplier, GameConstants.Currency.questPoint);
+        this.type = type;
+        this.totalPrice = ko.computed(function(){return this.basePrice}, this);
+    }
     
-        buy(amt: number) {
-            player.gainKeyItem(GameConstants.KeyItemType[this.type].replace("_", " "))
-        }
+    buy(amt: number) {
+        player.gainKeyItem(GameConstants.KeyItemType[this.type].replace("_", " "))
+    }
     
-        use() {
-        }
+    use() {
+    }
 
-        isAvailable(): boolean {
-            return super.isAvailable() && !player.hasKeyItem(this.name().replace("_", " "));
-        }
+    isAvailable(): boolean {
+        return super.isAvailable() && !player.hasKeyItem(this.name().replace("_", " "));
+    }
 }
     
     

--- a/src/scripts/keyitems/KeyItem.ts
+++ b/src/scripts/keyitems/KeyItem.ts
@@ -13,12 +13,12 @@ class KeyItem {
             return;
         }
         this.unlockReq = ko.computed<boolean>(unlockReq);
-            this.unlocker = this.unlockReq.subscribe(() => {
-                if (this.unlockReq()) {
-                    player.gainKeyItem(this.name());
-                    this.unlocker.dispose();
-                }
-            })
+        this.unlocker = this.unlockReq.subscribe(() => {
+            if (this.unlockReq()) {
+                player.gainKeyItem(this.name());
+                this.unlocker.dispose();
+            }
+        })
     }
 
     public isUnlocked(): boolean {

--- a/src/scripts/keyitems/KeyItemHandler.ts
+++ b/src/scripts/keyitems/KeyItemHandler.ts
@@ -49,7 +49,7 @@ class KeyItemHandler {
         KeyItemHandler.selectedItem(item);
     }
 
-    public static getKeyItemByName(name:string): KeyItem{
+    public static getKeyItemByName(name: string): KeyItem{
         for(let i = 0 ; i<KeyItemHandler.keyItemList.length; i++){
             if(KeyItemHandler.keyItemList[i]().name() == name){
                 return KeyItemHandler.keyItemList[i]();
@@ -57,7 +57,7 @@ class KeyItemHandler {
         }
     }
 
-    public static getKeyItemObservableByName(name:string): KnockoutObservable<KeyItem>{
+    public static getKeyItemObservableByName(name: string): KnockoutObservable<KeyItem>{
         for(let i = 0 ; i<KeyItemHandler.keyItemList.length; i++){
             if(KeyItemHandler.keyItemList[i]().name() == name){
                 return KeyItemHandler.keyItemList[i];
@@ -65,7 +65,7 @@ class KeyItemHandler {
         }
     }
 
-    public static hover(name:string){
+    public static hover(name: string){
         KeyItemHandler.inspectedItem(KeyItemHandler.getKeyItemByName(name));
     }
 
@@ -73,7 +73,7 @@ class KeyItemHandler {
         KeyItemHandler.inspectedItem(KeyItemHandler.selectedItem());
     }
 
-    public static click(name:string){
+    public static click(name: string){
         let item: KeyItem = KeyItemHandler.getKeyItemByName(name);
         KeyItemHandler.selectedItem(item);
     }

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -46,7 +46,7 @@ class PokedexHelper {
         PokedexHelper.filteredList(PokedexHelper.getList());
     }
 
-    public static getList(): Array<object> {
+    public static getList(): object[] {
         let filter = PokedexHelper.getFilters();
 
         let highestDefeated = 0;

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -86,7 +86,7 @@ class PokemonFactory {
         let maxHealth: number = Math.floor(baseHealth * (1 + (chestsOpened / 5)));
         let catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         let exp: number = basePokemon.exp;
-        let money: number = 0;
+        let money = 0;
         let shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
         return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny, GameConstants.DUNGEON_SHARDS);
     }
@@ -100,7 +100,7 @@ class PokemonFactory {
         let maxHealth: number = Math.floor(bossPokemon.baseHealth * (1 + (chestsOpened / 5)));
         let catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         let exp: number = basePokemon.exp;
-        let money: number = 0;
+        let money = 0;
         let shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
         return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, bossPokemon.level, catchRate, exp, money, shiny, GameConstants.DUNGEON_BOSS_SHARDS);
     }

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -2040,1327 +2040,1327 @@ const pokemonList = [
         "eggCycles": 120
     },
     {
-      "id": 152,
-      "name": "Chikorita",
-      "catchRate": 45,
-      "evolution": "Bayleef",
-      "evoLevel": 16,
-      "type": [
-        "Grass"
-      ],
-      "attack": 65,
-      "levelType": "mediumslow",
-      "exp": 64,
-      "eggCycles": 20
-    },
-    {
-      "id": 153,
-      "name": "Bayleef",
-      "catchRate": 45,
-      "evolution": "Meganium",
-      "evoLevel": 32,
-      "type": [
-        "Grass"
-      ],
-      "attack": 80,
-      "levelType": "mediumslow",
-      "exp": 142,
-      "eggCycles": 20
-    },
-    {
-      "id": 154,
-      "name": "Meganium",
-      "catchRate": 45,
-      "type": [
-        "Grass"
-      ],
-      "attack": 100,
-      "levelType": "mediumslow",
-      "exp": 236,
-      "eggCycles": 20
-    },
-    {
-      "id": 155,
-      "name": "Cyndaquil",
-      "catchRate": 45,
-      "evolution": "Quilava",
-      "evoLevel": 14,
-      "type": [
-        "Fire"
-      ],
-      "attack": 52,
-      "levelType": "mediumslow",
-      "exp": 62,
-      "eggCycles": 20
-    },
-    {
-      "id": 156,
-      "name": "Quilava",
-      "catchRate": 45,
-      "evolution": "Typhlosion",
-      "evoLevel": 36,
-      "type": [
-        "Fire"
-      ],
-      "attack": 65,
-      "levelType": "mediumslow",
-      "exp": 142,
-      "eggCycles": 20
-    },
-    {
-      "id": 157,
-      "name": "Typhlosion",
-      "catchRate": 45,
-      "type": [
-        "Fire"
-      ],
-      "attack": 85,
-      "levelType": "mediumslow",
-      "exp": 240,
-      "eggCycles": 20
-    },
-    {
-      "id": 158,
-      "name": "Totodile",
-      "catchRate": 45,
-      "evolution": "Croconaw",
-      "evoLevel": 18,
-      "type": [
-        "Water"
-      ],
-      "attack": 65,
-      "levelType": "mediumslow",
-      "exp": 63,
-      "eggCycles": 20
-    },
-    {
-      "id": 159,
-      "name": "Croconaw",
-      "catchRate": 45,
-      "evolution": "Feraligatr",
-      "evoLevel": 30,
-      "type": [
-        "Water"
-      ],
-      "attack": 80,
-      "levelType": "mediumslow",
-      "exp": 142,
-      "eggCycles": 20
-    },
-    {
-      "id": 160,
-      "name": "Feraligatr",
-      "catchRate": 45,
-      "type": [
-        "Water"
-      ],
-      "attack": 105,
-      "levelType": "mediumslow",
-      "exp": 239,
-      "eggCycles": 20
-    },
-    {
-      "id": 161,
-      "name": "Sentret",
-      "catchRate": 255,
-      "evolution": "Furret",
-      "evoLevel": 15,
-      "type": [
-        "Normal"
-      ],
-      "attack": 46,
-      "levelType": "mediumfast",
-      "exp": 43,
-      "eggCycles": 15
-    },
-    {
-      "id": 162,
-      "name": "Furret",
-      "catchRate": 90,
-      "type": [
-        "Normal"
-      ],
-      "attack": 76,
-      "levelType": "mediumfast",
-      "exp": 145,
-      "eggCycles": 15
-    },
-    {
-      "id": 163,
-      "name": "Hoothoot",
-      "catchRate": 255,
-      "evolution": "Noctowl",
-      "evoLevel": 20,
-      "type": [
-        "Normal",
-        "Flying"
-      ],
-      "attack": 56,
-      "levelType": "mediumfast",
-      "exp": 52,
-      "eggCycles": 15
-    },
-    {
-      "id": 164,
-      "name": "Noctowl",
-      "catchRate": 90,
-      "type": [
-        "Normal",
-        "Flying"
-      ],
-      "attack": 96,
-      "levelType": "mediumfast",
-      "exp": 158,
-      "eggCycles": 15
-    },
-    {
-      "id": 165,
-      "name": "Ledyba",
-      "catchRate": 255,
-      "evolution": "Ledian",
-      "evoLevel": 18,
-      "type": [
-        "Bug",
-        "Flying"
-      ],
-      "attack": 80,
-      "levelType": "fast",
-      "exp": 53,
-      "eggCycles": 15
-    },
-    {
-      "id": 166,
-      "name": "Ledian",
-      "catchRate": 90,
-      "type": [
-        "Bug",
-        "Flying"
-      ],
-      "attack": 110,
-      "levelType": "fast",
-      "exp": 137,
-      "eggCycles": 15
-    },
-    {
-      "id": 167,
-      "name": "Spinarak",
-      "catchRate": 255,
-      "evolution": "Ariados",
-      "evoLevel": 22,
-      "type": [
-        "Bug",
-        "Poison"
-      ],
-      "attack": 60,
-      "levelType": "fast",
-      "exp": 50,
-      "eggCycles": 15
-    },
-    {
-      "id": 168,
-      "name": "Ariados",
-      "catchRate": 90,
-      "type": [
-        "Bug",
-        "Poison"
-      ],
-      "attack": 90,
-      "levelType": "fast",
-      "exp": 140,
-      "eggCycles": 15
-    },
-    {
-      "id": 169,
-      "name": "Crobat",
-      "catchRate": 90,
-      "type": [
-        "Poison",
-        "Flying"
-      ],
-      "attack": 90,
-      "levelType": "mediumfast",
-      "exp": 241,
-      "eggCycles": 15
-    },
-    {
-      "id": 170,
-      "name": "Chinchou",
-      "catchRate": 190,
-      "evolution": "Lanturn",
-      "evoLevel": 27,
-      "type": [
-        "Water",
-        "Electric"
-      ],
-      "attack": 56,
-      "levelType": "slow",
-      "exp": 66,
-      "eggCycles": 20
-    },
-    {
-      "id": 171,
-      "name": "Lanturn",
-      "catchRate": 75,
-      "type": [
-        "Water",
-        "Electric"
-      ],
-      "attack": 76,
-      "levelType": "slow",
-      "exp": 161,
-      "eggCycles": 20
-    },
-    {
-      "id": 172,
-      "name": "Pichu",
-      "catchRate": 190,
-      "evolution": "Pikachu",
-      "evoLevel": 100,
-      "type": [
-        "Electric"
-      ],
-      "attack": 40,
-      "levelType": "mediumfast",
-      "exp": 41,
-      "eggCycles": 10
-    },
-    {
-      "id": 173,
-      "name": "Cleffa",
-      "catchRate": 150,
-      "evolution": "Clefairy",
-      "evoLevel": 100,
-      "type": [
-        "Fairy"
-      ],
-      "attack": 55,
-      "levelType": "fast",
-      "exp": 44,
-      "eggCycles": 10
-    },
-    {
-      "id": 174,
-      "name": "Igglybuff",
-      "catchRate": 170,
-      "evolution": "Jigglypuff",
-      "evoLevel": 100,
-      "type": [
-        "Normal",
-        "Fairy"
-      ],
-      "attack": 30,
-      "levelType": "fast",
-      "exp": 42,
-      "eggCycles": 10
-    },
-    {
-      "id": 175,
-      "name": "Togepi",
-      "catchRate": 190,
-      "evolution": "Togetic",
-      "evoLevel": 100,
-      "type": [
-        "Fairy"
-      ],
-      "attack": 65,
-      "levelType": "fast",
-      "exp": 49,
-      "eggCycles": 10
-    },
-    {
-      "id": 176,
-      "name": "Togetic",
-      "catchRate": 75,
-      "type": [
-        "Fairy",
-        "Flying"
-      ],
-      "attack": 105,
-      "levelType": "fast",
-      "exp": 142,
-      "eggCycles": 10
-    },
-    {
-      "id": 177,
-      "name": "Natu",
-      "catchRate": 190,
-      "evolution": "Xatu",
-      "evoLevel": 25,
-      "type": [
-        "Psychic",
-        "Flying"
-      ],
-      "attack": 50,
-      "levelType": "mediumfast",
-      "exp": 64,
-      "eggCycles": 20
-    },
-    {
-      "id": 178,
-      "name": "Xatu",
-      "catchRate": 75,
-      "type": [
-        "Psychic",
-        "Flying"
-      ],
-      "attack": 75,
-      "levelType": "mediumfast",
-      "exp": 165,
-      "eggCycles": 20
-    },
-    {
-      "id": 179,
-      "name": "Mareep",
-      "catchRate": 235,
-      "evolution": "Flaaffy",
-      "evoLevel": 15,
-      "type": [
-        "Electric"
-      ],
-      "attack": 45,
-      "levelType": "mediumslow",
-      "exp": 56,
-      "eggCycles": 20
-    },
-    {
-      "id": 180,
-      "name": "Flaaffy",
-      "catchRate": 120,
-      "evolution": "Ampharos",
-      "evoLevel": 30,
-      "type": [
-        "Electric"
-      ],
-      "attack": 60,
-      "levelType": "mediumslow",
-      "exp": 128,
-      "eggCycles": 20
-    },
-    {
-      "id": 181,
-      "name": "Ampharos",
-      "catchRate": 45,
-      "type": [
-        "Electric"
-      ],
-      "attack": 110,
-      "levelType": "mediumslow",
-      "exp": 230,
-      "eggCycles": 20
-    },
-    {
-      "id": 182,
-      "name": "Bellossom",
-      "catchRate": 45,
-      "type": [
-        "Grass"
-      ],
-      "attack": 100,
-      "levelType": "mediumslow",
-      "exp": 221,
-      "eggCycles": 20
-    },
-    {
-      "id": 183,
-      "name": "Marill",
-      "catchRate": 190,
-      "evolution": "Azumarill",
-      "evoLevel": 18,
-      "type": [
-        "Water",
-        "Fairy"
-      ],
-      "attack": 50,
-      "levelType": "fast",
-      "exp": 88,
-      "eggCycles": 10
-    },
-    {
-      "id": 184,
-      "name": "Azumarill",
-      "catchRate": 75,
-      "type": [
-        "Water",
-        "Fairy"
-      ],
-      "attack": 80,
-      "levelType": "fast",
-      "exp": 189,
-      "eggCycles": 10
-    },
-    {
-      "id": 185,
-      "name": "Sudowoodo",
-      "catchRate": 65,
-      "type": [
-        "Rock"
-      ],
-      "attack": 100,
-      "levelType": "mediumfast",
-      "exp": 144,
-      "eggCycles": 20
-    },
-    {
-      "id": 186,
-      "name": "Politoed",
-      "catchRate": 45,
-      "type": [
-        "Water"
-      ],
-      "attack": 100,
-      "levelType": "mediumslow",
-      "exp": 225,
-      "eggCycles": 20
-    },
-    {
-      "id": 187,
-      "name": "Hoppip",
-      "catchRate": 255,
-      "evolution": "Skiploom",
-      "evoLevel": 18,
-      "type": [
-        "Grass",
-        "Flying"
-      ],
-      "attack": 55,
-      "levelType": "mediumslow",
-      "exp": 50,
-      "eggCycles": 20
-    },
-    {
-      "id": 188,
-      "name": "Skiploom",
-      "catchRate": 120,
-      "evolution": "Jumpluff",
-      "evoLevel": 27,
-      "type": [
-        "Grass",
-        "Flying"
-      ],
-      "attack": 65,
-      "levelType": "mediumslow",
-      "exp": 119,
-      "eggCycles": 20
-    },
-    {
-      "id": 189,
-      "name": "Jumpluff",
-      "catchRate": 45,
-      "type": [
-        "Grass",
-        "Flying"
-      ],
-      "attack": 95,
-      "levelType": "mediumslow",
-      "exp": 207,
-      "eggCycles": 20
-    },
-    {
-      "id": 190,
-      "name": "Aipom",
-      "catchRate": 45,
-      "type": [
-        "Normal"
-      ],
-      "attack": 70,
-      "levelType": "fast",
-      "exp": 72,
-      "eggCycles": 20
-    },
-    {
-      "id": 191,
-      "name": "Sunkern",
-      "catchRate": 235,
-      "evolution": "Sunflora",
-      "evoLevel": "Sun_stone",
-      "type": [
-        "Grass"
-      ],
-      "attack": 30,
-      "levelType": "mediumslow",
-      "exp": 36,
-      "eggCycles": 20
-    },
-    {
-      "id": 192,
-      "name": "Sunflora",
-      "catchRate": 120,
-      "type": [
-        "Grass"
-      ],
-      "attack": 85,
-      "levelType": "mediumslow",
-      "exp": 149,
-      "eggCycles": 20
-    },
-    {
-      "id": 193,
-      "name": "Yanma",
-      "catchRate": 75,
-      "type": [
-        "Bug",
-        "Flying"
-      ],
-      "attack": 65,
-      "levelType": "mediumfast",
-      "exp": 78,
-      "eggCycles": 20
-    },
-    {
-      "id": 194,
-      "name": "Wooper",
-      "catchRate": 255,
-      "evolution": "Quagsire",
-      "evoLevel": 20,
-      "type": [
-        "Water",
-        "Ground"
-      ],
-      "attack": 45,
-      "levelType": "mediumfast",
-      "exp": 42,
-      "eggCycles": 20
-    },
-    {
-      "id": 195,
-      "name": "Quagsire",
-      "catchRate": 90,
-      "type": [
-        "Water",
-        "Ground"
-      ],
-      "attack": 85,
-      "levelType": "mediumfast",
-      "exp": 151,
-      "eggCycles": 20
-    },
-    {
-      "id": 196,
-      "name": "Espeon",
-      "catchRate": 45,
-      "type": [
-        "Psychic"
-      ],
-      "attack": 95,
-      "levelType": "mediumfast",
-      "exp": 184,
-      "eggCycles": 35
-    },
-    {
-      "id": 197,
-      "name": "Umbreon",
-      "catchRate": 45,
-      "type": [
-        "Dark"
-      ],
-      "attack": 130,
-      "levelType": "mediumfast",
-      "exp": 184,
-      "eggCycles": 35
-    },
-    {
-      "id": 198,
-      "name": "Murkrow",
-      "catchRate": 30,
-      "type": [
-        "Dark",
-        "Flying"
-      ],
-      "attack": 85,
-      "levelType": "mediumslow",
-      "exp": 81,
-      "eggCycles": 20
-    },
-    {
-      "id": 199,
-      "name": "Slowking",
-      "catchRate": 70,
-      "type": [
-        "Water",
-        "Psychic"
-      ],
-      "attack": 110,
-      "levelType": "mediumfast",
-      "exp": 172,
-      "eggCycles": 20
-    },
-    {
-      "id": 200,
-      "name": "Misdreavus",
-      "catchRate": 45,
-      "type": [
-        "Ghost"
-      ],
-      "attack": 85,
-      "levelType": "fast",
-      "exp": 87,
-      "eggCycles": 25
-    },
-    {
-      "id": 201,
-      "name": "Unown",
-      "catchRate": 225,
-      "type": [
-        "Psychic"
-      ],
-      "attack": 72,
-      "levelType": "mediumfast",
-      "exp": 118,
-      "eggCycles": 40
-    },
-    {
-      "id": 202,
-      "name": "Wobbuffet",
-      "catchRate": 45,
-      "type": [
-        "Psychic"
-      ],
-      "attack": 58,
-      "levelType": "mediumfast",
-      "exp": 142,
-      "eggCycles": 20
-    },
-    {
-      "id": 203,
-      "name": "Girafarig",
-      "catchRate": 60,
-      "type": [
-        "Normal",
-        "Psychic"
-      ],
-      "attack": 80,
-      "levelType": "mediumfast",
-      "exp": 159,
-      "eggCycles": 20
-    },
-    {
-      "id": 204,
-      "name": "Pineco",
-      "catchRate": 190,
-      "evolution": "Forretress",
-      "evoLevel": 31,
-      "type": [
-        "Bug"
-      ],
-      "attack": 65,
-      "levelType": "mediumfast",
-      "exp": 58,
-      "eggCycles": 20
-    },
-    {
-      "id": 205,
-      "name": "Forretress",
-      "catchRate": 75,
-      "type": [
-        "Bug",
-        "Steel"
-      ],
-      "attack": 90,
-      "levelType": "mediumfast",
-      "exp": 163,
-      "eggCycles": 20
-    },
-    {
-      "id": 206,
-      "name": "Dunsparce",
-      "catchRate": 190,
-      "type": [
-        "Normal"
-      ],
-      "attack": 70,
-      "levelType": "mediumfast",
-      "exp": 145,
-      "eggCycles": 20
-    },
-    {
-      "id": 207,
-      "name": "Gligar",
-      "catchRate": 60,
-      "type": [
-        "Ground",
-        "Flying"
-      ],
-      "attack": 75,
-      "levelType": "mediumslow",
-      "exp": 86,
-      "eggCycles": 20
-    },
-    {
-      "id": 208,
-      "name": "Steelix",
-      "catchRate": 25,
-      "type": [
-        "Steel",
-        "Ground"
-      ],
-      "attack": 125,
-      "levelType": "mediumfast",
-      "exp": 179,
-      "eggCycles": 25
-    },
-    {
-      "id": 209,
-      "name": "Snubbull",
-      "catchRate": 190,
-      "evolution": "Granbull",
-      "evoLevel": 23,
-      "type": [
-        "Fairy"
-      ],
-      "attack": 80,
-      "levelType": "fast",
-      "exp": 60,
-      "eggCycles": 20
-    },
-    {
-      "id": 210,
-      "name": "Granbull",
-      "catchRate": 75,
-      "type": [
-        "Fairy"
-      ],
-      "attack": 120,
-      "levelType": "fast",
-      "exp": 158,
-      "eggCycles": 20
-    },
-    {
-      "id": 211,
-      "name": "Qwilfish",
-      "catchRate": 45,
-      "type": [
-        "Water",
-        "Poison"
-      ],
-      "attack": 95,
-      "levelType": "mediumfast",
-      "exp": 88,
-      "eggCycles": 20
-    },
-    {
-      "id": 212,
-      "name": "Scizor",
-      "catchRate": 25,
-      "type": [
-        "Bug",
-        "Steel"
-      ],
-      "attack": 150,
-      "levelType": "mediumfast",
-      "exp": 175,
-      "eggCycles": 25
-    },
-    {
-      "id": 213,
-      "name": "Shuckle",
-      "catchRate": 190,
-      "type": [
-        "Bug",
-        "Rock"
-      ],
-      "attack": 230,
-      "levelType": "mediumslow",
-      "exp": 177,
-      "eggCycles": 20
-    },
-    {
-      "id": 214,
-      "name": "Heracross",
-      "catchRate": 45,
-      "type": [
-        "Bug",
-        "Fighting"
-      ],
-      "attack": 185,
-      "levelType": "slow",
-      "exp": 175,
-      "eggCycles": 25
-    },
-    {
-      "id": 215,
-      "name": "Sneasel",
-      "catchRate": 60,
-      "type": [
-        "Dark",
-        "Ice"
-      ],
-      "attack": 95,
-      "levelType": "mediumslow",
-      "exp": 86,
-      "eggCycles": 20
-    },
-    {
-      "id": 216,
-      "name": "Teddiursa",
-      "catchRate": 120,
-      "evolution": "Ursaring",
-      "evoLevel": 30,
-      "type": [
-        "Normal"
-      ],
-      "attack": 80,
-      "levelType": "mediumfast",
-      "exp": 66,
-      "eggCycles": 20
-    },
-    {
-      "id": 217,
-      "name": "Ursaring",
-      "catchRate": 60,
-      "type": [
-        "Normal"
-      ],
-      "attack": 130,
-      "levelType": "mediumfast",
-      "exp": 175,
-      "eggCycles": 20
-    },
-    {
-      "id": 218,
-      "name": "Slugma",
-      "catchRate": 190,
-      "evolution": "Magcargo",
-      "evoLevel": 38,
-      "type": [
-        "Fire"
-      ],
-      "attack": 40,
-      "levelType": "mediumfast",
-      "exp": 50,
-      "eggCycles": 20
-    },
-    {
-      "id": 219,
-      "name": "Magcargo",
-      "catchRate": 75,
-      "type": [
-        "Fire",
-        "Rock"
-      ],
-      "attack": 80,
-      "levelType": "mediumfast",
-      "exp": 151,
-      "eggCycles": 20
-    },
-    {
-      "id": 220,
-      "name": "Swinub",
-      "catchRate": 225,
-      "evolution": "Piloswine",
-      "evoLevel": 33,
-      "type": [
-        "Ice",
-        "Ground"
-      ],
-      "attack": 50,
-      "levelType": "slow",
-      "exp": 50,
-      "eggCycles": 20
-    },
-    {
-      "id": 221,
-      "name": "Piloswine",
-      "catchRate": 75,
-      "type": [
-        "Ice",
-        "Ground"
-      ],
-      "attack": 100,
-      "levelType": "slow",
-      "exp": 158,
-      "eggCycles": 20
-    },
-    {
-      "id": 222,
-      "name": "Corsola",
-      "catchRate": 60,
-      "type": [
-        "Water",
-        "Rock"
-      ],
-      "attack": 95,
-      "levelType": "fast",
-      "exp": 144,
-      "eggCycles": 20
-    },
-    {
-      "id": 223,
-      "name": "Remoraid",
-      "catchRate": 190,
-      "evolution": "Octillery",
-      "evoLevel": 25,
-      "type": [
-        "Water"
-      ],
-      "attack": 65,
-      "levelType": "mediumfast",
-      "exp": 60,
-      "eggCycles": 20
-    },
-    {
-      "id": 224,
-      "name": "Octillery",
-      "catchRate": 75,
-      "type": [
-        "Water"
-      ],
-      "attack": 105,
-      "levelType": "mediumfast",
-      "exp": 168,
-      "eggCycles": 20
-    },
-    {
-      "id": 225,
-      "name": "Delibird",
-      "catchRate": 45,
-      "type": [
-        "Ice",
-        "Flying"
-      ],
-      "attack": 55,
-      "levelType": "fast",
-      "exp": 116,
-      "eggCycles": 20
-    },
-    {
-      "id": 226,
-      "name": "Mantine",
-      "catchRate": 25,
-      "type": [
-        "Water",
-        "Flying"
-      ],
-      "attack": 140,
-      "levelType": "slow",
-      "exp": 170,
-      "eggCycles": 25
-    },
-    {
-      "id": 227,
-      "name": "Skarmory",
-      "catchRate": 25,
-      "type": [
-        "Steel",
-        "Flying"
-      ],
-      "attack": 80,
-      "levelType": "slow",
-      "exp": 163,
-      "eggCycles": 25
-    },
-    {
-      "id": 228,
-      "name": "Houndour",
-      "catchRate": 120,
-      "evolution": "Houndoom",
-      "evoLevel": 24,
-      "type": [
-        "Dark",
-        "Fire"
-      ],
-      "attack": 60,
-      "levelType": "slow",
-      "exp": 66,
-      "eggCycles": 20
-    },
-    {
-      "id": 229,
-      "name": "Houndoom",
-      "catchRate": 45,
-      "type": [
-        "Dark",
-        "Fire"
-      ],
-      "attack": 90,
-      "levelType": "slow",
-      "exp": 175,
-      "eggCycles": 20
-    },
-    {
-      "id": 230,
-      "name": "Kingdra",
-      "catchRate": 45,
-      "type": [
-        "Water",
-        "Dragon"
-      ],
-      "attack": 95,
-      "levelType": "mediumfast",
-      "exp": 243,
-      "eggCycles": 20
-    },
-    {
-      "id": 231,
-      "name": "Phanpy",
-      "catchRate": 120,
-      "evolution": "Donphan",
-      "evoLevel": 25,
-      "type": [
-        "Ground"
-      ],
-      "attack": 60,
-      "levelType": "mediumfast",
-      "exp": 66,
-      "eggCycles": 20
-    },
-    {
-      "id": 232,
-      "name": "Donphan",
-      "catchRate": 60,
-      "type": [
-        "Ground"
-      ],
-      "attack": 120,
-      "levelType": "mediumfast",
-      "exp": 175,
-      "eggCycles": 20
-    },
-    {
-      "id": 233,
-      "name": "Porygon2",
-      "catchRate": 45,
-      "type": [
-        "Normal"
-      ],
-      "attack": 95,
-      "levelType": "mediumfast",
-      "exp": 180,
-      "eggCycles": 20
-    },
-    {
-      "id": 234,
-      "name": "Stantler",
-      "catchRate": 45,
-      "type": [
-        "Normal"
-      ],
-      "attack": 95,
-      "levelType": "slow",
-      "exp": 163,
-      "eggCycles": 20
-    },
-    {
-      "id": 235,
-      "name": "Smeargle",
-      "catchRate": 45,
-      "type": [
-        "Normal"
-      ],
-      "attack": 45,
-      "levelType": "fast",
-      "exp": 88,
-      "eggCycles": 20
-    },
-    {
-      "id": 236,
-      "name": "Tyrogue",
-      "catchRate": 75,
-      "evolution": "Hitmonlee, Hitmonchan, Hitmontop",
-      "evoLevel": "20, 20, 20",
-      "type": [
-        "Fighting"
-      ],
-      "attack": 35,
-      "levelType": "mediumfast",
-      "exp": 42,
-      "eggCycles": 25
-    },
-    {
-      "id": 237,
-      "name": "Hitmontop",
-      "catchRate": 45,
-      "type": [
-        "Fighting"
-      ],
-      "attack": 110,
-      "levelType": "mediumfast",
-      "exp": 159,
-      "eggCycles": 25
-    },
-    {
-      "id": 238,
-      "name": "Smoochum",
-      "catchRate": 45,
-      "evolution": "Jynx",
-      "evoLevel": 30,
-      "type": [
-        "Ice",
-        "Psychic"
-      ],
-      "attack": 65,
-      "levelType": "mediumfast",
-      "exp": 61,
-      "eggCycles": 25
-    },
-    {
-      "id": 239,
-      "name": "Elekid",
-      "catchRate": 45,
-      "evolution": "Electabuzz",
-      "evoLevel": 30,
-      "type": [
-        "Electric"
-      ],
-      "attack": 63,
-      "levelType": "mediumfast",
-      "exp": 72,
-      "eggCycles": 25
-    },
-    {
-      "id": 240,
-      "name": "Magby",
-      "catchRate": 45,
-      "evolution": "Magmar",
-      "evoLevel": 30,
-      "type": [
-        "Fire"
-      ],
-      "attack": 75,
-      "levelType": "mediumfast",
-      "exp": 73,
-      "eggCycles": 25
-    },
-    {
-      "id": 241,
-      "name": "Miltank",
-      "catchRate": 45,
-      "type": [
-        "Normal"
-      ],
-      "attack": 80,
-      "levelType": "slow",
-      "exp": 172,
-      "eggCycles": 20
-    },
-    {
-      "id": 242,
-      "name": "Blissey",
-      "catchRate": 30,
-      "type": [
-        "Normal"
-      ],
-      "attack": 135,
-      "levelType": "fast",
-      "exp": 608,
-      "eggCycles": 40
-    },
-    {
-      "id": 243,
-      "name": "Raikou",
-      "catchRate": 3,
-      "type": [
-        "Electric"
-      ],
-      "attack": 100,
-      "levelType": "slow",
-      "exp": 261,
-      "eggCycles": 80
-    },
-    {
-      "id": 244,
-      "name": "Entei",
-      "catchRate": 3,
-      "type": [
-        "Fire"
-      ],
-      "attack": 115,
-      "levelType": "slow",
-      "exp": 261,
-      "eggCycles": 80
-    },
-    {
-      "id": 245,
-      "name": "Suicune",
-      "catchRate": 3,
-      "type": [
-        "Water"
-      ],
-      "attack": 115,
-      "levelType": "slow",
-      "exp": 261,
-      "eggCycles": 80
-    },
-    {
-      "id": 246,
-      "name": "Larvitar",
-      "catchRate": 45,
-      "evolution": "Pupitar",
-      "evoLevel": 30,
-      "type": [
-        "Rock",
-        "Ground"
-      ],
-      "attack": 64,
-      "levelType": "slow",
-      "exp": 60,
-      "eggCycles": 40
-    },
-    {
-      "id": 247,
-      "name": "Pupitar",
-      "catchRate": 45,
-      "evolution": "Tyranitar",
-      "evoLevel": 55,
-      "type": [
-        "Rock",
-        "Ground"
-      ],
-      "attack": 84,
-      "levelType": "slow",
-      "exp": 144,
-      "eggCycles": 40
-    },
-    {
-      "id": 248,
-      "name": "Tyranitar",
-      "catchRate": 45,
-      "type": [
-        "Rock",
-        "Dark"
-      ],
-      "attack": 164,
-      "levelType": "slow",
-      "exp": 270,
-      "eggCycles": 40
-    },
-    {
-      "id": 249,
-      "name": "Lugia",
-      "catchRate": 3,
-      "type": [
-        "Psychic",
-        "Flying"
-      ],
-      "attack": 154,
-      "levelType": "slow",
-      "exp": 306,
-      "eggCycles": 120
-    },
-    {
-      "id": 250,
-      "name": "Ho-Oh",
-      "catchRate": 3,
-      "type": [
-        "Fire",
-        "Flying"
-      ],
-      "attack": 154,
-      "levelType": "slow",
-      "exp": 306,
-      "eggCycles": 120
-    },
-    {
-      "id": 251,
-      "name": "Celebi",
-      "catchRate": 45,
-      "type": [
-        "Psychic",
-        "Grass"
-      ],
-      "attack": 100,
-      "levelType": "mediumslow",
-      "exp": 270,
-      "eggCycles": 120
+        "id": 152,
+        "name": "Chikorita",
+        "catchRate": 45,
+        "evolution": "Bayleef",
+        "evoLevel": 16,
+        "type": [
+            "Grass"
+        ],
+        "attack": 65,
+        "levelType": "mediumslow",
+        "exp": 64,
+        "eggCycles": 20
+    },
+    {
+        "id": 153,
+        "name": "Bayleef",
+        "catchRate": 45,
+        "evolution": "Meganium",
+        "evoLevel": 32,
+        "type": [
+            "Grass"
+        ],
+        "attack": 80,
+        "levelType": "mediumslow",
+        "exp": 142,
+        "eggCycles": 20
+    },
+    {
+        "id": 154,
+        "name": "Meganium",
+        "catchRate": 45,
+        "type": [
+            "Grass"
+        ],
+        "attack": 100,
+        "levelType": "mediumslow",
+        "exp": 236,
+        "eggCycles": 20
+    },
+    {
+        "id": 155,
+        "name": "Cyndaquil",
+        "catchRate": 45,
+        "evolution": "Quilava",
+        "evoLevel": 14,
+        "type": [
+            "Fire"
+        ],
+        "attack": 52,
+        "levelType": "mediumslow",
+        "exp": 62,
+        "eggCycles": 20
+    },
+    {
+        "id": 156,
+        "name": "Quilava",
+        "catchRate": 45,
+        "evolution": "Typhlosion",
+        "evoLevel": 36,
+        "type": [
+            "Fire"
+        ],
+        "attack": 65,
+        "levelType": "mediumslow",
+        "exp": 142,
+        "eggCycles": 20
+    },
+    {
+        "id": 157,
+        "name": "Typhlosion",
+        "catchRate": 45,
+        "type": [
+            "Fire"
+        ],
+        "attack": 85,
+        "levelType": "mediumslow",
+        "exp": 240,
+        "eggCycles": 20
+    },
+    {
+        "id": 158,
+        "name": "Totodile",
+        "catchRate": 45,
+        "evolution": "Croconaw",
+        "evoLevel": 18,
+        "type": [
+            "Water"
+        ],
+        "attack": 65,
+        "levelType": "mediumslow",
+        "exp": 63,
+        "eggCycles": 20
+    },
+    {
+        "id": 159,
+        "name": "Croconaw",
+        "catchRate": 45,
+        "evolution": "Feraligatr",
+        "evoLevel": 30,
+        "type": [
+            "Water"
+        ],
+        "attack": 80,
+        "levelType": "mediumslow",
+        "exp": 142,
+        "eggCycles": 20
+    },
+    {
+        "id": 160,
+        "name": "Feraligatr",
+        "catchRate": 45,
+        "type": [
+            "Water"
+        ],
+        "attack": 105,
+        "levelType": "mediumslow",
+        "exp": 239,
+        "eggCycles": 20
+    },
+    {
+        "id": 161,
+        "name": "Sentret",
+        "catchRate": 255,
+        "evolution": "Furret",
+        "evoLevel": 15,
+        "type": [
+            "Normal"
+        ],
+        "attack": 46,
+        "levelType": "mediumfast",
+        "exp": 43,
+        "eggCycles": 15
+    },
+    {
+        "id": 162,
+        "name": "Furret",
+        "catchRate": 90,
+        "type": [
+            "Normal"
+        ],
+        "attack": 76,
+        "levelType": "mediumfast",
+        "exp": 145,
+        "eggCycles": 15
+    },
+    {
+        "id": 163,
+        "name": "Hoothoot",
+        "catchRate": 255,
+        "evolution": "Noctowl",
+        "evoLevel": 20,
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "attack": 56,
+        "levelType": "mediumfast",
+        "exp": 52,
+        "eggCycles": 15
+    },
+    {
+        "id": 164,
+        "name": "Noctowl",
+        "catchRate": 90,
+        "type": [
+            "Normal",
+            "Flying"
+        ],
+        "attack": 96,
+        "levelType": "mediumfast",
+        "exp": 158,
+        "eggCycles": 15
+    },
+    {
+        "id": 165,
+        "name": "Ledyba",
+        "catchRate": 255,
+        "evolution": "Ledian",
+        "evoLevel": 18,
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "attack": 80,
+        "levelType": "fast",
+        "exp": 53,
+        "eggCycles": 15
+    },
+    {
+        "id": 166,
+        "name": "Ledian",
+        "catchRate": 90,
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "attack": 110,
+        "levelType": "fast",
+        "exp": 137,
+        "eggCycles": 15
+    },
+    {
+        "id": 167,
+        "name": "Spinarak",
+        "catchRate": 255,
+        "evolution": "Ariados",
+        "evoLevel": 22,
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "attack": 60,
+        "levelType": "fast",
+        "exp": 50,
+        "eggCycles": 15
+    },
+    {
+        "id": 168,
+        "name": "Ariados",
+        "catchRate": 90,
+        "type": [
+            "Bug",
+            "Poison"
+        ],
+        "attack": 90,
+        "levelType": "fast",
+        "exp": 140,
+        "eggCycles": 15
+    },
+    {
+        "id": 169,
+        "name": "Crobat",
+        "catchRate": 90,
+        "type": [
+            "Poison",
+            "Flying"
+        ],
+        "attack": 90,
+        "levelType": "mediumfast",
+        "exp": 241,
+        "eggCycles": 15
+    },
+    {
+        "id": 170,
+        "name": "Chinchou",
+        "catchRate": 190,
+        "evolution": "Lanturn",
+        "evoLevel": 27,
+        "type": [
+            "Water",
+            "Electric"
+        ],
+        "attack": 56,
+        "levelType": "slow",
+        "exp": 66,
+        "eggCycles": 20
+    },
+    {
+        "id": 171,
+        "name": "Lanturn",
+        "catchRate": 75,
+        "type": [
+            "Water",
+            "Electric"
+        ],
+        "attack": 76,
+        "levelType": "slow",
+        "exp": 161,
+        "eggCycles": 20
+    },
+    {
+        "id": 172,
+        "name": "Pichu",
+        "catchRate": 190,
+        "evolution": "Pikachu",
+        "evoLevel": 100,
+        "type": [
+            "Electric"
+        ],
+        "attack": 40,
+        "levelType": "mediumfast",
+        "exp": 41,
+        "eggCycles": 10
+    },
+    {
+        "id": 173,
+        "name": "Cleffa",
+        "catchRate": 150,
+        "evolution": "Clefairy",
+        "evoLevel": 100,
+        "type": [
+            "Fairy"
+        ],
+        "attack": 55,
+        "levelType": "fast",
+        "exp": 44,
+        "eggCycles": 10
+    },
+    {
+        "id": 174,
+        "name": "Igglybuff",
+        "catchRate": 170,
+        "evolution": "Jigglypuff",
+        "evoLevel": 100,
+        "type": [
+            "Normal",
+            "Fairy"
+        ],
+        "attack": 30,
+        "levelType": "fast",
+        "exp": 42,
+        "eggCycles": 10
+    },
+    {
+        "id": 175,
+        "name": "Togepi",
+        "catchRate": 190,
+        "evolution": "Togetic",
+        "evoLevel": 100,
+        "type": [
+            "Fairy"
+        ],
+        "attack": 65,
+        "levelType": "fast",
+        "exp": 49,
+        "eggCycles": 10
+    },
+    {
+        "id": 176,
+        "name": "Togetic",
+        "catchRate": 75,
+        "type": [
+            "Fairy",
+            "Flying"
+        ],
+        "attack": 105,
+        "levelType": "fast",
+        "exp": 142,
+        "eggCycles": 10
+    },
+    {
+        "id": 177,
+        "name": "Natu",
+        "catchRate": 190,
+        "evolution": "Xatu",
+        "evoLevel": 25,
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "attack": 50,
+        "levelType": "mediumfast",
+        "exp": 64,
+        "eggCycles": 20
+    },
+    {
+        "id": 178,
+        "name": "Xatu",
+        "catchRate": 75,
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "attack": 75,
+        "levelType": "mediumfast",
+        "exp": 165,
+        "eggCycles": 20
+    },
+    {
+        "id": 179,
+        "name": "Mareep",
+        "catchRate": 235,
+        "evolution": "Flaaffy",
+        "evoLevel": 15,
+        "type": [
+            "Electric"
+        ],
+        "attack": 45,
+        "levelType": "mediumslow",
+        "exp": 56,
+        "eggCycles": 20
+    },
+    {
+        "id": 180,
+        "name": "Flaaffy",
+        "catchRate": 120,
+        "evolution": "Ampharos",
+        "evoLevel": 30,
+        "type": [
+            "Electric"
+        ],
+        "attack": 60,
+        "levelType": "mediumslow",
+        "exp": 128,
+        "eggCycles": 20
+    },
+    {
+        "id": 181,
+        "name": "Ampharos",
+        "catchRate": 45,
+        "type": [
+            "Electric"
+        ],
+        "attack": 110,
+        "levelType": "mediumslow",
+        "exp": 230,
+        "eggCycles": 20
+    },
+    {
+        "id": 182,
+        "name": "Bellossom",
+        "catchRate": 45,
+        "type": [
+            "Grass"
+        ],
+        "attack": 100,
+        "levelType": "mediumslow",
+        "exp": 221,
+        "eggCycles": 20
+    },
+    {
+        "id": 183,
+        "name": "Marill",
+        "catchRate": 190,
+        "evolution": "Azumarill",
+        "evoLevel": 18,
+        "type": [
+            "Water",
+            "Fairy"
+        ],
+        "attack": 50,
+        "levelType": "fast",
+        "exp": 88,
+        "eggCycles": 10
+    },
+    {
+        "id": 184,
+        "name": "Azumarill",
+        "catchRate": 75,
+        "type": [
+            "Water",
+            "Fairy"
+        ],
+        "attack": 80,
+        "levelType": "fast",
+        "exp": 189,
+        "eggCycles": 10
+    },
+    {
+        "id": 185,
+        "name": "Sudowoodo",
+        "catchRate": 65,
+        "type": [
+            "Rock"
+        ],
+        "attack": 100,
+        "levelType": "mediumfast",
+        "exp": 144,
+        "eggCycles": 20
+    },
+    {
+        "id": 186,
+        "name": "Politoed",
+        "catchRate": 45,
+        "type": [
+            "Water"
+        ],
+        "attack": 100,
+        "levelType": "mediumslow",
+        "exp": 225,
+        "eggCycles": 20
+    },
+    {
+        "id": 187,
+        "name": "Hoppip",
+        "catchRate": 255,
+        "evolution": "Skiploom",
+        "evoLevel": 18,
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "attack": 55,
+        "levelType": "mediumslow",
+        "exp": 50,
+        "eggCycles": 20
+    },
+    {
+        "id": 188,
+        "name": "Skiploom",
+        "catchRate": 120,
+        "evolution": "Jumpluff",
+        "evoLevel": 27,
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "attack": 65,
+        "levelType": "mediumslow",
+        "exp": 119,
+        "eggCycles": 20
+    },
+    {
+        "id": 189,
+        "name": "Jumpluff",
+        "catchRate": 45,
+        "type": [
+            "Grass",
+            "Flying"
+        ],
+        "attack": 95,
+        "levelType": "mediumslow",
+        "exp": 207,
+        "eggCycles": 20
+    },
+    {
+        "id": 190,
+        "name": "Aipom",
+        "catchRate": 45,
+        "type": [
+            "Normal"
+        ],
+        "attack": 70,
+        "levelType": "fast",
+        "exp": 72,
+        "eggCycles": 20
+    },
+    {
+        "id": 191,
+        "name": "Sunkern",
+        "catchRate": 235,
+        "evolution": "Sunflora",
+        "evoLevel": "Sun_stone",
+        "type": [
+            "Grass"
+        ],
+        "attack": 30,
+        "levelType": "mediumslow",
+        "exp": 36,
+        "eggCycles": 20
+    },
+    {
+        "id": 192,
+        "name": "Sunflora",
+        "catchRate": 120,
+        "type": [
+            "Grass"
+        ],
+        "attack": 85,
+        "levelType": "mediumslow",
+        "exp": 149,
+        "eggCycles": 20
+    },
+    {
+        "id": 193,
+        "name": "Yanma",
+        "catchRate": 75,
+        "type": [
+            "Bug",
+            "Flying"
+        ],
+        "attack": 65,
+        "levelType": "mediumfast",
+        "exp": 78,
+        "eggCycles": 20
+    },
+    {
+        "id": 194,
+        "name": "Wooper",
+        "catchRate": 255,
+        "evolution": "Quagsire",
+        "evoLevel": 20,
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "attack": 45,
+        "levelType": "mediumfast",
+        "exp": 42,
+        "eggCycles": 20
+    },
+    {
+        "id": 195,
+        "name": "Quagsire",
+        "catchRate": 90,
+        "type": [
+            "Water",
+            "Ground"
+        ],
+        "attack": 85,
+        "levelType": "mediumfast",
+        "exp": 151,
+        "eggCycles": 20
+    },
+    {
+        "id": 196,
+        "name": "Espeon",
+        "catchRate": 45,
+        "type": [
+            "Psychic"
+        ],
+        "attack": 95,
+        "levelType": "mediumfast",
+        "exp": 184,
+        "eggCycles": 35
+    },
+    {
+        "id": 197,
+        "name": "Umbreon",
+        "catchRate": 45,
+        "type": [
+            "Dark"
+        ],
+        "attack": 130,
+        "levelType": "mediumfast",
+        "exp": 184,
+        "eggCycles": 35
+    },
+    {
+        "id": 198,
+        "name": "Murkrow",
+        "catchRate": 30,
+        "type": [
+            "Dark",
+            "Flying"
+        ],
+        "attack": 85,
+        "levelType": "mediumslow",
+        "exp": 81,
+        "eggCycles": 20
+    },
+    {
+        "id": 199,
+        "name": "Slowking",
+        "catchRate": 70,
+        "type": [
+            "Water",
+            "Psychic"
+        ],
+        "attack": 110,
+        "levelType": "mediumfast",
+        "exp": 172,
+        "eggCycles": 20
+    },
+    {
+        "id": 200,
+        "name": "Misdreavus",
+        "catchRate": 45,
+        "type": [
+            "Ghost"
+        ],
+        "attack": 85,
+        "levelType": "fast",
+        "exp": 87,
+        "eggCycles": 25
+    },
+    {
+        "id": 201,
+        "name": "Unown",
+        "catchRate": 225,
+        "type": [
+            "Psychic"
+        ],
+        "attack": 72,
+        "levelType": "mediumfast",
+        "exp": 118,
+        "eggCycles": 40
+    },
+    {
+        "id": 202,
+        "name": "Wobbuffet",
+        "catchRate": 45,
+        "type": [
+            "Psychic"
+        ],
+        "attack": 58,
+        "levelType": "mediumfast",
+        "exp": 142,
+        "eggCycles": 20
+    },
+    {
+        "id": 203,
+        "name": "Girafarig",
+        "catchRate": 60,
+        "type": [
+            "Normal",
+            "Psychic"
+        ],
+        "attack": 80,
+        "levelType": "mediumfast",
+        "exp": 159,
+        "eggCycles": 20
+    },
+    {
+        "id": 204,
+        "name": "Pineco",
+        "catchRate": 190,
+        "evolution": "Forretress",
+        "evoLevel": 31,
+        "type": [
+            "Bug"
+        ],
+        "attack": 65,
+        "levelType": "mediumfast",
+        "exp": 58,
+        "eggCycles": 20
+    },
+    {
+        "id": 205,
+        "name": "Forretress",
+        "catchRate": 75,
+        "type": [
+            "Bug",
+            "Steel"
+        ],
+        "attack": 90,
+        "levelType": "mediumfast",
+        "exp": 163,
+        "eggCycles": 20
+    },
+    {
+        "id": 206,
+        "name": "Dunsparce",
+        "catchRate": 190,
+        "type": [
+            "Normal"
+        ],
+        "attack": 70,
+        "levelType": "mediumfast",
+        "exp": 145,
+        "eggCycles": 20
+    },
+    {
+        "id": 207,
+        "name": "Gligar",
+        "catchRate": 60,
+        "type": [
+            "Ground",
+            "Flying"
+        ],
+        "attack": 75,
+        "levelType": "mediumslow",
+        "exp": 86,
+        "eggCycles": 20
+    },
+    {
+        "id": 208,
+        "name": "Steelix",
+        "catchRate": 25,
+        "type": [
+            "Steel",
+            "Ground"
+        ],
+        "attack": 125,
+        "levelType": "mediumfast",
+        "exp": 179,
+        "eggCycles": 25
+    },
+    {
+        "id": 209,
+        "name": "Snubbull",
+        "catchRate": 190,
+        "evolution": "Granbull",
+        "evoLevel": 23,
+        "type": [
+            "Fairy"
+        ],
+        "attack": 80,
+        "levelType": "fast",
+        "exp": 60,
+        "eggCycles": 20
+    },
+    {
+        "id": 210,
+        "name": "Granbull",
+        "catchRate": 75,
+        "type": [
+            "Fairy"
+        ],
+        "attack": 120,
+        "levelType": "fast",
+        "exp": 158,
+        "eggCycles": 20
+    },
+    {
+        "id": 211,
+        "name": "Qwilfish",
+        "catchRate": 45,
+        "type": [
+            "Water",
+            "Poison"
+        ],
+        "attack": 95,
+        "levelType": "mediumfast",
+        "exp": 88,
+        "eggCycles": 20
+    },
+    {
+        "id": 212,
+        "name": "Scizor",
+        "catchRate": 25,
+        "type": [
+            "Bug",
+            "Steel"
+        ],
+        "attack": 150,
+        "levelType": "mediumfast",
+        "exp": 175,
+        "eggCycles": 25
+    },
+    {
+        "id": 213,
+        "name": "Shuckle",
+        "catchRate": 190,
+        "type": [
+            "Bug",
+            "Rock"
+        ],
+        "attack": 230,
+        "levelType": "mediumslow",
+        "exp": 177,
+        "eggCycles": 20
+    },
+    {
+        "id": 214,
+        "name": "Heracross",
+        "catchRate": 45,
+        "type": [
+            "Bug",
+            "Fighting"
+        ],
+        "attack": 185,
+        "levelType": "slow",
+        "exp": 175,
+        "eggCycles": 25
+    },
+    {
+        "id": 215,
+        "name": "Sneasel",
+        "catchRate": 60,
+        "type": [
+            "Dark",
+            "Ice"
+        ],
+        "attack": 95,
+        "levelType": "mediumslow",
+        "exp": 86,
+        "eggCycles": 20
+    },
+    {
+        "id": 216,
+        "name": "Teddiursa",
+        "catchRate": 120,
+        "evolution": "Ursaring",
+        "evoLevel": 30,
+        "type": [
+            "Normal"
+        ],
+        "attack": 80,
+        "levelType": "mediumfast",
+        "exp": 66,
+        "eggCycles": 20
+    },
+    {
+        "id": 217,
+        "name": "Ursaring",
+        "catchRate": 60,
+        "type": [
+            "Normal"
+        ],
+        "attack": 130,
+        "levelType": "mediumfast",
+        "exp": 175,
+        "eggCycles": 20
+    },
+    {
+        "id": 218,
+        "name": "Slugma",
+        "catchRate": 190,
+        "evolution": "Magcargo",
+        "evoLevel": 38,
+        "type": [
+            "Fire"
+        ],
+        "attack": 40,
+        "levelType": "mediumfast",
+        "exp": 50,
+        "eggCycles": 20
+    },
+    {
+        "id": 219,
+        "name": "Magcargo",
+        "catchRate": 75,
+        "type": [
+            "Fire",
+            "Rock"
+        ],
+        "attack": 80,
+        "levelType": "mediumfast",
+        "exp": 151,
+        "eggCycles": 20
+    },
+    {
+        "id": 220,
+        "name": "Swinub",
+        "catchRate": 225,
+        "evolution": "Piloswine",
+        "evoLevel": 33,
+        "type": [
+            "Ice",
+            "Ground"
+        ],
+        "attack": 50,
+        "levelType": "slow",
+        "exp": 50,
+        "eggCycles": 20
+    },
+    {
+        "id": 221,
+        "name": "Piloswine",
+        "catchRate": 75,
+        "type": [
+            "Ice",
+            "Ground"
+        ],
+        "attack": 100,
+        "levelType": "slow",
+        "exp": 158,
+        "eggCycles": 20
+    },
+    {
+        "id": 222,
+        "name": "Corsola",
+        "catchRate": 60,
+        "type": [
+            "Water",
+            "Rock"
+        ],
+        "attack": 95,
+        "levelType": "fast",
+        "exp": 144,
+        "eggCycles": 20
+    },
+    {
+        "id": 223,
+        "name": "Remoraid",
+        "catchRate": 190,
+        "evolution": "Octillery",
+        "evoLevel": 25,
+        "type": [
+            "Water"
+        ],
+        "attack": 65,
+        "levelType": "mediumfast",
+        "exp": 60,
+        "eggCycles": 20
+    },
+    {
+        "id": 224,
+        "name": "Octillery",
+        "catchRate": 75,
+        "type": [
+            "Water"
+        ],
+        "attack": 105,
+        "levelType": "mediumfast",
+        "exp": 168,
+        "eggCycles": 20
+    },
+    {
+        "id": 225,
+        "name": "Delibird",
+        "catchRate": 45,
+        "type": [
+            "Ice",
+            "Flying"
+        ],
+        "attack": 55,
+        "levelType": "fast",
+        "exp": 116,
+        "eggCycles": 20
+    },
+    {
+        "id": 226,
+        "name": "Mantine",
+        "catchRate": 25,
+        "type": [
+            "Water",
+            "Flying"
+        ],
+        "attack": 140,
+        "levelType": "slow",
+        "exp": 170,
+        "eggCycles": 25
+    },
+    {
+        "id": 227,
+        "name": "Skarmory",
+        "catchRate": 25,
+        "type": [
+            "Steel",
+            "Flying"
+        ],
+        "attack": 80,
+        "levelType": "slow",
+        "exp": 163,
+        "eggCycles": 25
+    },
+    {
+        "id": 228,
+        "name": "Houndour",
+        "catchRate": 120,
+        "evolution": "Houndoom",
+        "evoLevel": 24,
+        "type": [
+            "Dark",
+            "Fire"
+        ],
+        "attack": 60,
+        "levelType": "slow",
+        "exp": 66,
+        "eggCycles": 20
+    },
+    {
+        "id": 229,
+        "name": "Houndoom",
+        "catchRate": 45,
+        "type": [
+            "Dark",
+            "Fire"
+        ],
+        "attack": 90,
+        "levelType": "slow",
+        "exp": 175,
+        "eggCycles": 20
+    },
+    {
+        "id": 230,
+        "name": "Kingdra",
+        "catchRate": 45,
+        "type": [
+            "Water",
+            "Dragon"
+        ],
+        "attack": 95,
+        "levelType": "mediumfast",
+        "exp": 243,
+        "eggCycles": 20
+    },
+    {
+        "id": 231,
+        "name": "Phanpy",
+        "catchRate": 120,
+        "evolution": "Donphan",
+        "evoLevel": 25,
+        "type": [
+            "Ground"
+        ],
+        "attack": 60,
+        "levelType": "mediumfast",
+        "exp": 66,
+        "eggCycles": 20
+    },
+    {
+        "id": 232,
+        "name": "Donphan",
+        "catchRate": 60,
+        "type": [
+            "Ground"
+        ],
+        "attack": 120,
+        "levelType": "mediumfast",
+        "exp": 175,
+        "eggCycles": 20
+    },
+    {
+        "id": 233,
+        "name": "Porygon2",
+        "catchRate": 45,
+        "type": [
+            "Normal"
+        ],
+        "attack": 95,
+        "levelType": "mediumfast",
+        "exp": 180,
+        "eggCycles": 20
+    },
+    {
+        "id": 234,
+        "name": "Stantler",
+        "catchRate": 45,
+        "type": [
+            "Normal"
+        ],
+        "attack": 95,
+        "levelType": "slow",
+        "exp": 163,
+        "eggCycles": 20
+    },
+    {
+        "id": 235,
+        "name": "Smeargle",
+        "catchRate": 45,
+        "type": [
+            "Normal"
+        ],
+        "attack": 45,
+        "levelType": "fast",
+        "exp": 88,
+        "eggCycles": 20
+    },
+    {
+        "id": 236,
+        "name": "Tyrogue",
+        "catchRate": 75,
+        "evolution": "Hitmonlee, Hitmonchan, Hitmontop",
+        "evoLevel": "20, 20, 20",
+        "type": [
+            "Fighting"
+        ],
+        "attack": 35,
+        "levelType": "mediumfast",
+        "exp": 42,
+        "eggCycles": 25
+    },
+    {
+        "id": 237,
+        "name": "Hitmontop",
+        "catchRate": 45,
+        "type": [
+            "Fighting"
+        ],
+        "attack": 110,
+        "levelType": "mediumfast",
+        "exp": 159,
+        "eggCycles": 25
+    },
+    {
+        "id": 238,
+        "name": "Smoochum",
+        "catchRate": 45,
+        "evolution": "Jynx",
+        "evoLevel": 30,
+        "type": [
+            "Ice",
+            "Psychic"
+        ],
+        "attack": 65,
+        "levelType": "mediumfast",
+        "exp": 61,
+        "eggCycles": 25
+    },
+    {
+        "id": 239,
+        "name": "Elekid",
+        "catchRate": 45,
+        "evolution": "Electabuzz",
+        "evoLevel": 30,
+        "type": [
+            "Electric"
+        ],
+        "attack": 63,
+        "levelType": "mediumfast",
+        "exp": 72,
+        "eggCycles": 25
+    },
+    {
+        "id": 240,
+        "name": "Magby",
+        "catchRate": 45,
+        "evolution": "Magmar",
+        "evoLevel": 30,
+        "type": [
+            "Fire"
+        ],
+        "attack": 75,
+        "levelType": "mediumfast",
+        "exp": 73,
+        "eggCycles": 25
+    },
+    {
+        "id": 241,
+        "name": "Miltank",
+        "catchRate": 45,
+        "type": [
+            "Normal"
+        ],
+        "attack": 80,
+        "levelType": "slow",
+        "exp": 172,
+        "eggCycles": 20
+    },
+    {
+        "id": 242,
+        "name": "Blissey",
+        "catchRate": 30,
+        "type": [
+            "Normal"
+        ],
+        "attack": 135,
+        "levelType": "fast",
+        "exp": 608,
+        "eggCycles": 40
+    },
+    {
+        "id": 243,
+        "name": "Raikou",
+        "catchRate": 3,
+        "type": [
+            "Electric"
+        ],
+        "attack": 100,
+        "levelType": "slow",
+        "exp": 261,
+        "eggCycles": 80
+    },
+    {
+        "id": 244,
+        "name": "Entei",
+        "catchRate": 3,
+        "type": [
+            "Fire"
+        ],
+        "attack": 115,
+        "levelType": "slow",
+        "exp": 261,
+        "eggCycles": 80
+    },
+    {
+        "id": 245,
+        "name": "Suicune",
+        "catchRate": 3,
+        "type": [
+            "Water"
+        ],
+        "attack": 115,
+        "levelType": "slow",
+        "exp": 261,
+        "eggCycles": 80
+    },
+    {
+        "id": 246,
+        "name": "Larvitar",
+        "catchRate": 45,
+        "evolution": "Pupitar",
+        "evoLevel": 30,
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "attack": 64,
+        "levelType": "slow",
+        "exp": 60,
+        "eggCycles": 40
+    },
+    {
+        "id": 247,
+        "name": "Pupitar",
+        "catchRate": 45,
+        "evolution": "Tyranitar",
+        "evoLevel": 55,
+        "type": [
+            "Rock",
+            "Ground"
+        ],
+        "attack": 84,
+        "levelType": "slow",
+        "exp": 144,
+        "eggCycles": 40
+    },
+    {
+        "id": 248,
+        "name": "Tyranitar",
+        "catchRate": 45,
+        "type": [
+            "Rock",
+            "Dark"
+        ],
+        "attack": 164,
+        "levelType": "slow",
+        "exp": 270,
+        "eggCycles": 40
+    },
+    {
+        "id": 249,
+        "name": "Lugia",
+        "catchRate": 3,
+        "type": [
+            "Psychic",
+            "Flying"
+        ],
+        "attack": 154,
+        "levelType": "slow",
+        "exp": 306,
+        "eggCycles": 120
+    },
+    {
+        "id": 250,
+        "name": "Ho-Oh",
+        "catchRate": 3,
+        "type": [
+            "Fire",
+            "Flying"
+        ],
+        "attack": 154,
+        "levelType": "slow",
+        "exp": 306,
+        "eggCycles": 120
+    },
+    {
+        "id": 251,
+        "name": "Celebi",
+        "catchRate": 45,
+        "type": [
+            "Psychic",
+            "Grass"
+        ],
+        "attack": 100,
+        "levelType": "mediumslow",
+        "exp": 270,
+        "eggCycles": 120
     }
 ];
 

--- a/src/scripts/quests/QuestLine.ts
+++ b/src/scripts/quests/QuestLine.ts
@@ -17,7 +17,7 @@ class QuestLine {
         this.curQuest = ko.computed(() => {
             let acc = 0;
             return this.quests().map((quest) => {return +quest.isCompleted()})
-                                .reduce( ( acc, iscompleted) => {return acc + iscompleted},0);
+                .reduce( ( acc, iscompleted) => {return acc + iscompleted},0);
         });
         this.curQuestInitial = ko.observable();
         this.curQuestInitial.equalityComparer = () => {return false} //Always update subscriptions, even if same data pushed in

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -1,13 +1,13 @@
 /// <reference path="../../libs/motio.d.ts" />
 
 class Safari {
-    static grid: Array<Array<number>>;
+    static grid: number[][];
     static player: Point = new Point(12, 20);
     static lastDirection: string = "up";
     static nextDirection: string;
     static walking: boolean = false;
     static isMoving: boolean = false;
-    static queue: Array<string> = [];
+    static queue: string[] = [];
     private static playerXY = {"x": 0, "y": 0};
     private static origin;
     static inBattle: KnockoutObservable<boolean> = ko.observable(false);

--- a/src/scripts/safari/SafariBody.ts
+++ b/src/scripts/safari/SafariBody.ts
@@ -1,5 +1,5 @@
 abstract class SafariBody {
-    grid: Array<Array<number>>;
+    grid: number[][];
     type: string;
 
     constructor() {
@@ -89,7 +89,7 @@ class SandBody extends SafariBody {
         return Math.floor(Math.random() * 3) + 3;
     }
 
-    private generateCube(sizeX: number, sizeY: number): Array<Array<number>> {
+    private generateCube(sizeX: number, sizeY: number): number[][] {
         let body = [];
         for (let i = 0; i < sizeY; i++) {
             let row = Array.apply(null, Array(sizeX)).map(Number.prototype.valueOf, 0);
@@ -105,7 +105,7 @@ class SandBody extends SafariBody {
         return body;
     }
 
-    private static addCube(x: number, y: number, body: Array<Array<number>>): Array<Array<number>> {
+    private static addCube(x: number, y: number, body: number[][]): number[][] {
         if (Math.random() >= 0.5){
             body[y+2][x] = 15;
             body[y+2][x+1] = 15;
@@ -372,5 +372,5 @@ Array.prototype.equals = function (array) {
 }
 
 interface Array<T> {
-    equals(array: Array<T>): boolean;
+    equals(array: T[]): boolean;
 }

--- a/src/scripts/safari/SafariPokemon.ts
+++ b/src/scripts/safari/SafariPokemon.ts
@@ -29,7 +29,7 @@ class SafariPokemon implements pokemonInterface {
         { name: "Tangela", weight: 4 },
     ];
 
-    static readonly listWeight = SafariPokemon.list.reduce((sum:number, pokemon) => {return sum += pokemon.weight}, 0);
+    static readonly listWeight = SafariPokemon.list.reduce((sum: number, pokemon) => {return sum += pokemon.weight}, 0);
 
     constructor(name: string) {
         let data = PokemonHelper.getPokemonByName(name);

--- a/src/scripts/types/TypeHelper.ts
+++ b/src/scripts/types/TypeHelper.ts
@@ -1,7 +1,7 @@
 class TypeHelper {
 
     //@formatter:off
-    public static typeMatrix : Array<Array<number>> = [
+    public static typeMatrix: number[][] = [
         //                E              F
         //                L              I                   P
         // N              E              G    P    G    F    S                   D

--- a/src/scripts/underground/DailyDeal.ts
+++ b/src/scripts/underground/DailyDeal.ts
@@ -4,7 +4,7 @@ class DailyDeal {
     public amount1: number;
     public amount2: number;
 
-    public static list: Array<DailyDeal> = [];
+    public static list: DailyDeal[] = [];
 
     constructor() {
         this.item1 = DailyDeal.randomItem();

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -1,9 +1,9 @@
 class Mine {
-    public static grid: Array<Array<KnockoutObservable<number>>>;
-    public static rewardGrid: Array<Array<any>>;
+    public static grid: KnockoutObservable<number>[][];
+    public static rewardGrid: any[][];
     public static itemsFound: KnockoutObservable<number>;
     public static itemsBuried: number;
-    public static rewardNumbers: Array<number>;
+    public static rewardNumbers: number[];
     public static toolSelected: KnockoutObservable<GameConstants.MineTool> = ko.observable(GameConstants.MineTool["Chisel"]);
     private static loadingNewLayer: boolean = true
 

--- a/src/scripts/underground/SeededRand.ts
+++ b/src/scripts/underground/SeededRand.ts
@@ -21,7 +21,7 @@ class SeededRand {
         return Math.floor( (max-min + 1) * SeededRand.next() + min )
     }
 
-    public static fromArray<T>(arr: Array<T>): T {
+    public static fromArray<T>(arr: T[]): T {
         return arr[SeededRand.intBetween(0, arr.length - 1)]
     }
 }

--- a/src/scripts/underground/UndergroundItem.ts
+++ b/src/scripts/underground/UndergroundItem.ts
@@ -1,13 +1,13 @@
 class UndergroundItem {
     public name: string;
     public id: number;
-    public space: Array<Array<number>>;
+    public space: number[][];
     public value: number;
     public valueType: string;
 
-    public static list: Array<UndergroundItem> = [];
+    public static list: UndergroundItem[] = [];
 
-    constructor(name: string, id: number, space: Array<Array<number>>, value: number = 1, valueType: string = "Diamond") {
+    constructor(name: string, id: number, space: number[][], value: number = 1, valueType: string = "Diamond") {
         this.name = name;
         this.id = id;
         this.space = space;
@@ -15,11 +15,11 @@ class UndergroundItem {
         this.valueType = valueType;
     }
 
-    private static addItem(name, id, space, ...rest) {
+    private static addItem(name, id, space, ...rest): void {
         UndergroundItem.list.push(new UndergroundItem(name, id, space, ...rest))
     }
 
-    public static initialize() {
+    public static initialize(): void {
         this.addItem("Helix Fossil", 1, [[0,1,1,1], [1,1,1,1], [1,1,1,1], [1,1,1]], 0, "Mine Egg");
         this.addItem("Dome Fossil", 2, [[2,2,2,2,2], [2,2,2,2,2], [2,2,2,2,2], [0,2,2,2,0]], 0, "Mine Egg");
         this.addItem("Old Amber", 3, [[0,3,3,3], [3,3,3,3], [3,3,3,3], [3,3,3,0]], 0, "Mine Egg");

--- a/src/scripts/underground/UndergroundUpgrade.ts
+++ b/src/scripts/underground/UndergroundUpgrade.ts
@@ -7,7 +7,7 @@ class UndergroundUpgrade {
     baseCost: number;
     initialValue: number;
 
-    static list: Array<UndergroundUpgrade> = []
+    static list: UndergroundUpgrade[] = []
 
     constructor(name, text, step, baseCost) {
         this.name = name;

--- a/src/scripts/utilities/Preload.ts
+++ b/src/scripts/utilities/Preload.ts
@@ -1,6 +1,6 @@
 class Preload {
 
-    public static hideSplashScreen(fast: boolean = false) {
+    public static hideSplashScreen(fast: boolean = false): void {
         if (fast) {
             $('.loader').hide();
         } else {
@@ -102,7 +102,7 @@ class Preload {
         })
     }
 
-    private static loadMap() {
+    private static loadMap(): void {
         /*
         return new Promise<number>(resolve => {
             let img = new Image();

--- a/src/scripts/wildBattle/RouteHelper.ts
+++ b/src/scripts/wildBattle/RouteHelper.ts
@@ -1,4 +1,4 @@
-///<reference path="PokemonsPerRoute.ts"/>
+//<reference path="PokemonsPerRoute.ts"/>
 
 /**
  * Helper class to retrieve information from PokemonsPerRoute
@@ -41,7 +41,7 @@ class RouteHelper {
         return RouteHelper.listCompleted(possiblePokemon, includeShiny);
     }
 
-    public static listCompleted(possiblePokemon: string[], includeShiny: boolean) {
+    public static listCompleted(possiblePokemon: string[], includeShiny: boolean): boolean {
         for (let i = 0; i < possiblePokemon.length; i++) {
             if (!player.alreadyCaughtPokemon(possiblePokemon[i])) {
                 return false;

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -1,6 +1,6 @@
 class MapHelper {
 
-    public static moveToRoute = function (route: number, region: GameConstants.Region) {
+    public static moveToRoute = function (route: number, region: GameConstants.Region): void {
         if (!isNaN(route) && !(route == player.route())) {
             if (this.accessToRoute(route, region)) {
                 $("[data-route='" + player.route() + "']").removeClass('currentRoute').addClass('unlockedRoute');
@@ -18,16 +18,16 @@ class MapHelper {
         }
     };
 
-    private static hasBadgeReq(route, region) {
+    private static hasBadgeReq(route, region): boolean {
         return player.hasBadge(GameConstants.routeBadgeRequirements[region][route]);
     }
 
-    private static hasDungeonReq(route, region) {
+    private static hasDungeonReq(route, region): boolean {
         let dungeonReq = GameConstants.routeDungeonRequirements[region][route];
         return dungeonReq == undefined || 0 < player.statistics.dungeonsCleared[Statistics.getDungeonIndex(dungeonReq)]();
     }
 
-    private static hasRouteKillReq(route, region) {
+    private static hasRouteKillReq(route, region): boolean {
         let reqList = GameConstants.routeRequirements[region][route];
         if (reqList == undefined) {
             return true;
@@ -41,12 +41,12 @@ class MapHelper {
         return true;
     }
 
-    public static accessToRoute = function (route: number, region: GameConstants.Region) {
+    public static accessToRoute = function (route: number, region: GameConstants.Region): boolean {
         return MapHelper.hasBadgeReq(route, region) && MapHelper.hasDungeonReq(route, region) && MapHelper.hasRouteKillReq(route, region);
     };
 
     public static calculateRouteCssClass(route: number, region: GameConstants.Region): KnockoutComputed<string> {
-        return ko.computed(function () {
+        return ko.computed(function (): string {
             if (player.route() == route && player.region == region) {
                 return "currentRoute";
             }
@@ -58,7 +58,7 @@ class MapHelper {
     }
 
     public static calculateTownCssClass(town: string): KnockoutComputed<string> {
-        return ko.computed(function () {
+        return ko.computed(function (): string {
             if (player.currentTown() == town) {
                 return "city currentTown";
             }
@@ -83,7 +83,7 @@ class MapHelper {
         return town.isUnlocked();
     };
 
-    public static moveToTown(townName: string) {
+    public static moveToTown(townName: string): void {
         if (MapHelper.accessToTown(townName)) {
             //console.log($("[data-town]"));
             Game.gameState(GameConstants.GameState.idle);
@@ -99,7 +99,7 @@ class MapHelper {
         }
     };
 
-    public static updateAllRoutes() {
+    public static updateAllRoutes(): void {
         for (let i = 0; i < GameConstants.AMOUNT_OF_ROUTES_KANTO; i++) {
             // TODO fix for multiple regions
             if (MapHelper.accessToRoute(i, GameConstants.Region.kanto)) {
@@ -117,8 +117,8 @@ class MapHelper {
         }
     }
 
-    public static openShipModal() {
-        let openModal = () => {Game.gameState(GameConstants.GameState.idle);$("#ShipModal").modal('show');}
+    public static openShipModal(): void {
+        let openModal = (): void => {Game.gameState(GameConstants.GameState.idle);$("#ShipModal").modal('show');}
         switch (player.region) {
             case 0:
                 if (TownList["Vermillion City"].isUnlocked() && player.highestRegion > 0) {
@@ -134,11 +134,11 @@ class MapHelper {
         Notifier.notify("You cannot access this dock yet", GameConstants.NotificationOption.warning)
     }
 
-    public static ableToTravel() {
+    public static ableToTravel(): boolean {
         return player.caughtPokemonList.length >= GameConstants.pokemonsNeededToTravel[player.highestRegion]
     }
 
-    public static travelToNextRegion() {
+    public static travelToNextRegion(): void {
         if (MapHelper.ableToTravel()) {
             player.highestRegion++;
             MapHelper.moveToTown(GameConstants.StartingTowns[player.highestRegion]);

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "triple-equals": false
-  }
-}


### PR DESCRIPTION
tslint is being replaced by eslint, It hasn't fully been released yet so unsure if you want to merge this.
_See https://github.com/palantir/tslint/issues/4534 for more info_

I've just left the rules as standard.

There is still a ton of errors, i've fixed some, but we can slowly remove more and more errors as we work on the project.

The main errors/warnings that pop up are when the return type hasn't been declared, usually:
```typescript
function nothingToReturn(): void {
```

I think merging this would mostly be good for keeping consistency in the code in terms of spacing etc..

Usage:
`npm test` - Shows all errors and warnings
`npm run test-error` - Only shows errors, ignores warnings
`npm run test-fix` - Will show all warnings and errors, and attempt to fix any that can be fixed automatically such as spacing issues