### PR TITLE
Updating Wailmer Pail unlock requirements

### DIFF
--- a/src/scripts/keyItems/KeyItems.ts
+++ b/src/scripts/keyItems/KeyItems.ts
@@ -31,7 +31,7 @@ class KeyItems implements Feature {
             }),
             new KeyItem(KeyItems.KeyItem.Safari_ticket, 'This ticket grants access to the Safari Zone in Fuchsia City'),
             new KeyItem(KeyItems.KeyItem.Wailmer_pail, 'This is a tool for watering Berries you planted to make them grow more quickly', function () {
-                return MapHelper.accessToRoute(14, 1) && App.game.farming.berryList[0] >= 3;
+                return MapHelper.accessToRoute(14, 0) && App.game.farming.berryList[0] >= 3;
             }),
 
             new KeyItem(KeyItems.KeyItem.Explorer_kit, 'A bag filled with convenient tools for exploring. It provides access to the Underground'),

--- a/src/scripts/keyItems/KeyItems.ts
+++ b/src/scripts/keyItems/KeyItems.ts
@@ -31,7 +31,7 @@ class KeyItems implements Feature {
             }),
             new KeyItem(KeyItems.KeyItem.Safari_ticket, 'This ticket grants access to the Safari Zone in Fuchsia City'),
             new KeyItem(KeyItems.KeyItem.Wailmer_pail, 'This is a tool for watering Berries you planted to make them grow more quickly', function () {
-                return MapHelper.accessToRoute(14, 0) && App.game.farming.berryList[0] >= 3;
+                return MapHelper.accessToRoute(14, 0);
             }),
 
             new KeyItem(KeyItems.KeyItem.Explorer_kit, 'A bag filled with convenient tools for exploring. It provides access to the Underground'),

--- a/src/scripts/keyItems/KeyItems.ts
+++ b/src/scripts/keyItems/KeyItems.ts
@@ -31,7 +31,7 @@ class KeyItems implements Feature {
             }),
             new KeyItem(KeyItems.KeyItem.Safari_ticket, 'This ticket grants access to the Safari Zone in Fuchsia City'),
             new KeyItem(KeyItems.KeyItem.Wailmer_pail, 'This is a tool for watering Berries you planted to make them grow more quickly', function () {
-                return MapHelper.accessToRoute(14, 0);
+                return MapHelper.accessToRoute(14, GameConstants.Region.kanto);
             }),
 
             new KeyItem(KeyItems.KeyItem.Explorer_kit, 'A bag filled with convenient tools for exploring. It provides access to the Underground'),


### PR DESCRIPTION
Closes #643 

- Allow accessing the farm in the first region
- No longer require 3 of the first berry