### PR TITLE
Prefer higher selected pokeball when encountering shinies

### DIFF
--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -46,9 +46,11 @@ class Pokeballs implements Feature {
         // just check against alreadyCaughtShiny as this returns false when you don't have the pokemon yet.
         if (isShiny) {
             if (!alreadyCaughtShiny) {
-                pref = this.notCaughtShinySelection;
+                // if the pokemon is also not caught, use the higher selection since a notCaughtShiny is also a notCaught pokemon
+                pref = !alreadyCaught ? Math.max(this.notCaughtSelection, this.notCaughtShinySelection) : this.notCaughtShinySelection;
             } else {
-                pref = this.alreadyCaughtShinySelection;
+                // if the shiny is already caught, use the higher selection since the pokemon is also a caught pokemon
+                pref = Math.max(this.alreadyCaughtSelection, this.alreadyCaughtShinySelection);
             }
         } else {
             if (!alreadyCaught) {


### PR DESCRIPTION
When encountering a shiny, the game should use the higher selected pokeball if the shiny is also already caught and the caught setting is higher. Same logic for uncaught. Wouldn't want someone to encounter a new shiny roamer and throw an ultraball instead of masterball if they have new pokemon set to masterball.

A potential issue would be with the new pokeballs and the order they fit in the list.