### PR TITLE
Reduce load on calculating effect time remaining

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -31,7 +31,11 @@
             </td>
           </tr>
           <tr data-bind="foreach: Object.keys(ItemList).filter(i=>ItemList[i].constructor.name == 'BattleItem')">
-            <td class="text-light p-0"><code data-bind="text: EffectEngineRunner.formattedTimeLeft($data)()"></code></td>
+            <td class="text-light p-0">
+              <!-- ko if: EffectEngineRunner.getEffect($data) > 0 -->
+                <code data-bind="text: player.effectTimer[$data]()"></code>
+              <!-- /ko -->
+            </td>
           </tr>
         </tbody>
       </table>

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -106,7 +106,7 @@ class Player {
         this.statistics = new Statistics(savedPlayer.statistics);
 
         this.effectList = Save.initializeEffects(savedPlayer.effectList || {});
-        this.effectTimer = Save.initializeEffects({});
+        this.effectTimer = Save.initializeEffectTimer(savedPlayer.effectTimer || {});
         this.highestRegion = ko.observable(savedPlayer.highestRegion || 0);
 
         this.tutorialProgress = ko.observable(savedPlayer.tutorialProgress || 0);
@@ -357,6 +357,7 @@ class Player {
             'statistics',
             'achievementsCompleted',
             'effectList',
+            'effectTimer',
             'highestRegion',
             'tutorialProgress',
             'tutorialState',

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -106,6 +106,7 @@ class Player {
         this.statistics = new Statistics(savedPlayer.statistics);
 
         this.effectList = Save.initializeEffects(savedPlayer.effectList || {});
+        this.effectTimer = Save.initializeEffects({});
         this.highestRegion = ko.observable(savedPlayer.highestRegion || 0);
 
         this.tutorialProgress = ko.observable(savedPlayer.tutorialProgress || 0);
@@ -132,6 +133,7 @@ class Player {
     private _shinyCatches: KnockoutObservable<number>;
 
     public effectList: { [name: string]: KnockoutObservable<number> } = {};
+    public effectTimer: { [name: string]: KnockoutObservable<string> } = {};
 
     public tutorialProgress: KnockoutObservable<number>;
     public tutorialState: any;

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -152,6 +152,14 @@ class Save {
         return res;
     }
 
+    public static initializeEffectTimer(saved?: Array<string>): { [name: string]: KnockoutObservable<string> } {
+        const res = {};
+        for (const obj in GameConstants.BattleItemType) {
+            res[obj] = ko.observable(saved ? saved[obj] || '00:00' : '00:00');
+        }
+        return res;
+    }
+
     public static loadFromFile(file) {
         const fileToRead = file;
         const fr = new FileReader();

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -7,8 +7,8 @@ class EffectEngineRunner {
         for (const itemName in GameConstants.BattleItemType) {
             const timeRemaining = player.effectList[itemName]();
             if (timeRemaining > 0) {
-              player.effectList[itemName](Math.max(0, timeRemaining - timeToReduce));
-              this.updateFormattedTimeLeft(itemName);
+                player.effectList[itemName](Math.max(0, timeRemaining - timeToReduce));
+                this.updateFormattedTimeLeft(itemName);
             }
             if (player.effectList[itemName]() == 5) {
                 Notifier.notify(`The ${itemName}s effect is about to wear off!`, GameConstants.NotificationOption.warning);

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -5,7 +5,11 @@ class EffectEngineRunner {
         this.counter = 0;
         const timeToReduce = 1;
         for (const itemName in GameConstants.BattleItemType) {
-            player.effectList[itemName](Math.max(0, player.effectList[itemName]() - timeToReduce));
+            const timeRemaining = player.effectList[itemName]();
+            if (timeRemaining > 0) {
+              player.effectList[itemName](Math.max(0, timeRemaining - timeToReduce));
+              this.updateFormattedTimeLeft(itemName);
+            }
             if (player.effectList[itemName]() == 5) {
                 Notifier.notify(`The ${itemName}s effect is about to wear off!`, GameConstants.NotificationOption.warning);
             }
@@ -21,17 +25,16 @@ class EffectEngineRunner {
 
     public static addEffect(itemName: string) {
         player.effectList[itemName](Math.max(0, player.effectList[itemName]() +  GameConstants.ITEM_USE_TIME));
+        this.updateFormattedTimeLeft(itemName);
     }
 
-    public static formattedTimeLeft(itemName: string) {
-        return ko.computed(function () {
-            const times = GameConstants.formatTime(player.effectList[itemName]()).split(':');
-            if (+times[0] > 0) {
-                return '60:00+';
-            }
-            times.shift();
-            return times.join(':');
-        }, this);
+    public static updateFormattedTimeLeft(itemName: string) {
+        const times = GameConstants.formatTime(player.effectList[itemName]()).split(':');
+        if (+times[0] > 0) {
+            return '60:00+';
+        }
+        times.shift();
+        player.effectTimer[itemName](times.join(':'));
     }
 
     public static getMoneyMultiplier() {


### PR DESCRIPTION
Update the timer every time the effect counter is reduced.
previously was being run multiple times per second even when the effect counter was at 0.

possibly closes #565 