### PR TITLE
Implement ExpUpgrade.ts

### DIFF
--- a/src/scripts/upgrades/ExpUpgrade.ts
+++ b/src/scripts/upgrades/ExpUpgrade.ts
@@ -1,9 +1,7 @@
 /**
  * An upgrade that requires experience to level up.
  */
-class ExpUpgrade extends Upgrade implements Saveable {
-    saveKey: string = "";
-
+class ExpUpgrade extends Upgrade {
     defaults = {
         level: 0,
         exp: 0
@@ -32,14 +30,13 @@ class ExpUpgrade extends Upgrade implements Saveable {
     }
 
     toJSON(): object {
-        return {
-            level: this.level,
-            exp: this.exp
-        }
+        let json = super.toJSON();
+        json["exp"] = this.exp;
+        return json;
     }
 
     fromJSON(json: object): void {
-        this.level = json["level"] ?? this.defaults.level;
+        super.fromJSON(json);
         this.exp = json["exp"] ?? this.defaults.exp;
     }
 

--- a/src/scripts/upgrades/ExpUpgrade.ts
+++ b/src/scripts/upgrades/ExpUpgrade.ts
@@ -1,0 +1,63 @@
+/**
+ * An upgrade that requires experience to level up.
+ */
+class ExpUpgrade extends Upgrade implements Saveable {
+    saveKey: string = "";
+
+    defaults = {
+        level: 0,
+        exp: 0
+    };
+
+    expList: number[];
+
+    private _exp: KnockoutObservable<number>;
+
+    constructor(name: any, displayName: string, maxLevel: number, expList: number[], costList: Amount[], bonusList: number[], increasing: boolean) {
+        super(name, displayName, maxLevel, costList, bonusList, increasing);
+        this.expList = expList;
+        this._exp = ko.observable(0);
+    }
+
+    gainExp(exp: number) {
+        this.exp = Math.min(this.expList[this.level], this.exp + exp);
+    }
+
+    canBuy(): boolean {
+        return super.canBuy() && this.hasEnoughExp();
+    }
+
+    hasEnoughExp() {
+        return this.exp >= this.expList[this.level];
+    }
+
+    toJSON(): object {
+        return {
+            level: this.level,
+            exp: this.exp
+        }
+    }
+
+    fromJSON(json: object): void {
+        this.level = json["level"] ?? this.defaults.level;
+        this.exp = json["exp"] ?? this.defaults.exp;
+    }
+
+    // Knockout getters/setters
+    get normalizedExp() {
+        if (this.level === 0) {
+            return this.exp
+        }
+        return this.exp - this.expList[this.level - 1];
+    }
+
+    // Private as external sources should use gainExp and normalizedExp
+    private get exp() {
+        return this._exp()
+    }
+
+    private set exp(exp: number) {
+        this._exp(exp)
+    }
+
+}

--- a/src/scripts/upgrades/Upgrade.ts
+++ b/src/scripts/upgrades/Upgrade.ts
@@ -1,4 +1,9 @@
-class Upgrade {
+class Upgrade implements Saveable {
+    defaults = {
+        level: 0
+    };
+    saveKey: string;
+
     name: any;
     displayName: string;
     maxLevel: number;
@@ -14,10 +19,11 @@ class Upgrade {
     bonusList: number[] = [];
 
     constructor(name: any, displayName: string, maxLevel: number, costList: Amount[], bonusList: number[], increasing = true) {
+        this.saveKey = name;
         this.name = name;
         this.displayName = displayName;
         this.maxLevel = maxLevel;
-        this.level = 0;
+        this.level = this.defaults.level;
         this.costList = costList;
         this.bonusList = bonusList;
         this.increasing = increasing;
@@ -61,6 +67,19 @@ class Upgrade {
 
     levelUp() {
         this.level = this.level + 1;
+    }
+
+    fromJSON(json: object): void {
+        if (json == null) {
+            return
+        }
+        this.level = json["level"] ?? this.defaults.level;
+    }
+
+    toJSON(): object {
+        return {
+            level: this.level
+        }
     }
 
     // Knockout getters/setters


### PR DESCRIPTION
An Upgrade that requires exp to level up, can be used for oak items later

Example usage
```
let test = new ExpUpgrade("test", "Test", 3, [100, 1000, 2000], AmountFactory.createArray([1000, 2500, 30000], GameConstants.Currency.money), [10, 20, 30], true)

test.exp // 0
test.gainExp(100)
test.canBuy() // true

test.buy()

test.calculateBonus() // 20
test.normalizedExp // 0

test.gainExp(1000)
test.gainExp(1000)
test.gainExp(1000)

test.exp // 1000
test.normalizedExp // 900
test.canBuy() // true
```