### PR TITLE
added a buy multiplier to battle items

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -2,6 +2,17 @@
     <div class="card-header p-0" data-toggle="collapse" href="#battleItemContainerBody">
       <span>Battle Items</span>
     </div>
+    <button type="button" class="btn btn-sm btn-primary" 
+            style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px;" 
+            data-bind="text: ItemHandler.multipliers[ItemHandler.multIndex()]"
+            onclick="ItemHandler.incrementMultiplier()"
+            oncontextmenu="ItemHandler.decrementMultiplier(); return false"
+            title="Controls"
+            data-toggle="popover"
+            data-content="Left click to next, right click to previous"
+            data-placement="right"
+            data-trigger="hover">1
+    </button>
     <div id="battleItemContainerBody" class="card-body p-0 show">
       <table class="table table-bordered m-0">
         <tbody>

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -23,8 +23,8 @@ class EffectEngineRunner {
         return player.effectList[itemName]();
     }
 
-    public static addEffect(itemName: string) {
-        player.effectList[itemName](Math.max(0, player.effectList[itemName]() +  GameConstants.ITEM_USE_TIME));
+    public static addEffect(itemName: string, amount: number) {
+        player.effectList[itemName](Math.max(0, player.effectList[itemName]() + (GameConstants.ITEM_USE_TIME * amount)));
         this.updateFormattedTimeLeft(itemName);
     }
 

--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -11,13 +11,13 @@ class BattleItem extends Item {
     }
 
     use() {
-        EffectEngineRunner.addEffect(this.name());
+        EffectEngineRunner.addEffect(this.name(), ItemHandler.amountToUse);
     }
 }
 
 ItemList['xAttack']         = new BattleItem(GameConstants.BattleItemType.xAttack, '+50% Bonus to Pokémon attack', 600);
 ItemList['xClick']          = new BattleItem(GameConstants.BattleItemType.xClick, '+50% Bonus to click attack', 400);
-ItemList['Lucky_egg']            = new BattleItem(GameConstants.BattleItemType.Lucky_egg, '+50% Bonus to experience gained', 800);
+ItemList['Lucky_egg']       = new BattleItem(GameConstants.BattleItemType.Lucky_egg, '+50% Bonus to experience gained', 800);
 ItemList['Token_collector'] = new BattleItem(GameConstants.BattleItemType.Token_collector, '+50% Bonus to dungeon tokens gained', 1000);
 ItemList['Item_magnet']     = new BattleItem(GameConstants.BattleItemType.Item_magnet, '+50% Chance of gaining an extra item', 1500);
 ItemList['Lucky_incense']   = new BattleItem(GameConstants.BattleItemType.Lucky_incense, '+50% Bonus to money gained', 2000);

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -4,13 +4,19 @@ class ItemHandler {
     public static pokemonSelected: KnockoutObservable<string> = ko.observable('Vulpix');
     public static amountSelected: KnockoutObservable<number> = ko.observable(1);
     static amount: KnockoutObservable<number> = ko.observable(1);
+    public static amountToUse = 1;
+    public static multipliers = ['x1', 'x10', 'x100', 'All'];
+    public static multIndex = ko.observable(0);
 
     public static useItem(name: string) {
         if (!player.itemList[name]()) {
             return Notifier.notify({ message: `You don't have any ${GameConstants.humanifyString(name)}s left...`, type: GameConstants.NotificationOption.danger });
         }
-
-        player.itemList[name](player.itemList[name]() - 1);
+        this.amountToUse =
+            this.multipliers[this.multIndex()] == 'All' ||
+                player.itemList[name]() - Number(this.multipliers[this.multIndex()].replace('x', '')) < 0 ?
+                player.itemList[name]() : Number(this.multipliers[this.multIndex()].replace('x', ''));
+        player.itemList[name](player.itemList[name]() - this.amountToUse);
         return ItemList[name].use();
     }
 
@@ -46,6 +52,14 @@ class ItemHandler {
         }
         const multiple = amountUsed == 1 ? '' : 's';
         Notifier.notify({ message: `You used ${amountUsed} ${GameConstants.humanifyString(this.stoneSelected())}${multiple}`, type: GameConstants.NotificationOption.success });
+    }
+
+    public static incrementMultiplier() {
+        this.multIndex((this.multIndex() + 1) % this.multipliers.length);
+    }
+
+    public static decrementMultiplier() {
+        this.multIndex((((this.multIndex() - 1) % this.multipliers.length) + this.multipliers.length) % this.multipliers.length);
     }
 
 }


### PR DESCRIPTION
I thought that the other PR would implement that, but nothing changed, so I resolved to add.

I think this button fits the model, but not discard the idea of a dropdown to choose the multiplier.

I  was afraid to change these functions thinking they were used by all the items, but are used just to battle items, so I will try to make more generic as possible in the next updates.

The 'all' option is a little controversial too.

![mult2](https://user-images.githubusercontent.com/27972070/94330814-35c15600-ff9e-11ea-9cb8-7fcb84ae805c.gif)