### PR TITLE
Pokeball usage selection

### DIFF
--- a/src/components/pokeballSelector.html
+++ b/src/components/pokeballSelector.html
@@ -5,26 +5,26 @@
     </div>
     <button type="button" class="btn btn-info"
             style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px; padding: 4px;"
-            data-bind="tooltip: { title: 'Select which Pokéball to use on caught Pokémon and new Pokémon (including unobtained shiny Pokémon)', trigger: 'hover', placement:'left' }">
+            data-bind="tooltip: { title: 'Select which Pokéball to use on Pokémon depending on their status', trigger: 'hover', placement:'left' }">
         ?
     </button>
     <div id="pokeballSelectorBody" class="card-body p-0 show">
         <table class="table table-sm">
             <thead>
             <tr>
-                <th width="35%">Caught</th>
-                <th width="30%">#</th>
-                <th width="35%">New</th>
+                <th width="20%" title="Previously captured Pokémon will use this ball selection">Caught</th>
+                <th width="20%" title="Previously captured Shiny Pokémon will use this ball selection">✨</th>
+                <th width="20%" title="Amount of balls you have available">#</th>
+                <th width="20%" title="Uncaptured Pokémon will use this ball selection">New</th>
+                <th width="20%" title="Uncaptured Shiny Pokémon will use this ball selection">✨</th>
             </tr>
             </thead>
             <tbody>
-            <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'None', 'amount': '', 'ball': GameConstants.Pokeball.None}}"></tr>
-            <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Pokeball-small', 'amount': App.game.pokeballs.pokeballs[0], 'ball': GameConstants.Pokeball.Pokeball}}"></tr>
-            <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Greatball-small', 'amount': App.game.pokeballs.pokeballs[1], 'ball': GameConstants.Pokeball.Greatball}}"></tr>
-            <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Ultraball-small', 'amount': App.game.pokeballs.pokeballs[2], 'ball': GameConstants.Pokeball.Ultraball}}"></tr>
-            <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Masterball-small', 'amount': App.game.pokeballs.pokeballs[3], 'ball': GameConstants.Pokeball.Masterball}}"></tr>
-
-
+              <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'None', 'amount': '', 'ball': GameConstants.Pokeball.None}}"></tr>
+              <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Pokeball-small', 'amount': App.game.pokeballs.pokeballs[0], 'ball': GameConstants.Pokeball.Pokeball}}"></tr>
+              <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Greatball-small', 'amount': App.game.pokeballs.pokeballs[1], 'ball': GameConstants.Pokeball.Greatball}}"></tr>
+              <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Ultraball-small', 'amount': App.game.pokeballs.pokeballs[2], 'ball': GameConstants.Pokeball.Ultraball}}"></tr>
+              <tr data-bind="template: { name: 'pokeballSelectionTemplate', data: {'image': 'Masterball-small', 'amount': App.game.pokeballs.pokeballs[3], 'ball': GameConstants.Pokeball.Masterball}}"></tr>
             </tbody>
         </table>
     </div>
@@ -38,11 +38,21 @@
                  click: function(){App.game.pokeballs.alreadyCaughtSelection = $data.ball}, css: {'pokeball-selected': App.game.pokeballs.alreadyCaughtSelection === $data.ball}"/>
     </td>
     <td>
+        <img class="pokeball-small clickable"
+             data-bind="attr: {src: 'assets/images/pokeball/' + $data.image + '.png'},
+                 click: function(){App.game.pokeballs.alreadyCaughtShinySelection = $data.ball}, css: {'pokeball-selected': App.game.pokeballs.alreadyCaughtShinySelection === $data.ball}"/>
+    </td>
+    <td>
         <span data-bind="text: $data.amount"></span>
     </td>
     <td>
         <img class="pokeball-small clickable"
              data-bind="attr: {src: 'assets/images/pokeball/' + $data.image + '.png'},
                  click: function(){App.game.pokeballs.notCaughtSelection = $data.ball}, css: {'pokeball-selected': App.game.pokeballs.notCaughtSelection === $data.ball}"/>
