### PR TITLE
Disable shards until ShardCase is unlocked

### DIFF
--- a/src/components/gameMenu.html
+++ b/src/components/gameMenu.html
@@ -19,8 +19,9 @@
         <li>
             <a class="dropdown-item" href="#logBookModal" data-toggle="modal">Log Book</a>
         </li>
-        <li>
-            <a class="dropdown-item" href="#" data-bind="click:function(){App.game.shards.openShardModal()}">Shards</a>
+        <li data-bind="attr: {  title: App.game.shards.canAccess() ? '' : 'Progress further to unlock...'}">
+            <a class="dropdown-item" href="#" data-bind="click:function(){App.game.shards.openShardModal()},
+            attr: {class: App.game.shards.canAccess() ? 'dropdown-item' : 'dropdown-item disabled'}">Shards</a>
         </li>
         <li>
             <a class="dropdown-item" href="#showItemsModal" data-toggle="modal">Items</a>
@@ -41,7 +42,9 @@
             <a class="dropdown-item" href="https://discordapp.com/invite/rHF3V54" target="_blank">Discord</a>
         </li>
         <li>
-            <a class="dropdown-item" href="https://gitreports.com/issue/pokeclicker/pokeclicker?name=Anonymous&issue_title=[BUG%20REPORT]%20" target="_blank">Report a bug</a>
+            <a class="dropdown-item"
+               href="https://gitreports.com/issue/pokeclicker/pokeclicker?name=Anonymous&issue_title=[BUG%20REPORT]%20"
+               target="_blank">Report a bug</a>
         </li>
 
     </ul>

--- a/src/components/gameMenu.html
+++ b/src/components/gameMenu.html
@@ -21,7 +21,7 @@
         </li>
         <li data-bind="attr: {  title: App.game.shards.canAccess() ? '' : 'Progress further to unlock...'}">
             <a class="dropdown-item" href="#" data-bind="click:function(){App.game.shards.openShardModal()},
-            attr: {class: App.game.shards.canAccess() ? 'dropdown-item' : 'dropdown-item disabled'}">Shards</a>
+            attr: {class: App.game.shards.canAccess() ? 'dropdown-item' : 'dropdown-item disabled all-pointers'}">Shards</a>
         </li>
         <li>
             <a class="dropdown-item" href="#showItemsModal" data-toggle="modal">Items</a>

--- a/src/scripts/shards/Shards.ts
+++ b/src/scripts/shards/Shards.ts
@@ -21,6 +21,10 @@ class Shards implements Feature {
     }
 
     public gainShards(amt: number, typeNum: PokemonType) {
+        if (!this.canAccess()) {
+            return;
+        }
+
         if (typeNum == PokemonType.None) {
             return;
         }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -299,3 +299,7 @@ td.tight {
   width: 1px;
   white-space: nowrap;
 }
+
+.all-pointers {
+  pointer-events: all !important;
+}


### PR DESCRIPTION
Closes #293 

- Disable the Start Menu entry if the shardcase is not yet unlocked.
- Don't allow the player to gain shards until they unlock the case
