### PR TITLE
Increase Shoal Cave DT cost.

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -334,7 +334,7 @@ dungeonList['Shoal Cave'] = new Dungeon('Shoal Cave',
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.Lucky_egg],
     290000,
     [new DungeonBossPokemon('Snorunt', 900000, 20)],
-    12000, 101, 5);
+    28000, 101, 5);
 
 dungeonList['Cave of Origin'] = new Dungeon('Cave of Origin',
     ['Zubat', 'Golbat', 'Sableye', 'Mawile'],


### PR DESCRIPTION
Twas too cheap for when it's unlocked. This seems more reasonable to me, between Mt. Pyre and Seafloor Cavern.