### PR TITLE
Balance Dungeon Quest Rewards

### DIFF
--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -124,7 +124,7 @@ class Battle {
     }
 
     public static catchPokemon() {
-        App.game.wallet.gainDungeonTokens(6 * Math.pow(this.enemyPokemon().level / 3, 1.05));
+        App.game.wallet.gainDungeonTokens(PokemonFactory.routeDungeonTokens(player.route(), player.region));
         App.game.oakItems.use(OakItems.OakItem.Magic_Ball);
         App.game.party.gainPokemonById(this.enemyPokemon().id, this.enemyPokemon().shiny);
     }

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -129,15 +129,19 @@ namespace GameConstants {
     //   which are now nerfed slightly until upgraded, so those numbers may need further adjusting
     const questBase = 1; // change this to scale all quest points
     export const DEFEAT_POKEMONS_BASE_REWARD  = questBase * 1;
-    export const CAPTURE_POKEMONS_BASE_REWARD = GameConstants.DEFEAT_POKEMONS_BASE_REWARD / 0.8; // Defeat reward divided by chance to catch (guessed)
+    export const CAPTURE_POKEMONS_BASE_REWARD = DEFEAT_POKEMONS_BASE_REWARD / 0.8; // Defeat reward divided by chance to catch (guessed)
     export const GAIN_MONEY_BASE_REWARD       = questBase * 0.0017;  // Dimava
     export const GAIN_TOKENS_BASE_REWARD      = CAPTURE_POKEMONS_BASE_REWARD / 13; // <route number> tokens gained for every capture
     export const HATCH_EGGS_BASE_REWARD       = questBase * 33;      // Dimava
     export const MINE_LAYERS_BASE_REWARD      = questBase * 720;     // Average of 1/4 squares revealed = 75 energy ~ 12 minutes ~ 720 pokemons
     export const SHINY_BASE_REWARD            = questBase * 6000;    // Dimava
-    export const USE_OAK_ITEM_BASE_REWARD     = GameConstants.DEFEAT_POKEMONS_BASE_REWARD; // not balanced at all for some oak items
+    export const USE_OAK_ITEM_BASE_REWARD     = DEFEAT_POKEMONS_BASE_REWARD; // not balanced at all for some oak items
 
     export const ACTIVE_QUEST_MULTIPLIER      = 4;
+
+    // Some active quests may be quicker if passive pokemon attack is used instead of active clicking
+    // This number is used to estimate time taken in terms of clicks, for reward calculation
+    export const QUEST_CLICKS_PER_SECOND      = 5;
 
     export const QuestTypes = [
         'DefeatPokemons',

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -30,24 +30,41 @@ class PokemonFactory {
         const maxHealth: number = PokemonFactory.routeHealth(route, region);
         const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         const exp: number = basePokemon.exp;
+        const level: number = this.routeLevel(route, region);
 
-        const deviation = Math.floor(Math.random() * 51) - 25;
-        const money: number = Math.max(10, 3 * route + 5 * Math.pow(route, 1.15) + deviation);
+        const money: number = this.routeMoney(route,region);
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
         if (shiny) {
             Notifier.notify(`✨ You encountered a shiny ${name}! ✨`, GameConstants.NotificationOption.warning);
         }
-        return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, route * 2, catchRate, exp, money, shiny);
+        return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny);
     }
 
