### PR TITLE
Make separate typed eggs for Gen2

### DIFF
--- a/src/components/shopView.html
+++ b/src/components/shopView.html
@@ -5,7 +5,7 @@
        <div
                data-bind="click: function() {ShopHandler.setSelected($index())}, attr: {class: ShopHandler.calculateCss($index())}">
            <img src="" height="36px"
-                data-bind="attr:{ src: '/assets/images/items/' + name() + '.png' }">
+                data-bind="attr:{ src: '/assets/images/items/' + imageName() + '.png' }">
            <p data-bind="text: GameConstants.humanifyString(name())">Item Name</p>
            <div data-bind="if: $data.isAvailable()">
                 <img src="" class="currencyImage"

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -603,9 +603,13 @@ namespace GameConstants {
     }
 
     export enum EggItemType {
-        Fire_egg,
-        Water_egg,
-        Grass_egg,
+        Fire_egg_I,
+        Water_egg_I,
+        Grass_egg_I,
+        Fire_egg_II,
+        Water_egg_II,
+        Grass_egg_II,
+        
         Fighting_egg,
         Electric_egg,
         Dragon_egg,
@@ -619,9 +623,12 @@ namespace GameConstants {
     }
 
     export enum EggType {
-        Fire,
-        Water,
-        Grass,
+        Fire_I,
+        Water_I,
+        Grass_I,
+        Fire_II,
+        Water_II,
+        Grass_II,
         Fighting,
         Electric,
         Dragon,

--- a/src/scripts/breeding/BreedingHelper.ts
+++ b/src/scripts/breeding/BreedingHelper.ts
@@ -105,7 +105,7 @@ class BreedingHelper {
     }
 
     public static getEggImage(egg: Egg): string {
-        let eggType = GameConstants.EggType[egg.type].toLowerCase();
+        let eggType = GameConstants.EggType[egg.type].toLowerCase().split("_")[0];
         if (eggType == "pokemon") {
             let dataPokemon: DataPokemon = PokemonHelper.getPokemonByName(egg.pokemon);
             eggType = String(dataPokemon.type1).toLowerCase();
@@ -135,9 +135,12 @@ class BreedingHelper {
 }
 
 const HatchList: { [name: number]: string[] } = {};
-HatchList[GameConstants.EggType.Fire] = ["Charmander", "Vulpix", "Growlithe", "Ponyta"];
-HatchList[GameConstants.EggType.Water] = ["Squirtle", "Lapras", "Staryu", "Psyduck"];
-HatchList[GameConstants.EggType.Grass] = ["Bulbasaur", "Oddish", "Tangela", "Bellsprout"];
+HatchList[GameConstants.EggType.Fire_I] = ["Charmander", "Vulpix", "Growlithe", "Ponyta"];
+HatchList[GameConstants.EggType.Water_I] = ["Squirtle", "Lapras", "Staryu", "Psyduck"];
+HatchList[GameConstants.EggType.Grass_I] = ["Bulbasaur", "Oddish", "Tangela", "Bellsprout"];
+HatchList[GameConstants.EggType.Fire_II] = ["Cyndaquil", "Slugma", "Growlithe", "Houndour"];
+HatchList[GameConstants.EggType.Water_II] = ["Totodile", "Wooper", "Marill", "Qwilfish"];
+HatchList[GameConstants.EggType.Grass_II] = ["Chikorita", "Hoppip", "Sunkern", "Bellsprout"];
 HatchList[GameConstants.EggType.Fighting] = ["Hitmonlee", "Hitmonchan", "Machop", "Mankey"];
 HatchList[GameConstants.EggType.Electric] = ["Magnemite", "Pikachu", "Voltorb", "Electabuzz"];
 HatchList[GameConstants.EggType.Dragon] = ["Dratini", "Dragonair", "Dragonite"];

--- a/src/scripts/items/EggItem.ts
+++ b/src/scripts/items/EggItem.ts
@@ -21,7 +21,7 @@ class EggItem extends Item {
         if (this.type === GameConstants.EggItemType.Mystery_egg) {
             success = player.gainEgg(BreedingHelper.createRandomEgg());
         } else {
-            let etype = GameConstants.EggType[GameConstants.EggItemType[this.type].split("_")[0]];
+            let etype = GameConstants.EggType[GameConstants.EggItemType[this.type].replace("_egg", "")];
             success = player.gainEgg(BreedingHelper.createTypedEgg(etype));
         }
         
@@ -29,12 +29,20 @@ class EggItem extends Item {
             player.loseItem(this.name(), 1);
         }
     }
+
+    imageName(): string {
+        let parts = this.name().split("_");
+        return parts[0] + "_" + parts[1];   // Get rid of the generation number (e.g. I or II) after "egg"
+    }
 }
 
 
-ItemList['Fire_egg'] = new EggItem(GameConstants.EggItemType.Fire_egg);
-ItemList['Water_egg'] = new EggItem(GameConstants.EggItemType.Water_egg);
-ItemList['Grass_egg'] = new EggItem(GameConstants.EggItemType.Grass_egg);
+ItemList['Fire_egg_I'] = new EggItem(GameConstants.EggItemType.Fire_egg_I);
+ItemList['Water_egg_I'] = new EggItem(GameConstants.EggItemType.Water_egg_I);
+ItemList['Grass_egg_I'] = new EggItem(GameConstants.EggItemType.Grass_egg_I);
+ItemList['Fire_egg_II'] = new EggItem(GameConstants.EggItemType.Fire_egg_II);
+ItemList['Water_egg_II'] = new EggItem(GameConstants.EggItemType.Water_egg_II);
+ItemList['Grass_egg_II'] = new EggItem(GameConstants.EggItemType.Grass_egg_II);
 ItemList['Fighting_egg'] = new EggItem(GameConstants.EggItemType.Fighting_egg);
 ItemList['Electric_egg'] = new EggItem(GameConstants.EggItemType.Electric_egg);
 ItemList['Dragon_egg'] = new EggItem(GameConstants.EggItemType.Dragon_egg);

--- a/src/scripts/items/Item.ts
+++ b/src/scripts/items/Item.ts
@@ -75,6 +75,10 @@ abstract class Item {
         this.price(Math.round(this.basePrice * player.itemMultipliers[this.name()]));
     }
 
+    imageName(): string {
+        return this.name();
+    }
+
 }
 
 const ItemList: { [name: string]: Item } = {};

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -87,7 +87,7 @@ const TownList: { [name: string]: Town | PokemonLeague } = {};
 let PewterCityShop = new Shop(["Pokeball", "Token_collector", "xExp","Dungeon_ticket"]);
 TownList["Pewter City"] = new Town("Pewter City", [2], PewterCityShop);
 
-let CeruleanCityShop = new Shop(["Water_stone", "xAttack", "Water_egg"]);
+let CeruleanCityShop = new Shop(["Water_stone", "xAttack", "Water_egg_I"]);
 TownList["Cerulean City"] = new Town("Cerulean City", [4], CeruleanCityShop, dungeonList["Cerulean Cave"]);
 
 let VermillionCityShop = new Shop(["Thunder_stone", "xExp", "Electric_egg"]);
@@ -102,7 +102,7 @@ TownList["Saffron City"] = new Town("Saffron City", [5], SaffronCityShop);
 let FuchsiaCityShop = new Shop(["Ultraball", "Trade_stone", "xExp", "Dragon_egg"]);
 TownList["Fuchsia City"] = new Town("Fuchsia City", [18], FuchsiaCityShop);
 
-let CinnabarIslandShop = new Shop(["Fire_stone", "Fire_egg", "SmallRestore", "Explorer_kit"]);
+let CinnabarIslandShop = new Shop(["Fire_stone", "Fire_egg_I", "SmallRestore", "Explorer_kit"]);
 TownList["Cinnabar Island"] = new Town("Cinnabar Island", [20], CinnabarIslandShop, dungeonList["Pokemon Mansion"]);
 
 let ViridianCityShop = new Shop(["xAttack", "xClick", "Mystery_egg"]);
@@ -110,7 +110,7 @@ TownList["Viridian City"] = new Town("Viridian City", [1], ViridianCityShop);
 
 TownList["Pallet Town"] = new Town("Pallet Town", []);
 
-let LavenderTownShop = new Shop(["Greatball", "Item_magnet", "Lucky_incense", "Grass_egg"]);
+let LavenderTownShop = new Shop(["Greatball", "Item_magnet", "Lucky_incense", "Grass_egg_I"]);
 TownList["Lavender Town"] = new Town("Lavender Town", [10], LavenderTownShop, dungeonList["Pokemon Tower"]);
 
 //Kanto Dungeons
@@ -126,7 +126,8 @@ TownList["Cerulean Cave"] = new DungeonTown("Cerulean Cave", [4], GameConstants.
 TownList["Pokemon Mansion"] = new DungeonTown("Pokemon Mansion", [20], GameConstants.Badge.Soul);
 
 //Johto Towns
-TownList["New Bark Town"] = new Town("New Bark Town", []);
+let NewBarkTownShop = new Shop(["Grass_egg_II", "Fire_egg_II", "Water_egg_II"]);
+TownList["New Bark Town"] = new Town("New Bark Town", [], NewBarkTownShop);
 
 TownList["Cherrygrove City"] = new Town("Cherrygrove City", [29]);
 


### PR DESCRIPTION
Alternative to #374 . Closes #374 

Implement @Ishadijcks 's suggestion of making separate egg items for Gen2 eggs. Now use `{Type}_egg_{GenNumberInRomanNumeral}` naming convention for these eggs.

**Shop in New Bark Town:**
![image](https://user-images.githubusercontent.com/36806183/60265315-7752e500-98b3-11e9-9670-1f0d78ff8df8.png)

**Shop in Cerulean City:**
![image](https://user-images.githubusercontent.com/36806183/60265340-85086a80-98b3-11e9-9f8d-936aa7acc257.png)
