### PR TITLE
Fix Lurking Computed Observers

### DIFF
--- a/src/scripts/GameHelper.ts
+++ b/src/scripts/GameHelper.ts
@@ -5,10 +5,10 @@ class GameHelper {
     public static counter = 0;
     public static currentTime: KnockoutObservable<Date> = ko.observable(new Date());
     public static tomorrow: Date = GameHelper.getTomorrow();
-    public static msUntilTomorrow: KnockoutComputed<number> = ko.computed(function () {
+    public static msUntilTomorrow: KnockoutComputed<number> = ko.pureComputed(function () {
         return Number(GameHelper.tomorrow) - Number(GameHelper.currentTime());
     });
-    public static formattedTimeUntilTomorrow: KnockoutComputed<string> = ko.computed(function () {
+    public static formattedTimeUntilTomorrow: KnockoutComputed<string> = ko.pureComputed(function () {
         let milliseconds = GameHelper.msUntilTomorrow();
         const hours = Math.floor(milliseconds / GameHelper.MS_IN_HOUR);
         milliseconds -= hours * GameHelper.MS_IN_HOUR;
@@ -16,7 +16,7 @@ class GameHelper {
         return `${hours}:${GameHelper.twoDigitNumber(minutes)}`;
     });
 
-    public static formattedLetterTimeUntilTomorrow: KnockoutComputed<string> = ko.computed(function () {
+    public static formattedLetterTimeUntilTomorrow: KnockoutComputed<string> = ko.pureComputed(function () {
         let milliseconds = GameHelper.msUntilTomorrow();
         const hours = Math.floor(milliseconds / GameHelper.MS_IN_HOUR);
         milliseconds -= hours * GameHelper.MS_IN_HOUR;

--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -26,7 +26,7 @@ class Egg implements Saveable {
     }
 
     private init() {
-        this.progress = ko.computed(function () {
+        this.progress = ko.pureComputed(function () {
             return this.steps() / this.totalSteps * 100;
         }, this);
 

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -31,7 +31,7 @@ class DungeonRunner {
         DungeonRunner.pokemonDefeated = 0;
         DungeonRunner.chestsOpened = 0;
         DungeonRunner.loot = [];
-        DungeonRunner.currentTileType = ko.computed(function () {
+        DungeonRunner.currentTileType = ko.pureComputed(function () {
             return DungeonRunner.map.currentTile().type;
         });
         DungeonRunner.fightingBoss(false);
@@ -107,7 +107,7 @@ class DungeonRunner {
         }
     }
 
-    public static timeLeftSeconds = ko.computed(function () {
+    public static timeLeftSeconds = ko.pureComputed(function () {
         return (Math.ceil(DungeonRunner.timeLeft() / 10) / 10).toFixed(1);
     })
 

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -47,7 +47,7 @@ class EffectEngineRunner {
 
 
     public static isActive(itemName: string): KnockoutComputed<boolean> {
-        return ko.computed(function () {
+        return ko.pureComputed(function () {
             if (!player) {
                 return false;
             }

--- a/src/scripts/gym/Gym.ts
+++ b/src/scripts/gym/Gym.ts
@@ -33,7 +33,7 @@ class Gym {
     }
 
     public static calculateCssClass(gym: Gym): KnockoutComputed<string> {
-        return ko.computed(function () {
+        return ko.pureComputed(function () {
             if (App.game.badgeCase.hasBadge(gym.badgeReward)) {
                 return 'btn btn-success';
             }

--- a/src/scripts/gym/GymBattle.ts
+++ b/src/scripts/gym/GymBattle.ts
@@ -30,11 +30,11 @@ class GymBattle extends Battle {
         this.enemyPokemon(PokemonFactory.generateTrainerPokemon(this.gym.town, this.index()));
     }
 
-    public static pokemonsDefeatedComputable: KnockoutComputed<number> = ko.computed(function () {
+    public static pokemonsDefeatedComputable: KnockoutComputed<number> = ko.pureComputed(function () {
         return GymBattle.index();
     });
 
-    public static pokemonsUndefeatedComputable: KnockoutComputed<number> = ko.computed(function () {
+    public static pokemonsUndefeatedComputable: KnockoutComputed<number> = ko.pureComputed(function () {
         return GymBattle.totalPokemons() - GymBattle.index();
     })
 }

--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -78,7 +78,7 @@ class GymRunner {
         App.game.gameState = GameConstants.GameState.town;
     }
 
-    public static timeLeftSeconds = ko.computed(function () {
+    public static timeLeftSeconds = ko.pureComputed(function () {
         return (Math.ceil(GymRunner.timeLeft() / 10) / 10).toFixed(1);
     })
 

--- a/src/scripts/keyItems/KeyItem.ts
+++ b/src/scripts/keyItems/KeyItem.ts
@@ -15,6 +15,7 @@ class KeyItem {
             this.unlockReq = null;
             return;
         }
+        // This computed is disposed by unlock()
         this.unlockReq = ko.computed<boolean>(unlockReq);
         this.unlocker = this.unlockReq.subscribe(() => {
             if (this.unlockReq()) {

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -19,7 +19,7 @@ class PokedexHelper {
      * @returns {boolean}
      */
     public static pokemonSeen(id: number): KnockoutComputed<boolean> {
-        return ko.computed(function () {
+        return ko.pureComputed(function () {
             return player.defeatedAmount[id]() > 0 || player.caughtAmount[id]() > 0;
         });
     }

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -80,7 +80,9 @@ abstract class Quest {
             }
         }, this);
 
-        // this computed has a side effect - creating a notification - so we cannot safely make it a pureComputed
+        // This computed has a side effect - creating a notification - so we cannot safely make it a pureComputed
+        // This will only be a problem if we make it subscribe to a function which lives longer than itself
+        // Since it is only subscribing to observables on `this`, and the function is being kept on `this`, we shouldn't have a problem
         this.isCompleted = ko.computed(function() {
             const completed = this.progress() == 1;
             if (!this.autoComplete && completed && !this.notified) {

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -64,7 +64,7 @@ abstract class Quest {
     }
 
     protected createProgressObservables() {
-        this.progress = ko.computed(function() {
+        this.progress = ko.pureComputed(function() {
             if (this.initial() !== null) {
                 return Math.min(1, ( this.questFocus() - this.initial()) / this.amount);
             } else {
@@ -72,13 +72,15 @@ abstract class Quest {
             }
         }, this);
 
-        this.progressText = ko.computed(function() {
+        this.progressText = ko.pureComputed(function() {
             if (this.initial() !== null) {
                 return `${Math.min((this.questFocus() - this.initial()), this.amount)}/${this.amount}`;
             } else {
                 return `0/${this.amount}`;
             }
         }, this);
+
+        // this computed has a side effect - creating a notification - so we cannot safely make it a pureComputed
         this.isCompleted = ko.computed(function() {
             const completed = this.progress() == 1;
             if (!this.autoComplete && completed && !this.notified) {
@@ -103,7 +105,7 @@ abstract class Quest {
     }
 
     inProgress() {
-        return ko.computed(() => {
+        return ko.pureComputed(() => {
             return player.currentQuests().map(x => x.index).includes(this.index) && !this.isCompleted();
         });
     }

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -198,7 +198,7 @@ class QuestHelper {
     }
 
     public static questSlots(): KnockoutComputed<number> {
-        return ko.computed(function () {
+        return ko.pureComputed(function () {
             // Minimum of 1, Maximum of 4
             return Math.min(4, Math.max(1, player ? Math.floor(player.questLevel / 5) : 1));
         }, this);

--- a/src/scripts/quests/QuestLine.ts
+++ b/src/scripts/quests/QuestLine.ts
@@ -14,7 +14,7 @@ class QuestLine {
         this.description = description;
         this.quests = ko.observableArray();
         this.totalQuests = 0;
-        this.curQuest = ko.computed(() => {
+        this.curQuest = ko.pureComputed(() => {
             const acc = 0;
             return this.quests().map((quest) => {
                 return +quest.isCompleted();
@@ -28,7 +28,7 @@ class QuestLine {
             return false;
         }; //Always update subscriptions, even if same data pushed in
 
-        this.curQuestObject = ko.computed(() => {
+        this.curQuestObject = ko.pureComputed(() => {
             this.quests(); //register dependency on this computed so it will update
             if (this.totalQuests > 0 && this.curQuest() < this.totalQuests) {
                 return this.quests()[this.curQuest()];

--- a/src/scripts/settings/Setting.ts
+++ b/src/scripts/settings/Setting.ts
@@ -43,7 +43,7 @@ class Setting {
     }
 
     isSelected(value: any): KnockoutComputed<boolean> {
-        return ko.computed(function () {
+        return ko.pureComputed(function () {
             return this.observableValue() === value;
         }, this);
     }

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -67,6 +67,7 @@ class Underground {
     }
 
     public static calculateCssClass(i: number, j: number): KnockoutComputed<string> {
+        // disposed via the disposeWhen function passed as an option
         return ko.computed(function () {
             return `col-sm-1 rock${Math.max(Mine.grid[i][j](), 0)} mineSquare ${Mine.Tool[Mine.toolSelected()]}Selected`;
         }, this, {


### PR DESCRIPTION
This pull request fixes at least one cause of pokeclicker accumulating memory as you play.
The main source of memory leaking it fixes is from clickAttacks

All of the changes are changing ko.computed into ko.pureComputed wherever possible.

A ko.computed will subscribe to any observables that it sees, which adds this ko.computed to an update list on each observable. When we lose any normal references to this computed (eg, a variable or DOM node), we expect the garbage collector to free up the memory. Since the computed is still referenced in this hidden update list of one or more observables, the garbage collector thinks we still want the function and does not free its memory.

This happens every time we calculate click attack (eg, every time we do a clickAttack), because we are checking if the x attack item is active by creating a computed, evaluating it, and then forgetting about. Except the effectList remembers every single one of those computed functions.

We can solve this in two ways:
1. Make sure to call dispose() on the computed when we are done with it
2. Use a pureComputed instead

A pureComputed will unsubscribe from all observables when it no longer has any subscribers to itself. This method is only a problem for computeds that we want to stay subscribed even if nothing is subscribed to itself, because we want the computed to perform some side effect when an observable changes - for example, creating a notification.

I have changed as many computed functions as I can to pureComputed, and eyeballed the remaining ones to see if they are disposed properly. The minesquare one in Underground looks possibly leaky.