+    </td>
+    <td>
+        <img class="pokeball-small clickable"
+             data-bind="attr: {src: 'assets/images/pokeball/' + $data.image + '.png'},
+                 click: function(){App.game.pokeballs.notCaughtShinySelection = $data.ball}, css: {'pokeball-selected': App.game.pokeballs.notCaughtShinySelection === $data.ball}"/>
     </td>
 </script>

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -134,7 +134,7 @@ namespace GameConstants {
     export const GAIN_TOKENS_BASE_REWARD      = CAPTURE_POKEMONS_BASE_REWARD / 13; // <route number> tokens gained for every capture
     export const HATCH_EGGS_BASE_REWARD       = questBase * 33;      // Dimava
     export const MINE_LAYERS_BASE_REWARD      = questBase * 720;     // Average of 1/4 squares revealed = 75 energy ~ 12 minutes ~ 720 pokemons
-    export const SHINY_BASE_REWARD            = questBase * 6000;    // Dimava
+    export const SHINY_BASE_REWARD            = questBase * 3000;    // Dimava
     export const USE_OAK_ITEM_BASE_REWARD     = DEFEAT_POKEMONS_BASE_REWARD; // not balanced at all for some oak items
 
     export const ACTIVE_QUEST_MULTIPLIER      = 4;

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -5,7 +5,9 @@ class Pokeballs implements Feature {
     defaults = {
         'pokeballs': [25, 0, 0, 0],
         'notCaughtSelection': GameConstants.Pokeball.Pokeball,
+        'notCaughtShinySelection': GameConstants.Pokeball.Pokeball,
         'alreadyCaughtSelection': GameConstants.Pokeball.Pokeball,
+        'alreadyCaughtShinySelection': GameConstants.Pokeball.Pokeball,
     };
 
     private pokeballCatchBonus: number[];
@@ -13,12 +15,16 @@ class Pokeballs implements Feature {
 
     public pokeballs: ArrayOfObservables<number>;
     private _notCaughtSelection: KnockoutObservable<GameConstants.Pokeball>;
+    private _notCaughtShinySelection: KnockoutObservable<GameConstants.Pokeball>;
     private _alreadyCaughtSelection: KnockoutObservable<GameConstants.Pokeball>;
+    private _alreadyCaughtShinySelection: KnockoutObservable<GameConstants.Pokeball>;
 
     constructor() {
         this.pokeballs = new ArrayOfObservables(this.defaults.pokeballs);
         this._notCaughtSelection = ko.observable(this.defaults.notCaughtSelection);
+        this._notCaughtShinySelection = ko.observable(this.defaults.notCaughtShinySelection);
         this._alreadyCaughtSelection = ko.observable(this.defaults.alreadyCaughtSelection);
+        this._alreadyCaughtShinySelection = ko.observable(this.defaults.alreadyCaughtShinySelection);
     }
 
     initialize(): void {
@@ -38,10 +44,18 @@ class Pokeballs implements Feature {
         const alreadyCaughtShiny = App.game.party.alreadyCaughtPokemon(id, true);
         let pref: GameConstants.Pokeball;
         // just check against alreadyCaughtShiny as this returns false when you don't have the pokemon yet.
-        if (!alreadyCaught || (!alreadyCaughtShiny && isShiny)) {
-            pref = this.notCaughtSelection;
+        if (isShiny) {
+            if (!alreadyCaughtShiny) {
+                pref = this.notCaughtShinySelection;
+            } else {
+                pref = this.alreadyCaughtShinySelection;
+            }
         } else {
-            pref = this.alreadyCaughtSelection;
+            if (!alreadyCaught) {
+                pref = this.notCaughtSelection;
+            } else {
+                pref = this.alreadyCaughtSelection;
+            }
         }
 
         let use: GameConstants.Pokeball = GameConstants.Pokeball.None;
@@ -94,7 +108,9 @@ class Pokeballs implements Feature {
             ]);
         }
         this.notCaughtSelection = json['notCaughtSelection'] ?? this.defaults.notCaughtSelection;
+        this.notCaughtShinySelection = json['notCaughtShinySelection'] ?? this.defaults.notCaughtShinySelection;
         this.alreadyCaughtSelection = json['alreadyCaughtSelection'] ?? this.defaults.alreadyCaughtSelection;
+        this.alreadyCaughtShinySelection = json['alreadyCaughtShinySelection'] ?? this.defaults.alreadyCaughtShinySelection;
     }
 
     toJSON(): object {
@@ -106,7 +122,9 @@ class Pokeballs implements Feature {
                 this.pokeballs[GameConstants.Pokeball.Masterball],
             ],
             'notCaughtSelection': this.notCaughtSelection,
+            'notCaughtShinySelection': this.notCaughtShinySelection,
             'alreadyCaughtSelection': this.alreadyCaughtSelection,
+            'alreadyCaughtShinySelection': this.alreadyCaughtShinySelection,
         };
     }
 
@@ -115,6 +133,22 @@ class Pokeballs implements Feature {
     }
 
     // Knockout getters/setters
+    get notCaughtSelection() {
+        return this._notCaughtSelection();
+    }
+
+    set notCaughtSelection(ball: GameConstants.Pokeball) {
+        this._notCaughtSelection(ball);
+    }
+
+    get notCaughtShinySelection() {
+        return this._notCaughtShinySelection();
+    }
+
+    set notCaughtShinySelection(ball: GameConstants.Pokeball) {
+        this._notCaughtShinySelection(ball);
+    }
+
     get alreadyCaughtSelection() {
         return this._alreadyCaughtSelection();
     }
@@ -123,11 +157,11 @@ class Pokeballs implements Feature {
         this._alreadyCaughtSelection(ball);
     }
 
-    get notCaughtSelection() {
-        return this._notCaughtSelection();
+    get alreadyCaughtShinySelection() {
+        return this._alreadyCaughtShinySelection();
     }
 
-    set notCaughtSelection(ball: GameConstants.Pokeball) {
-        this._notCaughtSelection(ball);
+    set alreadyCaughtShinySelection(ball: GameConstants.Pokeball) {
+        this._alreadyCaughtShinySelection(ball);
     }
 }


### PR DESCRIPTION
Closes #425 
Add a selector for pokeball to use based on caught/shiny status of pokemon encountered.
Nerfed the catch shiny quest due to the ease of catching already obtained shinies.

_**NOTE:** Tested with 1m pokeballs, list still shows fine:_
![image](https://user-images.githubusercontent.com/7288322/79516224-de3dc680-809e-11ea-914d-da81dcaf23e8.png)