-    public static routeHealth(route: number, region: number): number {
+    public static routeLevel(route: number, region: GameConstants.Region): number {
+        return route * 2;
+    }
+
+    public static routeHealth(route: number, region: GameConstants.Region): number {
         switch (region) {
             // Hoenn starts at route 101 need to reduce the total hp of pokemon on those routes.
-            case 2:
+            case GameConstants.Region.hoenn:
                 route -= 54;
                 break;
         }
         return Math.max(Math.floor(Math.pow((100 * Math.pow(route, 2.2) / 12), 1.15)), 20) || 20;
+    }
+
+    public static routeMoney(route: number, region: GameConstants.Region): number {
+        const deviation = Math.floor(Math.random() * 51) - 25;
+        const money: number = Math.max(10, 3 * route + 5 * Math.pow(route, 1.15) + deviation);
+
+        return money;
+    }
+
+    public static routeDungeonTokens(route: number, region: GameConstants.Region): number {
+        const tokens = 6 * Math.pow(this.routeLevel(route,region) / 3, 1.05);
+
+        return tokens;
     }
 
     /**

--- a/src/scripts/quests/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/DefeatDungeonQuest.ts
@@ -14,7 +14,7 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
         const attacksToCompleteDungeon = attacksToDefeatPokemon * averageTilesToBoss;
         const completeDungeonsReward = attacksToCompleteDungeon * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * GameConstants.ACTIVE_QUEST_MULTIPLIER * amount;
 
-        let region:GameConstants.Region, route:number;
+        let region: GameConstants.Region, route: number;
         for (region = player.highestRegion; region >= 0; region--) {
             route = QuestHelper.highestOneShotRoute(region); // returns 0 if no routes in this region can be one shot
             if (route) {
@@ -26,7 +26,7 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
         }
         const tokens = PokemonFactory.routeDungeonTokens(route,region);
         const routeKillsPerDungeon = dungeonList[dungeon].tokenCost / tokens;
-        const collectTokensReward = routeKillsPerDungeon * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * amount
+        const collectTokensReward = routeKillsPerDungeon * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * amount;
 
         return Math.ceil(completeDungeonsReward + collectTokensReward);
     }

--- a/src/scripts/quests/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/DefeatDungeonQuest.ts
@@ -8,9 +8,26 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
     }
 
     private static calcReward(dungeon: string, amount: number): number {
-        const playerDamage = App.game.party.calculateClickAttack();
-        const attacksToDefeatPokemon = Math.min(4, dungeonList[dungeon].baseHealth / playerDamage);
-        // Average tiles till boss ~= 13
-        return Math.ceil(attacksToDefeatPokemon * 13 * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * GameConstants.ACTIVE_QUEST_MULTIPLIER * amount);
+        const playerDamage = App.game.party.calculateClickAttack() + (App.game.party.calculatePokemonAttack() / GameConstants.QUEST_CLICKS_PER_SECOND);
+        const attacksToDefeatPokemon = Math.ceil(Math.min(4, dungeonList[dungeon].baseHealth / playerDamage));
+        const averageTilesToBoss = 13;
+        const attacksToCompleteDungeon = attacksToDefeatPokemon * averageTilesToBoss;
+        const completeDungeonsReward = attacksToCompleteDungeon * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * GameConstants.ACTIVE_QUEST_MULTIPLIER * amount;
+
+        let region:GameConstants.Region, route:number;
+        for (region = player.highestRegion; region >= 0; region--) {
+            route = QuestHelper.highestOneShotRoute(region); // returns 0 if no routes in this region can be one shot
+            if (route) {
+                break;
+            }
+        }
+        if (!route) {
+            route = 1, region = GameConstants.Region.kanto;
+        }
+        const tokens = PokemonFactory.routeDungeonTokens(route,region);
+        const routeKillsPerDungeon = dungeonList[dungeon].tokenCost / tokens;
+        const collectTokensReward = routeKillsPerDungeon * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * amount
+
+        return Math.ceil(completeDungeonsReward + collectTokensReward);
     }
 }

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -203,4 +203,17 @@ class QuestHelper {
             return Math.min(4, Math.max(1, player ? Math.floor(player.questLevel / 5) : 1));
         }, this);
     }
+
+    public static highestOneShotRoute(region: GameConstants.Region): number {
+        const [first, last] = GameConstants.RegionRoute[region];
+        const attack = Math.max(1, App.game.party.calculatePokemonAttack());
+
+        for (let route = last; route >= first; route--) {
+            if (PokemonFactory.routeHealth(route, region) < attack) {
+                return route;
+            }
+        }
+
+        return 0;
+    }
 }


### PR DESCRIPTION
Fixes a feature where dungeon quests were estimating that you only take 0.0034 attacks per pokemon, therefore your quest reward should be similarly low.

Also accounts for time spent farming the dungeon tokens to actually enter and complete the dungeons, rewarded at afk levels.