### PR TITLE
Add notification settings for egg hatching and gyms won

### DIFF
--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -101,6 +101,8 @@ namespace GameConstants {
     };
     export const NotificationSetting = {
         ready_to_hatch: new BooleanSetting('notification.ready_to_hatch', 'Egg ready to hatch', true),
+        hatched: new BooleanSetting('notification.hatched', 'Egg hatched', true),
+        hatched_shiny: new BooleanSetting('notification.hatched_shiny', 'Egg hatched a shiny', true),
         route_item_found: new BooleanSetting('notification.route_item_found', 'Item found during route battle', true),
         dungeon_item_found: new BooleanSetting('notification.dungeon_item_found', 'Item found in dungeon chest', true),
         battle_item_timer: new BooleanSetting('notification.battle_item_timer', 'Battle item about to wear off', true),
@@ -110,6 +112,7 @@ namespace GameConstants {
         event_start_end: new BooleanSetting('notification.event_start_end', 'Event start/end information', true),
         dropped_item: new BooleanSetting('notification.dropped_item', 'Enemy pokemon dropped an item', true),
         ready_to_harvest: new BooleanSetting('notification.ready_to_harvest', 'Berry ready to harvest', true),
+        gym_won: new BooleanSetting('notification.gym_won', 'Gym leader defeated', true),
     };
 
     export enum DungeonTile {

--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -100,12 +100,12 @@ class Egg implements Saveable {
         App.game.party.gainPokemonById(pokemonID, shiny);
 
         if (shiny) {
-            Notifier.notify({ message: `✨ You hatched a shiny ${this.pokemon}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long });
+            Notifier.notify({ message: `✨ You hatched a shiny ${this.pokemon}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.hatched_shiny });
             App.game.logbook.newLog(LogBookTypes.SHINY, `You hatched a shiny ${this.pokemon}!`);
             GameHelper.incrementObservable(App.game.statistics.shinyPokemonHatched[pokemonID]);
             GameHelper.incrementObservable(App.game.statistics.totalShinyPokemonHatched);
         } else {
-            Notifier.notify({ message: `You hatched ${GameHelper.anOrA(this.pokemon)} ${this.pokemon}!`, type: GameConstants.NotificationOption.success });
+            Notifier.notify({ message: `You hatched ${GameHelper.anOrA(this.pokemon)} ${this.pokemon}!`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.hatched });
         }
 
         // Capture base form if not already caught. This helps players get Gen2 Pokemon that are base form of Gen1

--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -70,7 +70,7 @@ class GymRunner {
     }
 
     public static gymWon(gym: Gym) {
-        Notifier.notify({ message: `Congratulations, you defeated ${GymBattle.gym.leaderName}!`, type: GameConstants.NotificationOption.success });
+        Notifier.notify({ message: `Congratulations, you defeated ${GymBattle.gym.leaderName}!`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.gym_won });
         this.gymObservable(gym);
         App.game.wallet.gainMoney(gym.moneyReward);
         // If this is the first time defeating this gym


### PR DESCRIPTION
I didn't add settings for "additional finds" when hatching or for new captures or shiny captures since they are one time events, but maybe they can have settings, too. I don't know where to place the gym notification setting either, so I just put it at the bottom.