### PR TITLE
Fix up events checking

### DIFF
--- a/src/scripts/specialEvents/SpecialEvent.ts
+++ b/src/scripts/specialEvents/SpecialEvent.ts
@@ -129,7 +129,7 @@ class SpecialEvent {
 
         // If more than 1 day, don't notify the player yet
         if (timeTillEventEnd > 1 * GameConstants.DAY) {
-            // Check again when 7 days left until event start, or in 7 days (whichever is less)
+            // Check again when 1 day left until event start, or in 1 day (whichever is less)
             setTimeout(() => {
                 this.checkEnd();
             }, Math.min(1 * GameConstants.DAY, timeTillEventEnd - 1 * GameConstants.DAY));

--- a/src/scripts/specialEvents/SpecialEvent.ts
+++ b/src/scripts/specialEvents/SpecialEvent.ts
@@ -31,51 +31,8 @@ class SpecialEvent {
     }
 
     initialize(): void {
-        // If event already over, do nothing
-        if (this.timeTillEnd() <= 0) {
-            this.status = SpecialEventStatus.ended;
-            return;
-        }
-
-        const timeTillEventStart = this.timeTillStart();
-        // If more than 1 week, don't notify the player yet
-        if (timeTillEventStart > 7 * GameConstants.DAY) {
-            // Check again when 7 days left until event start
-            setTimeout(() => {
-                this.initialize();
-            }, timeTillEventStart - 7 * GameConstants.DAY);
-            return;
-        }
-
-        // If more than 1 day, notify player about the upcoming event
-        if (timeTillEventStart > 1 * GameConstants.DAY) {
-            this.notify(`starts in ${GameConstants.formatTimeShortWords(timeTillEventStart)}!`, Math.min(1 * GameConstants.HOUR));
-            // Check again when less than 6 hours till event start
-            setTimeout(() => {
-                this.initialize();
-            }, timeTillEventStart - 6 * GameConstants.HOUR);
-            return;
-        }
-
-        // If more than 1 hour, notify player about event starting time
-        if (timeTillEventStart > 1 * GameConstants.HOUR) {
-            this.notify(`starts in ${GameConstants.formatTimeShortWords(timeTillEventStart)}!`, Math.min(timeTillEventStart, 1 * GameConstants.HOUR));
-        }
-
-        // If not started yet, notify player event will start soon
-        if (!this.shouldStartNow()) {
-            // Notify player when 1 hour left, or now
-            const sendNotificationTimeout = Math.max(timeTillEventStart - 1 * GameConstants.HOUR, 0);
-            const notificationTimeout = sendNotificationTimeout ? 1 * GameConstants.HOUR : timeTillEventStart;
-            setTimeout(() => {
-                this.notify(`starts in ${GameConstants.formatTimeShortWords(notificationTimeout)}!`, notificationTimeout);
-            }, sendNotificationTimeout);
-        }
-
-        // Start event now, or at start time
-        setTimeout(() => {
-            this.start();
-        }, Math.max(0, timeTillEventStart));
+        // Start checking when the event should start
+        this.checkStart();
     }
 
     shouldStartNow(): boolean {
@@ -104,13 +61,83 @@ class SpecialEvent {
         Notifier.notify({ title: `[EVENT] ${this.title}`, message: `${this.description}<br/><br/><strong>Start time:</strong> ${this.startTime.toLocaleString()}<br/><strong>End time:</strong> ${this.endTime.toLocaleString()}`, type, time, timeout, setting: GameConstants.NotificationSetting.event_start_end });
     }
 
+    checkStart() {
+        // If event already over, do nothing
+        if (this.timeTillEnd() <= 0) {
+            this.status = SpecialEventStatus.ended;
+            return;
+        }
+
+        const timeTillEventStart = this.timeTillStart();
+        // If more than 1 week, don't notify the player yet
+        if (timeTillEventStart > 7 * GameConstants.DAY) {
+            // Check again when 7 days left until event start, or in 7 days
+            setTimeout(() => {
+                this.checkStart();
+            }, Math.min(7 * GameConstants.DAY, timeTillEventStart - 7 * GameConstants.DAY));
+            // return as this function will be run again after the timeout
+            return;
+        }
+
+        // If more than 1 day, notify player about the upcoming event
+        if (timeTillEventStart > 1 * GameConstants.DAY) {
+            this.notify(`starts in ${GameConstants.formatTimeShortWords(timeTillEventStart)}!`, Math.min(1 * GameConstants.HOUR));
+            // Check again when less than 6 hours till event start
+            setTimeout(() => {
+                this.checkStart();
+            }, timeTillEventStart - 6 * GameConstants.HOUR);
+            // return as this function will be run again after the timeout
+            return;
+        }
+
+        // If more than 1 hour, notify player about event starting time
+        if (timeTillEventStart > 1 * GameConstants.HOUR) {
+            this.notify(`starts in ${GameConstants.formatTimeShortWords(timeTillEventStart)}!`, Math.min(timeTillEventStart, 1 * GameConstants.HOUR));
+        }
+
+        // If not started yet, notify player event will start soon
+        if (!this.shouldStartNow()) {
+            // Notify player when 1 hour left, or now
+            const sendNotificationTimeout = Math.max(timeTillEventStart - 1 * GameConstants.HOUR, 0);
+            const notificationTimeout = sendNotificationTimeout ? 1 * GameConstants.HOUR : timeTillEventStart;
+            setTimeout(() => {
+                this.notify(`starts in ${GameConstants.formatTimeShortWords(notificationTimeout)}!`, notificationTimeout);
+            }, sendNotificationTimeout);
+        }
+
+        // Start event now, or at start time
+        setTimeout(() => {
+            this.start();
+        }, Math.max(0, timeTillEventStart));
+    }
+
     start() {
+        // Update event status
         this.status = SpecialEventStatus.started;
+
+        // We only wan't the notification displayed for 1 hour, or until the event is over
+        const timeTillEventEnd = this.timeTillEnd();
+        this.notify('on now!', Math.min(1 * GameConstants.HOUR, timeTillEventEnd), GameConstants.NotificationOption.success);
+
+        this.startFunction();
+        // Start checking when the event should be ending
+        this.checkEnd();
+    }
+
+    checkEnd() {
         const timeTillEventEnd = this.timeTillEnd();
 
-        this.notify('on now!', Math.min(1 * GameConstants.HOUR, timeTillEventEnd), GameConstants.NotificationOption.success);
-        this.startFunction();
+        // If more than 1 day, don't notify the player yet
+        if (timeTillEventEnd > 1 * GameConstants.DAY) {
+            // Check again when 7 days left until event start, or in 7 days (whichever is less)
+            setTimeout(() => {
+                this.checkEnd();
+            }, Math.min(1 * GameConstants.DAY, timeTillEventEnd - 1 * GameConstants.DAY));
+            // return as this function will be run again after the timeout
+            return;
+        }
 
+        // If less than 1 day, and not already over, notify the player when it will end
         if (timeTillEventEnd > 0) {
             // Notify player when 1 hour left, or now
             const sendNotificationTimeout = Math.max(timeTillEventEnd - 1 * GameConstants.HOUR, 0);
@@ -127,6 +154,7 @@ class SpecialEvent {
     }
 
     end() {
+        // Update event status
         this.status = SpecialEventStatus.ended;
         this.notify('just ended!', 1 * GameConstants.HOUR, GameConstants.NotificationOption.danger);
         this.endFunction();


### PR DESCRIPTION
setTimeout is run instantly if the number is too large:
The delay (in milliseconds) for these functions is a 32 bit signed quantity, which limits it to 2147483647 ms or 24.855 days.

The main change is here:
```diff
-                this.initialize();
-            }, timeTillEventStart - 7 * GameConstants.DAY);
+                this.checkStart();
+            }, Math.min(7 * GameConstants.DAY, timeTillEventStart - 7 * GameConstants.DAY));
```
It was running the `initialize` function constantly over and over if the event start time was more than ~25 days away, as that's the limit for setTImeout.
But it should now run a set timeout for 7 days or until the event start, whichever is less.

🤞 Should reduce some lag.