### PR TITLE
Add option to sort pokemon list by base attack

### DIFF
--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -32,33 +32,12 @@ class PartyController {
     public static compareBy(option: SortOptions, direction: boolean): (a: PartyPokemon, b: PartyPokemon) => number {
         return function (a, b) {
             let res, dir = (direction) ? -1 : 1;
+            const config = SortOptionConfigs[option];
 
-            let aValue;
-            let bValue;
-            switch (option) {
-                case SortOptions.id:
-                    aValue = a.id;
-                    bValue = b.id;
-                    break;
-                case SortOptions.name:
-                    aValue = a.name;
-                    bValue = b.name;
-                    break;
-                case SortOptions.attack:
-                    aValue = a.calculateAttack();
-                    bValue = b.calculateAttack();
-                    break;
-                case SortOptions.level:
-                    aValue = a.level;
-                    bValue = b.level;
-                    break;
-                case SortOptions.shiny:
-                    aValue = Number(App.game.party.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(a.name).id, true));
-                    bValue = Number(App.game.party.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(b.name).id, true));
+            const aValue = config.getValue(a);
+            const bValue = config.getValue(b);
 
-
-            }
-            if (option === SortOptions.attack || option == SortOptions.level || option == SortOptions.shiny) {
+            if (config.invert) {
                 dir *= -1;
             }
 

--- a/src/scripts/settings/Settings.ts
+++ b/src/scripts/settings/Settings.ts
@@ -77,14 +77,13 @@ Settings.add(
     )
 );
 
+const sortsettings = Object.keys(SortOptionConfigs).map(
+    function(opt) {
+        return new GameConstants.Option(SortOptionConfigs[opt].text, parseInt(opt));
+    }
+);
 Settings.add(new MultipleChoiceSetting('partySort', 'Sort:',
-    [
-        new GameConstants.Option('Pokedex #', SortOptions.id),
-        new GameConstants.Option('Name', SortOptions.name),
-        new GameConstants.Option('Attack', SortOptions.attack),
-        new GameConstants.Option('Level', SortOptions.level),
-        new GameConstants.Option('Shiny', SortOptions.shiny),
-    ],
+    sortsettings,
     SortOptions.id
 ));
 

--- a/src/scripts/settings/SortOptions.ts
+++ b/src/scripts/settings/SortOptions.ts
@@ -3,7 +3,8 @@ enum SortOptions {
     'name' = 1,
     'attack' = 2,
     'level' = 3,
-    'shiny' = 4
+    'shiny' = 4,
+    'baseAttack' = 5,
 }
 
 type SortOptionConfig = {
@@ -43,6 +44,12 @@ const SortOptionConfigs: Record<SortOptions, SortOptionConfig> = {
     [SortOptions.shiny]: {
         'text': 'Shiny',
         'getValue': p => Number(App.game.party.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(p.name).id, true)),
+        'invert': true,
+    },
+
+    [SortOptions.baseAttack]: {
+        'text': 'Base Attack',
+        'getValue': p => p.baseAttack,
         'invert': true,
     },
 };

--- a/src/scripts/settings/SortOptions.ts
+++ b/src/scripts/settings/SortOptions.ts
@@ -5,3 +5,44 @@ enum SortOptions {
     'level' = 3,
     'shiny' = 4
 }
+
+type SortOptionConfig = {
+    // Display text in sort dropdown
+    text: string;
+
+    // How to get the comparison value from a PartyPokemon
+    getValue: (p: PartyPokemon) => any;
+
+    // true if the default sort direction should be descending
+    invert?: boolean;
+}
+
+const SortOptionConfigs: Record<SortOptions, SortOptionConfig> = {
+    [SortOptions.id]: {
+        'text': 'Pokemon #',
+        'getValue': p => p.id,
+    },
+
+    [SortOptions.name]: {
+        'text': 'Name',
+        'getValue': p => p.name,
+    },
+
+    [SortOptions.attack]: {
+        'text': 'Attack',
+        'getValue': p => p.calculateAttack(),
+        'invert': true,
+    },
+
+    [SortOptions.level]: {
+        'text': 'Level',
+        'getValue': p => p.level,
+        'invert': true,
+    },
+
+    [SortOptions.shiny]: {
+        'text': 'Shiny',
+        'getValue': p => Number(App.game.party.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(p.name).id, true)),
+        'invert': true,
+    },
+};


### PR DESCRIPTION
There have been many requests for sorting by base attack, so people know which is the best pokemon to breed.

I didn't like having to add to a large switch statement to have a new sort option, and also have to add code in Settings.ts to register it, so I have refactored the sort options to have all the data in one place.


The Record type annotation on sortOptionConfigs is a nice feature, TypeScript will complain if we don't add an entry for all possible enum values

Fixes #682 