### PR TITLE
Fix battleitems not buying correctly

### DIFF
--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -12,7 +12,7 @@ class BattleItem extends Item {
         this.description = description;
     }
 
-    buy(amt: number) {
+    gain(amt: number) {
         player.gainItem(this.name(), amt);
     }
 

--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -12,10 +12,6 @@ class BattleItem extends Item {
         this.description = description;
     }
 
-    gain(amt: number) {
-        player.gainItem(this.name(), amt);
-    }
-
     use() {
         EffectEngineRunner.addEffect(this.name());
     }


### PR DESCRIPTION
It was overriding the `buy` function while it does not need to override anything