### PR TITLE
Move `ko: if seen` conditional in pokedex image html

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -95,14 +95,14 @@ aria-labelledby="pokedexModalLabel">
                    <li class="col-sm-4 col-md-3 col-lg-2 pokedexEntry"
                         data-bind="style:{background: PokedexHelper.getBackgroundColors($data.name)}">
                         <span class="id" style="top: 0; border-top-left-radius: 6px; border-top-right-radius: 6px;" data-bind="text: (Math.floor($data.id) + '').padStart(3, 0)">number</span>
-                        <!-- ko if: PokedexHelper.pokemonSeen($data.id) -->
                             <div data-bind="visible: App.game.party.alreadyCaughtPokemonByName(name)" style="position: absolute;right: 2px;top: -15px;">
                                 <img width="18px" src="" data-bind="attr: { src: `assets/images/pokeball/Pokeball${App.game.party.alreadyCaughtPokemon($data.id, true) ? '-shiny' : ''}-small.png`}"/>
                             </div>
                             <img src="" width="80px" data-bind="css: { 'pokemon-not-seen': !PokedexHelper.pokemonSeen($data.id)() }, attr:{ src: PokedexHelper.getImage($data.id)}">
+                            <!-- ko if: PokedexHelper.pokemonSeen($data.id) -->
                             <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: $data.name">name</span>
                             <a class="overlay" href="#pokemonStatisticsModal" data-toggle="modal" data-bind="click: ()=>{App.game.statistics.selectedPokemonID($data.id)}, tooltip: { html: true, title: `<u>Information:</u><br/>Base Attack: <strong>${$data.attack}</strong><br/>Catch Rate: <strong>${PokemonFactory.catchRateHelper($data.catchRate, true)}%</strong><br/>Hatch Steps: <strong>${App.game.breeding.getSteps($data.eggCycles).toLocaleString('en-US')}</strong>`, trigger: 'hover', placement:'bottom' }"></a>
-                        <!-- /ko -->
+                            <!-- /ko -->
                    </li>
                </ul>
            </div>


### PR DESCRIPTION
The silhouette image for unseen pokemon is not being shown since the fix to the hatchery display.
This moves the `ko if` to surround just the things we don't want for the unseen pokemon.

Before hatchery changes:
![Before hatchery changes](https://i.imgur.com/CT0TWpO.png)

After hatchery changes:
![After hatchery changes](https://i.imgur.com/bpD4kxx.png)

With this change:
![With this change](https://i.imgur.com/KBAYMEL.png)