### PR TITLE
Ignore controls when focused on input element

### DIFF
--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -116,6 +116,11 @@ class GameController {
 
     static addKeyListeners() {
         $(document).on('keydown', function (e) {
+            // Ignore any of our controls if focused on an input element
+            if (document.activeElement.localName == 'input') {
+                return;
+            }
+
             const keyCode = e.keyCode;
 
             if (App.game.gameState === GameConstants.GameState.dungeon) {


### PR DESCRIPTION
Ignore controls when focused on input element, This allows users to enter `-` in the code box correctly if on a route, instead of it trying to move routes.