### PR TITLE
Allow Mystery Egg to hatch from Dragon Eggs pool

### DIFF
--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -198,7 +198,7 @@ class Breeding implements Feature {
     }
 
     public createRandomEgg(): Egg {
-        const type = Math.floor(Math.random() * (Object.keys(this.hatchList).length - 1));
+        const type = Math.floor(Math.random() * Object.keys(this.hatchList).length);
         const egg = this.createTypedEgg(type);
         egg.type = EggType.Mystery;
         return egg;


### PR DESCRIPTION
Mystery Egg currently ignores the Dragon egg pool.
This PR allows it to pull from there too.