### PR TITLE
Fix double LevelEvolution messages

### DIFF
--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -31,11 +31,11 @@ class Party implements Feature {
 
     }
 
-    gainPokemonById(id: number, shiny = false) {
-        this.gainPokemon(PokemonFactory.generatePartyPokemon(id), shiny);
+    gainPokemonById(id: number, shiny = false, suppressNotification = false) {
+        this.gainPokemon(PokemonFactory.generatePartyPokemon(id), shiny, suppressNotification);
     }
 
-    gainPokemon(pokemon: PartyPokemon, shiny = false) {
+    gainPokemon(pokemon: PartyPokemon, shiny = false, suppressNotification = false) {
         GameHelper.incrementObservable(player.caughtAmount[pokemon.id]);
         GameHelper.incrementObservable(player.statistics.pokemonCaptured);
 
@@ -56,7 +56,11 @@ class Party implements Feature {
         if (this.alreadyCaughtPokemon(pokemon.id, false)) {
             return;
         }
-        Notifier.notify(`You have captured ${GameHelper.anOrA(pokemon.name)} ${pokemon.name}!`, GameConstants.NotificationOption.success);
+
+        if (!suppressNotification) {
+            Notifier.notify(`You have captured ${GameHelper.anOrA(pokemon.name)} ${pokemon.name}!`, GameConstants.NotificationOption.success);
+        }
+
         App.game.logbook.newLog(LogBookTypes.CAUGHT, `You have captured ${GameHelper.anOrA(pokemon.name)} ${pokemon.name}!`);
         this._caughtPokemon.push(pokemon);
 

--- a/src/scripts/party/evolutions/Evolution.ts
+++ b/src/scripts/party/evolutions/Evolution.ts
@@ -24,7 +24,7 @@ abstract class Evolution {
         }
 
         const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_STONE);
-        App.game.party.gainPokemonById(PokemonHelper.getPokemonByName(this.evolvedPokemon).id, shiny);
+        App.game.party.gainPokemonById(PokemonHelper.getPokemonByName(this.evolvedPokemon).id, shiny, true);
         return shiny;
     }
 


### PR DESCRIPTION
Allow a suppression of the normal `You catch a ...` message.