### PR TITLE
Add Sinnoh Roamers

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -451,11 +451,11 @@ dungeonList['Mt. Coronet North'] = new Dungeon('Mt. Coronet North',
     69500, 201, 20);
 
 dungeonList['Lake Verity'] = new Dungeon('Lake Verity',
-    ['Starly', 'Bidoof', 'Psyduck', 'Golduck', 'Magikarp', 'Goldeen'],
+    ['Starly', 'Bidoof', 'Psyduck', 'Magikarp', 'Goldeen'],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.Item_magnet],
     768735,
     [
-        new DungeonBossPokemon('Mesprit', 3820000, 10),
+        new DungeonBossPokemon('Golduck', 3820000, 10),
         new DungeonBossPokemon('Seaking', 3820000, 10),
     ],
     72500, 201, 5);
@@ -529,7 +529,7 @@ dungeonList['Fullmoon Island'] = new Dungeon('Fullmoon Island',
     ['Illumise', 'Minun', 'Espeon', 'Luvdisc'],
     [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
     2203000,
-    [new DungeonBossPokemon('Cresselia', 9000000, 70)],
+    [new DungeonBossPokemon('Clefable', 9000000, 70)],
     96500, 201, 35);
 
 dungeonList['Newmoon Island'] = new Dungeon('Newmoon Island',

--- a/src/scripts/pokemons/RoamingPokemonList.ts
+++ b/src/scripts/pokemons/RoamingPokemonList.ts
@@ -42,3 +42,5 @@ RoamingPokemonList.add(GameConstants.Region.hoenn, new RoamingPokemon(pokemonMap
 
 // Sinnoh
 RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon(pokemonMap.Manaphy));
+RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon(pokemonMap.Mesprit, undefined, new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Lake Verity'))));
+RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon(pokemonMap.Cresselia, undefined, new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Fullmoon Island'))));


### PR DESCRIPTION
Cresselia and Mesprit unlocked as roamers in Sinnoh after you clear their respective dungeons. Also removed them from those dungeons.

Make roamers roam again.

I swear there's some other file that needs changing, but I entirely forget which one... maybe my mind's playing tricks.