### PR TITLE
Add use all battle items button under each item

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -30,6 +30,26 @@
 
             </td>
           </tr>
+		  <tr data-bind="foreach: Object.keys(ItemList).filter(i=>ItemList[i].constructor.name == 'BattleItem')">
+            <td class="p-0 clickable" data-bind="visible: player.highestRegion,
+							css: {
+                                'bg-primary': EffectEngineRunner.getEffect($data) > 5,
+                                'bg-warning': EffectEngineRunner.getEffect($data) <= 5 && EffectEngineRunner.getEffect($data) > 0,
+                                'bg-secondary': !EffectEngineRunner.isActive($data)(),
+								'text-light': EffectEngineRunner.isActive($data)()
+                            },
+                            event: {
+                                click: function(){ItemHandler.useAllItems($data)}
+                            },
+							text: 'MAX',
+                            tooltip: {
+                              title: 'Use all avaliable ' + $data.replace('_', ' ') + 's at once.',
+                              trigger: 'hover',
+                              placement:'bottom',
+                              html: true
+                            }">
+            </td>
+          </tr>
           <tr data-bind="foreach: Object.keys(ItemList).filter(i=>ItemList[i].constructor.name == 'BattleItem')">
             <td class="text-light p-0">
               <!-- ko if: EffectEngineRunner.getEffect($data) > 0 -->

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -23,8 +23,8 @@ class EffectEngineRunner {
         return player.effectList[itemName]();
     }
 
-    public static addEffect(itemName: string) {
-        player.effectList[itemName](Math.max(0, player.effectList[itemName]() +  GameConstants.ITEM_USE_TIME));
+    public static addEffect(itemName: string, amount: number = 1) {
+        player.effectList[itemName](Math.max(0, player.effectList[itemName]() + amount * GameConstants.ITEM_USE_TIME));
         this.updateFormattedTimeLeft(itemName);
     }
 

--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -10,8 +10,8 @@ class BattleItem extends Item {
         this.description = description;
     }
 
-    use() {
-        EffectEngineRunner.addEffect(this.name());
+    use(amount: number = 1) {
+        EffectEngineRunner.addEffect(this.name(), amount);
     }
 }
 

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -13,6 +13,17 @@ class ItemHandler {
         player.itemList[name](player.itemList[name]() - 1);
         return ItemList[name].use();
     }
+	
+	public static useAllItems(name: string) {
+		if (!player.itemList[name]()) {
+            return Notifier.notify({ message: `You don't have any ${GameConstants.humanifyString(name)}s left...`, type: GameConstants.NotificationOption.danger });
+        }
+
+		const amount = player.itemList[name]();
+		
+        player.itemList[name](0);
+        return ItemList[name].use(amount);
+	}
 
     public static resetAmount() {
         const input = $("input[name='amountOfStones']");


### PR DESCRIPTION
Clicking hundreds of times to keep battle items active for hours gets kinda old after a few regions. This should add buttons similar to the shop screens that'll use all of a battle item in a single click under each item. I've set it to only show after arriving in Johto (similar to the shortcuts menu), as this probably shouldn't be a feature that's available early in the game.