### PR TITLE
Change effect timers to show up to 99 hours

### DIFF
--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -30,8 +30,10 @@ class EffectEngineRunner {
 
     public static updateFormattedTimeLeft(itemName: string) {
         const times = GameConstants.formatTime(player.effectList[itemName]()).split(':');
-        if (+times[0] > 0) {
-            return player.effectTimer[itemName]('60:00+');
+        if (+times[0] > 99) {
+            return player.effectTimer[itemName]('99h+');
+        } else if (+times[0] > 0) {
+            return player.effectTimer[itemName](`${times[0]}h`);
         }
         times.shift();
         player.effectTimer[itemName](times.join(':'));

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -33,7 +33,7 @@ class EffectEngineRunner {
         if (+times[0] > 99) {
             return player.effectTimer[itemName]('99h+');
         } else if (+times[0] > 0) {
-            return player.effectTimer[itemName](`${times[0]}h`);
+            return player.effectTimer[itemName](`${+times[0]}h`);
         }
         times.shift();
         player.effectTimer[itemName](times.join(':'));


### PR DESCRIPTION
Originally shows up to 60 minutes, while it's common to have many hours running at endgame. Knowing how many hours is useful for people who want to run overnight and how many more they need to use.