### PR TITLE
chore(circular): moves notification constants into separate file

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -38,7 +38,7 @@
                     <div class="tab-pane" id="settings-sound">
                         <div data-bind="template: {name: 'RangeSettingTemplate', data: Settings.getSetting('sound.volume')}"></div>
                         <table class="table table-striped table-hover m-0">
-                            <tbody data-bind="foreach: Object.values(GameConstants.NotificationSound)">
+                            <tbody data-bind="foreach: Object.values(NotificationConstants.NotificationSound)">
                               <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting(`sound.${$data.name}`)}"></tr>
                             </tbody>
                         </table>
@@ -46,7 +46,7 @@
 
                     <div class="tab-pane" id="settings-notifications">
                         <table class="table table-striped table-hover m-0">
-                            <tbody data-bind="foreach: Object.values(GameConstants.NotificationSetting)">
+                            <tbody data-bind="foreach: Object.values(NotificationConstants.NotificationSetting)">
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: $data}"></tr>
                             </tbody>
                         </table>

--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -38,7 +38,7 @@ class App {
             );
 
             console.log(`[${GameConstants.formatDate(new Date())}] %cGame loaded`, 'color:#8e44ad;font-weight:900;');
-            Notifier.notify({ message: 'Game loaded', type: GameConstants.NotificationOption.info });
+            Notifier.notify({ message: 'Game loaded', type: NotificationConstants.NotificationOption.info });
 
             GameController.bindToolTips();
             GameController.addKeyListeners();

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -135,7 +135,11 @@ class Game {
                 this.quests.resetRefreshes();
                 this.quests.generateQuestList();
                 DailyDeal.generateDeals(Underground.getDailyDealsMax(), now);
-                Notifier.notify({ message: 'It\'s a new day! Your quests and underground deals have been updated.', type: GameConstants.NotificationOption.info, timeout: 1e4 });
+                Notifier.notify({
+                    message: 'It\'s a new day! Your quests and underground deals have been updated.',
+                    type: NotificationConstants.NotificationOption.info,
+                    timeout: 1e4,
+                });
             }
             player._lastSeen = Date.now();
             Save.store(player);

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -1,13 +1,8 @@
-///<reference path="./badgeCase/BadgeCase.ts" />
-///<reference path="utilities/Sound.ts"/>
-///<reference path="settings/BooleanSetting.ts"/>
-
 /**
  * Contains all game constants for easy access.
  */
 
 namespace GameConstants {
-
     // Ticks
     export const TICK_TIME = 100;
     export const BATTLE_TICK = 1000;
@@ -77,43 +72,6 @@ namespace GameConstants {
         equal,
         more,
     }
-
-    export enum NotificationOption {
-        info,
-        success,
-        warning,
-        danger,
-        primary,
-        secondary,
-        dark,
-        light,
-    }
-    export const NotificationSound = {
-        ready_to_hatch: new Sound('ready_to_hatch', 'Egg ready to hatch'),
-        shiny_long: new Sound('shiny_long', 'Shiny Pokemon encountered/hatched'),
-        new_catch: new Sound('new_catch', 'New pokemon/shiny captured'),
-        achievement: new Sound('achievement', 'New achievement earned'),
-        battle_item_timer: new Sound('battle_item_timer', 'Battle item about to wear off'),
-        quest_ready_to_complete: new Sound('quest_ready_to_complete', 'Quest is ready to be completed'),
-        quest_level_increased: new Sound('quest_level_increased', 'Quest level increased'),
-        underground_energy_full: new Sound('underground_energy_full', 'Mining energy reached maximum capacity'),
-        ready_to_harvest: new Sound('ready_to_harvest', 'Farm ready to harvest'),
-    };
-    export const NotificationSetting = {
-        ready_to_hatch: new BooleanSetting('notification.ready_to_hatch', 'Egg ready to hatch', true),
-        hatched: new BooleanSetting('notification.hatched', 'Egg hatched', true),
-        hatched_shiny: new BooleanSetting('notification.hatched_shiny', 'Egg hatched a shiny', true),
-        route_item_found: new BooleanSetting('notification.route_item_found', 'Item found during route battle', true),
-        dungeon_item_found: new BooleanSetting('notification.dungeon_item_found', 'Item found in dungeon chest', true),
-        battle_item_timer: new BooleanSetting('notification.battle_item_timer', 'Battle item about to wear off', true),
-        encountered_shiny: new BooleanSetting('notification.encountered_shiny', 'Encountered a shiny Pokemon', true),
-        quest_ready_to_complete: new BooleanSetting('notification.quest_ready_to_complete', 'Quest is ready to be completed', true),
-        underground_energy_full: new BooleanSetting('notification.underground_energy_full', 'Mining energy reached maximum capacity', true),
-        event_start_end: new BooleanSetting('notification.event_start_end', 'Event start/end information', true),
-        dropped_item: new BooleanSetting('notification.dropped_item', 'Enemy pokemon dropped an item', true),
-        ready_to_harvest: new BooleanSetting('notification.ready_to_harvest', 'Berry ready to harvest', true),
-        gym_won: new BooleanSetting('notification.gym_won', 'Gym leader defeated', true),
-    };
 
     export enum DungeonTile {
         empty,

--- a/src/scripts/NotificationConstants.ts
+++ b/src/scripts/NotificationConstants.ts
@@ -1,0 +1,46 @@
+///<reference path="./utilities/Sound.ts"/>
+///<reference path="./settings/BooleanSetting.ts"/>
+
+/**
+ * Contains all notification constants for easy access.
+ */
+
+namespace NotificationConstants {
+    export enum NotificationOption {
+        info,
+        success,
+        warning,
+        danger,
+        primary,
+        secondary,
+        dark,
+        light,
+    }
+
+    export const NotificationSound = {
+        ready_to_hatch: new Sound('ready_to_hatch', 'Egg ready to hatch'),
+        shiny_long: new Sound('shiny_long', 'Shiny Pokemon encountered/hatched'),
+        new_catch: new Sound('new_catch', 'New pokemon/shiny captured'),
+        achievement: new Sound('achievement', 'New achievement earned'),
+        battle_item_timer: new Sound('battle_item_timer', 'Battle item about to wear off'),
+        quest_ready_to_complete: new Sound('quest_ready_to_complete', 'Quest is ready to be completed'),
+        quest_level_increased: new Sound('quest_level_increased', 'Quest level increased'),
+        underground_energy_full: new Sound('underground_energy_full', 'Mining energy reached maximum capacity'),
+        ready_to_harvest: new Sound('ready_to_harvest', 'Farm ready to harvest'),
+    };
+    export const NotificationSetting = {
+        ready_to_hatch: new BooleanSetting('notification.ready_to_hatch', 'Egg ready to hatch', true),
+        hatched: new BooleanSetting('notification.hatched', 'Egg hatched', true),
+        hatched_shiny: new BooleanSetting('notification.hatched_shiny', 'Egg hatched a shiny', true),
+        route_item_found: new BooleanSetting('notification.route_item_found', 'Item found during route battle', true),
+        dungeon_item_found: new BooleanSetting('notification.dungeon_item_found', 'Item found in dungeon chest', true),
+        battle_item_timer: new BooleanSetting('notification.battle_item_timer', 'Battle item about to wear off', true),
+        encountered_shiny: new BooleanSetting('notification.encountered_shiny', 'Encountered a shiny Pokemon', true),
+        quest_ready_to_complete: new BooleanSetting('notification.quest_ready_to_complete', 'Quest is ready to be completed', true),
+        underground_energy_full: new BooleanSetting('notification.underground_energy_full', 'Mining energy reached maximum capacity', true),
+        event_start_end: new BooleanSetting('notification.event_start_end', 'Event start/end information', true),
+        dropped_item: new BooleanSetting('notification.dropped_item', 'Enemy pokemon dropped an item', true),
+        ready_to_harvest: new BooleanSetting('notification.ready_to_harvest', 'Berry ready to harvest', true),
+        gym_won: new BooleanSetting('notification.gym_won', 'Gym leader defeated', true),
+    };
+}

--- a/src/scripts/Notifier.ts
+++ b/src/scripts/Notifier.ts
@@ -1,5 +1,21 @@
 class Notifier {
-    public static notify({ message, type = GameConstants.NotificationOption.primary, title = '', timeout = 3000, time = 'just now', sound = null, setting = null }: { message: string; type?: GameConstants.NotificationOption; title?: string; timeout?: number; time?: string, sound?: Sound, setting?: BooleanSetting }) {
+    public static notify({
+        message,
+        type = NotificationConstants.NotificationOption.primary,
+        title = '',
+        timeout = 3000,
+        time = 'just now',
+        sound = null,
+        setting = null,
+    }: {
+        message: string;
+        type?: NotificationConstants.NotificationOption;
+        title?: string;
+        timeout?: number;
+        time?: string,
+        sound?: Sound,
+        setting?: BooleanSetting,
+    }) {
         $(document).ready(function() {
             // If we have sounds enabled for this, play it now
             if (sound) {
@@ -13,7 +29,7 @@ class Notifier {
 
             // Get the notification ready to display
             const toastID = Math.random().toString(36).substr(2, 9);
-            const toastHTML = `<div id="${toastID}" class="toast bg-${GameConstants.NotificationOption[type]}" data-autohide="false">
+            const toastHTML = `<div id="${toastID}" class="toast bg-${NotificationConstants.NotificationOption[type]}" data-autohide="false">
                   ${title ? `<div class="toast-header">
                     <strong class="mr-auto text-primary">${title || ''}</strong>
                     <small class="text-muted">${time}</small>

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -63,7 +63,12 @@ class Save {
             document.body.removeChild(element);
         } catch (err) {
             console.error('Error trying to download save', err);
-            Notifier.notify({ title: 'Failed to download save data', message: 'Please check the console for errors, and report them on our Discord.', type: GameConstants.NotificationOption.primary, timeout: 6e4 });
+            Notifier.notify({
+                title: 'Failed to download save data',
+                message: 'Please check the console for errors, and report them on our Discord.',
+                type: NotificationConstants.NotificationOption.primary,
+                timeout: 6e4,
+            });
             try {
                 localStorage.backupSave = JSON.stringify(backupSaveData);
             } catch (e) {}
@@ -179,10 +184,16 @@ class Save {
                     localStorage.setItem('save', JSON.stringify(json.save));
                     location.reload();
                 } else {
-                    Notifier.notify({ message: 'This is not a valid decoded savefile', type: GameConstants.NotificationOption.danger });
+                    Notifier.notify({
+                        message: 'This is not a valid decoded savefile',
+                        type: NotificationConstants.NotificationOption.danger,
+                    });
                 }
             } catch (err) {
-                Notifier.notify({ message: 'This is not a valid savefile', type: GameConstants.NotificationOption.danger });
+                Notifier.notify({
+                    message: 'This is not a valid savefile',
+                    type: NotificationConstants.NotificationOption.danger,
+                });
             }
         }, 1000);
     }
@@ -195,7 +206,10 @@ class Save {
             Save.convertShinies(p.caughtPokemonList);
             $('#saveModal').modal('hide');
         } catch (e) {
-            Notifier.notify({ message: 'Invalid save data.', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'Invalid save data.',
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
     }
 
@@ -210,9 +224,16 @@ class Save {
             }
         }
         if (converted.length > 0) {
-            Notifier.notify({ message: `You have gained the following shiny Pokémon:</br>${converted.join(',</br>')}`, type: GameConstants.NotificationOption.success, timeout: 1e4 });
+            Notifier.notify({
+                message: `You have gained the following shiny Pokémon:</br>${converted.join(',</br>')}`,
+                type: NotificationConstants.NotificationOption.success,
+                timeout: 1e4,
+            });
         } else {
-            Notifier.notify({ message: 'No new shiny Pokémon to import.', type: GameConstants.NotificationOption.info });
+            Notifier.notify({
+                message: 'No new shiny Pokémon to import.',
+                type: NotificationConstants.NotificationOption.info,
+            });
         }
     }
 }

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -269,10 +269,20 @@ class Update implements Saveable {
                 }
                 button.style.display = '';
 
-                Notifier.notify({ title: `[v${this.version}] Game has been updated!`, message: `Check the <a class="text-light" href="#changelogModal" data-toggle="modal"><u>changelog</u></a> for details!<br/><br/>${button.outerHTML}`, type: GameConstants.NotificationOption.primary, timeout: 6e4 });
+                Notifier.notify({
+                    title: `[v${this.version}] Game has been updated!`,
+                    message: `Check the <a class="text-light" href="#changelogModal" data-toggle="modal"><u>changelog</u></a> for details!<br/><br/>${button.outerHTML}`,
+                    type: NotificationConstants.NotificationOption.primary,
+                    timeout: 6e4,
+                });
             } catch (err) {
                 console.error('Error trying to convert backup save', err);
-                Notifier.notify({ title: `[v${this.version}] Game has been updated!`, message: 'Check the <a class="text-light" href="#changelogModal" data-toggle="modal"><u>changelog</u></a> for details!<br/><br/><i>Failed to download old save, Please check the console for errors, and report them on our Discord.</i>', type: GameConstants.NotificationOption.primary, timeout: 6e4 });
+                Notifier.notify({
+                    title: `[v${this.version}] Game has been updated!`,
+                    message: 'Check the <a class="text-light" href="#changelogModal" data-toggle="modal"><u>changelog</u></a> for details!<br/><br/><i>Failed to download old save, Please check the console for errors, and report them on our Discord.</i>',
+                    type: NotificationConstants.NotificationOption.primary,
+                    timeout: 6e4,
+                });
                 try {
                     localStorage.backupSave = JSON.stringify(backupSaveData);
                 } catch (e) {}

--- a/src/scripts/achievements/Achievement.ts
+++ b/src/scripts/achievements/Achievement.ts
@@ -10,7 +10,13 @@ class Achievement {
 
     public check() {
         if (this.isCompleted()) {
-            Notifier.notify({ title: `[Achievement] ${this.name}`, message: this.description, type: GameConstants.NotificationOption.warning, timeout: 1e4, sound: GameConstants.NotificationSound.achievement });
+            Notifier.notify({
+                title: `[Achievement] ${this.name}`,
+                message: this.description,
+                type: NotificationConstants.NotificationOption.warning,
+                timeout: 1e4,
+                sound: NotificationConstants.NotificationSound.achievement,
+            });
             player.achievementsCompleted[this.name] = true;
             this.unlocked = true;
         }

--- a/src/scripts/battleFrontier/BattleFrontier.ts
+++ b/src/scripts/battleFrontier/BattleFrontier.ts
@@ -8,7 +8,11 @@ class BattleFrontier {
 
     public static enter() {
         if (!this.canAccess()) {
-            return Notifier.notify({ title: '[Battle Frontier]', message: 'You must progress further in the "Mystery of Deoxys" quest before you can participate', type: GameConstants.NotificationOption.warning });
+            return Notifier.notify({
+                title: '[Battle Frontier]',
+                message: 'You must progress further in the "Mystery of Deoxys" quest before you can participate',
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
         App.game.gameState = GameConstants.GameState.battleFrontier;
     }

--- a/src/scripts/battleFrontier/BattleFrontierMilestones.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestones.ts
@@ -43,7 +43,12 @@ class BattleFrontierMilestones {
     public static gainReward(defeatedStage: number): void {
         const reward = this.nextMileStone();
         if (reward && reward.stage == defeatedStage) {
-            Notifier.notify({ title: '[Battle Frontier]', message: `You've successfully defeated stage ${defeatedStage} and earned:<br/><span>${reward.description}</span>!`, type: GameConstants.NotificationOption.warning, timeout: 1e4 });
+            Notifier.notify({
+                title: '[Battle Frontier]',
+                message: `You've successfully defeated stage ${defeatedStage} and earned:<br/><span>${reward.description}</span>!`,
+                type: NotificationConstants.NotificationOption.warning,
+                timeout: 1e4,
+            });
             reward.gain();
         }
     }

--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -59,7 +59,12 @@ class BattleFrontierRunner {
         const battlePointsEarned = Math.round(stageBeaten * battleMultiplier);
         const moneyEarned = stageBeaten * 100 * battleMultiplier;
 
-        Notifier.notify({ title: 'Battle Frontier', message: `You managed to beat stage ${stageBeaten}.<br/>You received ${battlePointsEarned} BP`, type: GameConstants.NotificationOption.success, timeout: 5 * GameConstants.MINUTE });
+        Notifier.notify({
+            title: 'Battle Frontier',
+            message: `You managed to beat stage ${stageBeaten}.<br/>You received ${battlePointsEarned} BP`,
+            type: NotificationConstants.NotificationOption.success,
+            timeout: 5 * GameConstants.MINUTE,
+        });
 
         // Award battle points
         App.game.wallet.gainBattlePoints(battlePointsEarned);
@@ -73,7 +78,12 @@ class BattleFrontierRunner {
             return;
         }
         // Don't give any points, user quit the challenge
-        Notifier.notify({ title: 'Battle Frontier', message: `You made it to stage ${this.stage()}`, type: GameConstants.NotificationOption.info, timeout: 5 * GameConstants.MINUTE });
+        Notifier.notify({
+            title: 'Battle Frontier',
+            message: `You made it to stage ${this.stage()}`,
+            type: NotificationConstants.NotificationOption.info,
+            timeout: 5 * GameConstants.MINUTE,
+        });
 
         this.end();
     }

--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -175,7 +175,10 @@ class Breeding implements Feature {
 
     public gainPokemonEgg(pokemon: PartyPokemon): boolean {
         if (!this.hasFreeEggSlot()) {
-            Notifier.notify({ message: "You don't have any free egg slots", type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: "You don't have any free egg slots",
+                type: NotificationConstants.NotificationOption.warning,
+            });
             return false;
         }
         const egg = this.createEgg(pokemon.name);
@@ -232,7 +235,11 @@ class Breeding implements Feature {
         const pokemonName = GameConstants.FossilToPokemon[fossil];
         const pokemonNativeRegion = PokemonHelper.calcNativeRegion(pokemonName);
         if (pokemonNativeRegion > player.highestRegion()) {
-            Notifier.notify({ message: 'You must progress further before you can uncover this fossil Pokemon!', type: GameConstants.NotificationOption.warning, timeout: 5e3 });
+            Notifier.notify({
+                message: 'You must progress further before you can uncover this fossil Pokemon!',
+                type: NotificationConstants.NotificationOption.warning,
+                timeout: 5e3,
+            });
             return new Egg();
         }
         return this.createEgg(pokemonName, EggType.Fossil);

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -97,7 +97,10 @@ class BreedingController {
         if (App.game.breeding.canAccess()) {
             $('#breedingModal').modal('show');
         } else {
-            Notifier.notify({ message: 'You do not have access to the Day Care yet.<br/><i>Clear route 5 first</i>', type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: 'You do not have access to the Day Care yet.<br/><i>Clear route 5 first</i>',
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 

--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -66,9 +66,19 @@ class Egg implements Saveable {
         }
         if (this.canHatch()) {
             if (this.type == EggType.Pokemon) {
-                Notifier.notify({ message: `${this.pokemon} is ready to hatch!`, type: GameConstants.NotificationOption.success, sound: GameConstants.NotificationSound.ready_to_hatch, setting: GameConstants.NotificationSetting.ready_to_hatch });
+                Notifier.notify({
+                    message: `${this.pokemon} is ready to hatch!`,
+                    type: NotificationConstants.NotificationOption.success,
+                    sound: NotificationConstants.NotificationSound.ready_to_hatch,
+                    setting: NotificationConstants.NotificationSetting.ready_to_hatch,
+                });
             } else {
-                Notifier.notify({ message: 'An egg is ready to hatch!', type: GameConstants.NotificationOption.success, sound: GameConstants.NotificationSound.ready_to_hatch, setting: GameConstants.NotificationSetting.ready_to_hatch });
+                Notifier.notify({
+                    message: 'An egg is ready to hatch!',
+                    type: NotificationConstants.NotificationOption.success,
+                    sound: NotificationConstants.NotificationSound.ready_to_hatch,
+                    setting: NotificationConstants.NotificationSetting.ready_to_hatch,
+                });
             }
             this.notified = true;
         }
@@ -105,18 +115,30 @@ class Egg implements Saveable {
         App.game.party.gainPokemonById(pokemonID, shiny);
 
         if (shiny) {
-            Notifier.notify({ message: `✨ You hatched a shiny ${this.pokemon}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.hatched_shiny });
+            Notifier.notify({
+                message: `✨ You hatched a shiny ${this.pokemon}! ✨`,
+                type: NotificationConstants.NotificationOption.warning,
+                sound: NotificationConstants.NotificationSound.shiny_long,
+                setting: NotificationConstants.NotificationSetting.hatched_shiny,
+            });
             App.game.logbook.newLog(LogBookTypes.SHINY, `You hatched a shiny ${this.pokemon}!`);
             GameHelper.incrementObservable(App.game.statistics.shinyPokemonHatched[pokemonID]);
             GameHelper.incrementObservable(App.game.statistics.totalShinyPokemonHatched);
         } else {
-            Notifier.notify({ message: `You hatched ${GameHelper.anOrA(this.pokemon)} ${this.pokemon}!`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.hatched });
+            Notifier.notify({
+                message: `You hatched ${GameHelper.anOrA(this.pokemon)} ${this.pokemon}!`,
+                type: NotificationConstants.NotificationOption.success,
+                setting: NotificationConstants.NotificationSetting.hatched,
+            });
         }
 
         // Capture base form if not already caught. This helps players get Gen2 Pokemon that are base form of Gen1
         const baseForm = App.game.breeding.calculateBaseForm(this.pokemon);
         if (this.pokemon != baseForm && !App.game.party.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(baseForm).id)) {
-            Notifier.notify({ message: `You also found ${GameHelper.anOrA(baseForm)} ${baseForm} nearby!`, type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                message: `You also found ${GameHelper.anOrA(baseForm)} ${baseForm} nearby!`,
+                type: NotificationConstants.NotificationOption.success,
+            });
             App.game.party.gainPokemonById(PokemonHelper.getPokemonByName(baseForm).id);
         }
 

--- a/src/scripts/codes/RedeemableCode.ts
+++ b/src/scripts/codes/RedeemableCode.ts
@@ -14,7 +14,10 @@ class RedeemableCode {
 
     redeem() {
         if (this.isRedeemed) {
-            Notifier.notify({ message: 'You have already redeemed this code', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You have already redeemed this code',
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return;
         }
         

--- a/src/scripts/codes/RedeemableCodes.ts
+++ b/src/scripts/codes/RedeemableCodes.ts
@@ -11,14 +11,24 @@ class RedeemableCodes implements Saveable {
                 App.game.wallet.gainFarmPoints(10000);
                 App.game.farming.gainBerry(BerryType.Cheri, 100);
                 // Notify that the code was activated successfully
-                Notifier.notify({ title:'Code activated!', message: 'You gained 10,000 farmpoints and 100 Cheri berries', type: GameConstants.NotificationOption.success, timeout: 1e4 });
+                Notifier.notify({
+                    title:'Code activated!',
+                    message: 'You gained 10,000 farmpoints and 100 Cheri berries',
+                    type: NotificationConstants.NotificationOption.success,
+                    timeout: 1e4,
+                });
             }),
             new RedeemableCode('shiny-charmer', -318017456, false, function () {
                 // Select a random Pokemon to give the player as a shiny
                 const pokemon = pokemonMap.random(GameConstants.TotalPokemonsPerRegion[player.highestRegion()]);
                 App.game.party.gainPokemonById(pokemon.id, true, true);
                 // Notify that the code was activated successfully
-                Notifier.notify({ title:'Code activated!', message: `✨ You found a shiny ${pokemon.name}! ✨`, type: GameConstants.NotificationOption.success, timeout: 1e4 });
+                Notifier.notify({
+                    title:'Code activated!',
+                    message: `✨ You found a shiny ${pokemon.name}! ✨`,
+                    type: NotificationConstants.NotificationOption.success,
+                    timeout: 1e4,
+                });
             }),
             new RedeemableCode('complete-kanto', 750807787, false, function () {
                 // Complete all routes
@@ -42,7 +52,12 @@ class RedeemableCodes implements Saveable {
                     App.game.party.gainPokemonById(id, false, true);
                 }
                 // Notify that the code was activated successfully
-                Notifier.notify({ title:'Code activated!', message: 'You have unlocked all of the Kanto region', type: GameConstants.NotificationOption.success, timeout: 1e4 });
+                Notifier.notify({
+                    title:'Code activated!',
+                    message: 'You have unlocked all of the Kanto region',
+                    type: NotificationConstants.NotificationOption.success,
+                    timeout: 1e4,
+                });
             }),
         ];
     }
@@ -64,7 +79,10 @@ class RedeemableCodes implements Saveable {
         });
 
         if (!redeemableCode) {
-            return Notifier.notify({ message: `Invalid code ${code}`, type: GameConstants.NotificationOption.danger });
+            return Notifier.notify({
+                message: `Invalid code ${code}`,
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
 
         if (redeemableCode) {

--- a/src/scripts/discord/Discord.ts
+++ b/src/scripts/discord/Discord.ts
@@ -46,7 +46,12 @@ class Discord implements Saveable {
                     if (data && data.id) {
                         this.ID(data.id);
                         this.username(`${data.username}#${data.discriminator}`);
-                        Notifier.notify({ title: `Welcome ${this.username()}`, message: 'Successfully logged in to Discord!', type: GameConstants.NotificationOption.success, timeout:GameConstants.MINUTE });
+                        Notifier.notify({
+                            title: `Welcome ${this.username()}`,
+                            message: 'Successfully logged in to Discord!',
+                            type: NotificationConstants.NotificationOption.success,
+                            timeout: GameConstants.MINUTE,
+                        });
                     }
                 },
                 complete: () => {
@@ -103,12 +108,18 @@ class Discord implements Saveable {
     enterCode(enteredCode: string): boolean {
         // Discord integration disabled
         if (!this.enabled) {
-            Notifier.notify({ message: 'Discord integration not enabled', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'Discord integration not enabled',
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return false;
         }
         // User not logged in to Discord
         if (!this.ID()) {
-            Notifier.notify({ message: 'You must sign in to Discord before attempting this code', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You must sign in to Discord before attempting this code',
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return false;
         }
 
@@ -117,7 +128,10 @@ class Discord implements Saveable {
 
         // No code found
         if (!code) {
-            Notifier.notify({ message: `Invalid code ${enteredCode}`, type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: `Invalid code ${enteredCode}`,
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return false;
         }
 

--- a/src/scripts/discord/DiscordCode.ts
+++ b/src/scripts/discord/DiscordCode.ts
@@ -16,7 +16,7 @@ class DiscordCode {
             Notifier.notify({
                 title: `[Discord Code] ${this.name}`,
                 message: 'Already claimed!',
-                type: GameConstants.NotificationOption.warning,
+                type: NotificationConstants.NotificationOption.warning,
             });
             return;
         }
@@ -26,7 +26,7 @@ class DiscordCode {
             Notifier.notify({
                 title: `[Discord Code] ${this.name}`,
                 message: 'Successfully claimed!',
-                type: GameConstants.NotificationOption.success,
+                type: NotificationConstants.NotificationOption.success,
             });
         }
     }

--- a/src/scripts/discord/DiscordPokemonCode.ts
+++ b/src/scripts/discord/DiscordPokemonCode.ts
@@ -5,7 +5,11 @@ class DiscordPokemonCode extends DiscordCode {
             const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_SHOP);
             App.game.party.gainPokemonById(pokemon.id, shiny, true);
             // Notify that the code was activated successfully
-            Notifier.notify({ message: `You obtained a${shiny ? ' shiny' : ''} ${pokemon.name}!`, type: GameConstants.NotificationOption.success, timeout: 1e4 });
+            Notifier.notify({
+                message: `You obtained a${shiny ? ' shiny' : ''} ${pokemon.name}!`,
+                type: NotificationConstants.NotificationOption.success,
+                timeout: 1e4,
+            });
             return true;
         };
         super(pokemon.name, image, price, description, claimFunction);

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -27,7 +27,10 @@ class Dungeon {
     public isUnlocked(): boolean {
         // Player requires the Dungeon Ticket to access the dungeons
         if (!App.game.keyItems.hasKeyItem(KeyItems.KeyItem.Dungeon_ticket)) {
-            Notifier.notify({ message: 'You need the Dungeon ticket to access dungeons', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You need the Dungeon ticket to access dungeons',
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return false;
         }
         return true;

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -21,7 +21,10 @@ class DungeonRunner {
         DungeonRunner.dungeon = dungeon;
 
         if (!DungeonRunner.hasEnoughTokens()) {
-            Notifier.notify({ message: "You don't have enough dungeon tokens", type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: "You don't have enough dungeon tokens",
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return false;
         }
         App.game.wallet.loseAmount(new Amount(DungeonRunner.dungeon.tokenCost, GameConstants.Currency.dungeonToken));
@@ -66,7 +69,11 @@ class DungeonRunner {
                 amount += 1;
             }
         }
-        Notifier.notify({ message: `Found ${amount} ${GameConstants.humanifyString(input)} in a dungeon chest`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.dungeon_item_found });
+        Notifier.notify({
+            message: `Found ${amount} ${GameConstants.humanifyString(input)} in a dungeon chest`,
+            type: NotificationConstants.NotificationOption.success,
+            setting: NotificationConstants.NotificationSetting.dungeon_item_found,
+        });
         player.gainItem(input, amount);
         DungeonRunner.map.currentTile().type(GameConstants.DungeonTile.empty);
         DungeonRunner.map.currentTile().calculateCssClass();
@@ -93,7 +100,10 @@ class DungeonRunner {
             DungeonRunner.fighting(false);
             DungeonRunner.fightingBoss(false);
             MapHelper.moveToTown(DungeonRunner.dungeon.name());
-            Notifier.notify({ message: 'You could not complete the dungeon in time', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You could not complete the dungeon in time',
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
     }
 
@@ -103,7 +113,10 @@ class DungeonRunner {
             GameHelper.incrementObservable(App.game.statistics.dungeonsCleared[Statistics.getDungeonIndex(DungeonRunner.dungeon.name())]);
             MapHelper.moveToTown(DungeonRunner.dungeon.name());
             // TODO award loot with a special screen
-            Notifier.notify({ message: 'You have successfully completed the dungeon', type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                message: 'You have successfully completed the dungeon',
+                type: NotificationConstants.NotificationOption.success,
+            });
         }
     }
 

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -11,7 +11,12 @@ class EffectEngineRunner {
                 this.updateFormattedTimeLeft(itemName);
             }
             if (player.effectList[itemName]() == 5) {
-                Notifier.notify({ message: `The ${GameConstants.humanifyString(itemName)}s effect is about to wear off!`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.battle_item_timer, setting: GameConstants.NotificationSetting.battle_item_timer });
+                Notifier.notify({
+                    message: `The ${GameConstants.humanifyString(itemName)}s effect is about to wear off!`,
+                    type: NotificationConstants.NotificationOption.warning,
+                    sound: NotificationConstants.NotificationSound.battle_item_timer,
+                    setting: NotificationConstants.NotificationSetting.battle_item_timer,
+                });
             }
         }
     }

--- a/src/scripts/farming/FarmController.ts
+++ b/src/scripts/farming/FarmController.ts
@@ -6,7 +6,10 @@ class FarmController {
         if (App.game.farming.canAccess()) {
             $('#farmModal').modal('show');
         } else {
-            Notifier.notify({ message: `You need the ${GameConstants.humanifyString(KeyItems.KeyItem[KeyItems.KeyItem.Wailmer_pail])} to access this location`, type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: `You need the ${GameConstants.humanifyString(KeyItems.KeyItem[KeyItems.KeyItem.Wailmer_pail])} to access this location`,
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -44,7 +44,12 @@ class Farming implements Feature {
             }
         });
         if (notify) {
-            Notifier.notify({ message: 'A berry is ready to harvest!', type: GameConstants.NotificationOption.success, sound: GameConstants.NotificationSound.ready_to_harvest, setting: GameConstants.NotificationSetting.ready_to_harvest });
+            Notifier.notify({
+                message: 'A berry is ready to harvest!',
+                type: NotificationConstants.NotificationOption.success,
+                sound: NotificationConstants.NotificationSound.ready_to_harvest,
+                setting: NotificationConstants.NotificationSetting.ready_to_harvest,
+            });
         }
     }
 
@@ -112,7 +117,10 @@ class Farming implements Feature {
         this.gainBerry(plot.berry, amount);
 
         if (!suppressNotification) {
-            Notifier.notify({ message: `You earned ${money} money from the harvest!`, type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                message: `You earned ${money} money from the harvest!`,
+                type: NotificationConstants.NotificationOption.success,
+            });
         }
 
         plot.berry = BerryType.None;
@@ -130,14 +138,21 @@ class Farming implements Feature {
         });
 
         if (total > 0) {
-            Notifier.notify({ message: `You earned ${total} money from the harvest!`, type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                message: `You earned ${total} money from the harvest!`,
+                type: NotificationConstants.NotificationOption.success,
+            });
         }
     }
 
     gainRandomBerry(amount = 1, disableNotification = false) {
         const berry = GameHelper.getIndexFromDistribution(GameConstants.BerryDistribution);
         if (!disableNotification) {
-            Notifier.notify({ message: `You got a ${BerryType[berry]} berry!`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.route_item_found });
+            Notifier.notify({
+                message: `You got a ${BerryType[berry]} berry!`,
+                type: NotificationConstants.NotificationOption.success,
+                setting: NotificationConstants.NotificationSetting.route_item_found,
+            });
         }
         this.gainBerry(berry, amount);
     }

--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -36,7 +36,10 @@ class GymRunner {
                     reqsList.push(requirement.hint());
                 }
             });
-            Notifier.notify({ message: `You don't have access to ${gym.leaderName}s Gym yet.<br/>${reqsList.join('<br/>')}`, type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: `You don't have access to ${gym.leaderName}s Gym yet.<br/>${reqsList.join('<br/>')}`,
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 
@@ -65,12 +68,19 @@ class GymRunner {
     }
 
     public static gymLost() {
-        Notifier.notify({ message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName}`, type: GameConstants.NotificationOption.danger });
+        Notifier.notify({
+            message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName}`,
+            type: NotificationConstants.NotificationOption.danger,
+        });
         App.game.gameState = GameConstants.GameState.town;
     }
 
     public static gymWon(gym: Gym) {
-        Notifier.notify({ message: `Congratulations, you defeated ${GymBattle.gym.leaderName}!`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.gym_won });
+        Notifier.notify({
+            message: `Congratulations, you defeated ${GymBattle.gym.leaderName}!`,
+            type: NotificationConstants.NotificationOption.success,
+            setting: NotificationConstants.NotificationSetting.gym_won,
+        });
         this.gymObservable(gym);
         App.game.wallet.gainMoney(gym.moneyReward);
         // If this is the first time defeating this gym

--- a/src/scripts/items/EnergyRestore.ts
+++ b/src/scripts/items/EnergyRestore.ts
@@ -13,7 +13,10 @@ class EnergyRestore extends Item {
             return;
         }
         if (Underground.energy === Underground.getMaxEnergy()) {
-            Notifier.notify({ message: 'Your mining energy is already full!', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'Your mining energy is already full!',
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return;
         }
         Underground.gainEnergyThroughItem(this.type);

--- a/src/scripts/items/Item.ts
+++ b/src/scripts/items/Item.ts
@@ -60,12 +60,18 @@ abstract class Item {
         }
 
         if (n > this.maxAmount) {
-            Notifier.notify({ message: `You can only buy ${this.maxAmount} &times; ${GameConstants.humanifyString(this.name())}!`, type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: `You can only buy ${this.maxAmount} &times; ${GameConstants.humanifyString(this.name())}!`,
+                type: NotificationConstants.NotificationOption.danger,
+            });
             n = this.maxAmount;
         }
 
         if (!this.isAvailable()) {
-            Notifier.notify({ message: `${GameConstants.humanifyString(this.name())} is sold out!`, type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: `${GameConstants.humanifyString(this.name())} is sold out!`,
+                type: NotificationConstants.NotificationOption.danger,
+            });
             return;
         }
 
@@ -75,7 +81,10 @@ abstract class Item {
             App.game.wallet.loseAmount(new Amount(this.totalPrice(n), this.currency));
             this.gain(n);
             this.increasePriceMultiplier(n);
-            Notifier.notify({ message: `You bought ${n} ${GameConstants.humanifyString(this.name())}${multiple}`, type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                message: `You bought ${n} ${GameConstants.humanifyString(this.name())}${multiple}`,
+                type: NotificationConstants.NotificationOption.success,
+            });
         } else {
             let curr = GameConstants.camelCaseToString(GameConstants.Currency[this.currency]);
             switch (this.currency) {
@@ -85,7 +94,10 @@ abstract class Item {
                     curr += 's';
                     break;
             }
-            Notifier.notify({ message: `You don't have enough ${curr} to buy ${n} ${GameConstants.humanifyString(this.name()) + multiple}`, type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: `You don't have enough ${curr} to buy ${n} ${GameConstants.humanifyString(this.name()) + multiple}`,
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
     }
 

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -10,7 +10,10 @@ class ItemHandler {
 
     public static useItem(name: string) {
         if (!player.itemList[name]()) {
-            return Notifier.notify({ message: `You don't have any ${GameConstants.humanifyString(name)}s left...`, type: GameConstants.NotificationOption.danger });
+            return Notifier.notify({
+                message: `You don't have any ${GameConstants.humanifyString(name)}s left...`,
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
         // Either the digits specified, or All (Infinity)
         const amountSelected = Number(this.multipliers[this.multIndex()].replace(/\D/g, '')) || Infinity;
@@ -34,12 +37,18 @@ class ItemHandler {
 
     public static useStones() {
         if (this.pokemonSelected() == '') {
-            return Notifier.notify({ message: 'No Pokémon selected', type: GameConstants.NotificationOption.danger });
+            return Notifier.notify({
+                message: 'No Pokémon selected',
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
         const amountTotal = Math.min(this.amountSelected(), player.itemList[this.stoneSelected()]());
 
         if (!amountTotal) {
-            return Notifier.notify({ message: `You don't have any ${this.stoneSelected().replace(/_/g, ' ')}s left...`, type: GameConstants.NotificationOption.danger });
+            return Notifier.notify({
+                message: `You don't have any ${this.stoneSelected().replace(/_/g, ' ')}s left...`,
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
 
         let amountUsed = 0;
@@ -52,7 +61,10 @@ class ItemHandler {
             }
         }
         const multiple = amountUsed == 1 ? '' : 's';
-        Notifier.notify({ message: `You used ${amountUsed} ${GameConstants.humanifyString(this.stoneSelected())}${multiple}`, type: GameConstants.NotificationOption.success });
+        Notifier.notify({
+            message: `You used ${amountUsed} ${GameConstants.humanifyString(this.stoneSelected())}${multiple}`,
+            type: NotificationConstants.NotificationOption.success,
+        });
     }
 
     public static incrementMultiplier() {

--- a/src/scripts/items/PokemonItem.ts
+++ b/src/scripts/items/PokemonItem.ts
@@ -13,7 +13,10 @@ class PokemonItem extends CaughtIndicatingItem {
         const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_SHOP);
         const pokemonName = this.name();
         if (shiny) {
-            Notifier.notify({ message: `✨ You obtained a shiny ${pokemonName}! ✨`, type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: `✨ You obtained a shiny ${pokemonName}! ✨`,
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
         App.game.party.gainPokemonById(PokemonHelper.getPokemonByName(pokemonName).id, shiny, true);
     }

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -49,7 +49,11 @@ class Party implements Feature {
                 return;
             }
             // Notify if not already caught
-            Notifier.notify({ message: `✨ You have captured a shiny ${pokemon.name}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.new_catch });
+            Notifier.notify({
+                message: `✨ You have captured a shiny ${pokemon.name}! ✨`,
+                type: NotificationConstants.NotificationOption.warning,
+                sound: NotificationConstants.NotificationSound.new_catch,
+            });
             // Add to caught shiny list
             this.shinyPokemon.push(pokemon.id);
         }
@@ -60,7 +64,11 @@ class Party implements Feature {
         }
 
         if (!suppressNotification) {
-            Notifier.notify({ message: `You have captured ${GameHelper.anOrA(pokemon.name)} ${pokemon.name}!`, type: GameConstants.NotificationOption.success, sound: GameConstants.NotificationSound.new_catch });
+            Notifier.notify({
+                message: `You have captured ${GameHelper.anOrA(pokemon.name)} ${pokemon.name}!`,
+                type: NotificationConstants.NotificationOption.success,
+                sound: NotificationConstants.NotificationSound.new_catch,
+            });
         }
 
         App.game.logbook.newLog(LogBookTypes.CAUGHT, `You have captured ${GameHelper.anOrA(pokemon.name)} ${pokemon.name}!`);

--- a/src/scripts/party/evolutions/Evolution.ts
+++ b/src/scripts/party/evolutions/Evolution.ts
@@ -24,7 +24,10 @@ abstract class Evolution {
 
         // Notify the player if they haven't already caught the evolution, or notifications are forced
         if (!App.game.party.alreadyCaughtPokemonByName(evolvedPokemon) || notification) {
-            Notifier.notify({ message: `Your ${this.basePokemon} evolved into a ${evolvedPokemon}`, type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                message: `Your ${this.basePokemon} evolved into a ${evolvedPokemon}`,
+                type: NotificationConstants.NotificationOption.success,
+            });
         }
 
         const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_STONE);

--- a/src/scripts/pokemons/BattlePokemon.ts
+++ b/src/scripts/pokemons/BattlePokemon.ts
@@ -68,7 +68,11 @@ class BattlePokemon implements EnemyPokemonInterface {
             const name = GameConstants.humanifyString(item.name());
             item.gain(1);
             const msg = `${this.name} dropped ${GameHelper.anOrA(name)} ${name}!`;
-            Notifier.notify({ message: `The enemy ${msg}`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.dropped_item });
+            Notifier.notify({
+                message: `The enemy ${msg}`,
+                type: NotificationConstants.NotificationOption.success,
+                setting: NotificationConstants.NotificationSetting.dropped_item,
+            });
             App.game.logbook.newLog(LogBookTypes.FOUND, `An enemy ${msg}`);
         }
         App.game.party.gainExp(this.exp, this.level, trainer);

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -36,7 +36,12 @@ class PokemonFactory {
         const money: number = this.routeMoney(route,region);
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
         if (shiny) {
-            Notifier.notify({ message: `✨ You encountered a shiny ${name}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.encountered_shiny });
+            Notifier.notify({
+                message: `✨ You encountered a shiny ${name}! ✨`,
+                type: NotificationConstants.NotificationOption.warning,
+                sound: NotificationConstants.NotificationSound.shiny_long,
+                setting: NotificationConstants.NotificationSetting.encountered_shiny,
+            });
         }
         return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny, 1, heldItem);
     }
@@ -117,7 +122,12 @@ class PokemonFactory {
         const heldItem = this.generateHeldItem(basePokemon.heldItem, GameConstants.DUNGEON_HELD_ITEM_CHANCE);
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_DUNGEON);
         if (shiny) {
-            Notifier.notify({ message: `✨ You encountered a shiny ${name}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.encountered_shiny });
+            Notifier.notify({
+                message: `✨ You encountered a shiny ${name}! ✨`,
+                type: NotificationConstants.NotificationOption.warning,
+                sound: NotificationConstants.NotificationSound.shiny_long,
+                setting: NotificationConstants.NotificationSetting.encountered_shiny,
+            });
         }
         return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny, GameConstants.DUNGEON_SHARDS, heldItem);
     }
@@ -134,7 +144,12 @@ class PokemonFactory {
         const money = 0;
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_DUNGEON);
         if (shiny) {
-            Notifier.notify({ message: `✨ You encountered a shiny ${name}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.encountered_shiny });
+            Notifier.notify({
+                message: `✨ You encountered a shiny ${name}! ✨`,
+                type: NotificationConstants.NotificationOption.warning,
+                sound: NotificationConstants.NotificationSound.shiny_long,
+                setting: NotificationConstants.NotificationSetting.encountered_shiny,
+            });
         }
         return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, bossPokemon.level, catchRate, exp, money, shiny, GameConstants.DUNGEON_BOSS_SHARDS);
     }

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -31,9 +31,15 @@ abstract class Quest {
             this.claimed(true);
             if (this.pointsReward) {
                 App.game.wallet.gainQuestPoints(this.pointsReward);
-                Notifier.notify({ message: `You have completed your quest and claimed ${this.pointsReward} quest points!`, type: GameConstants.NotificationOption.success });
+                Notifier.notify({
+                    message: `You have completed your quest and claimed ${this.pointsReward} quest points!`,
+                    type: NotificationConstants.NotificationOption.success,
+                });
             } else {
-                Notifier.notify({ message: 'You have completed a quest!', type: GameConstants.NotificationOption.success });
+                Notifier.notify({
+                    message: 'You have completed a quest!',
+                    type: NotificationConstants.NotificationOption.success,
+                });
             }
             GameHelper.incrementObservable(App.game.statistics.questsCompleted);
             return true;
@@ -85,7 +91,13 @@ abstract class Quest {
         this.isCompleted = ko.computed(function() {
             const completed = this.progress() == 1;
             if (!this.autoComplete && completed && !this.notified) {
-                Notifier.notify({ message: `You can complete your quest for ${this.pointsReward} quest points!`, type: GameConstants.NotificationOption.success, timeout: 5e3, sound: GameConstants.NotificationSound.quest_ready_to_complete, setting: GameConstants.NotificationSetting.quest_ready_to_complete });
+                Notifier.notify({
+                    message: `You can complete your quest for ${this.pointsReward} quest points!`,
+                    type: NotificationConstants.NotificationOption.success,
+                    timeout: 5e3,
+                    sound: NotificationConstants.NotificationSound.quest_ready_to_complete,
+                    setting: NotificationConstants.NotificationSetting.quest_ready_to_complete,
+                });
                 this.notified = true;
             }
             return completed;

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -39,7 +39,7 @@ class QuestLineHelper {
 
         //Defeat Pewter Gym
         const pewterReward = () => {
-            Notifier.notify({ message: 'Tutorial completed!', type: GameConstants.NotificationOption.success });
+            Notifier.notify({ message: 'Tutorial completed!', type: NotificationConstants.NotificationOption.success });
             Information.show({
                 steps: [
                     {
@@ -71,7 +71,11 @@ class QuestLineHelper {
         // Defeat 500 Psychic type Pokemon
         const psychicShardReward = () => {
             App.game.shards.gainShards(500, PokemonType.Psychic);
-            Notifier.notify({ title: deoxysQuestLine.name, message: 'You have gained 500 Psychic shards', type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                title: deoxysQuestLine.name,
+                message: 'You have gained 500 Psychic shards',
+                type: NotificationConstants.NotificationOption.success,
+            });
         };
         const defeatPsychic = new CustomQuest(500, psychicShardReward, 'Defeat 500 Psychic type Pokémon', () => {
             return pokemonMap.filter(p => p.type.includes(PokemonType.Psychic)).map(p => App.game.statistics.pokemonDefeated[p.id]()).reduce((a,b) => a + b, 0);
@@ -85,7 +89,11 @@ class QuestLineHelper {
                 return console.error('Unable to find item Mind Plate');
             }
             Underground.gainMineItem(mindPlate.id, 20);
-            Notifier.notify({ title: deoxysQuestLine.name, message: `You have gained 20 ${mindPlate.name}s`, type: GameConstants.NotificationOption.success });
+            Notifier.notify({
+                title: deoxysQuestLine.name,
+                message: `You have gained 20 ${mindPlate.name}s`,
+                type: NotificationConstants.NotificationOption.success,
+            });
         };
         const catchPsychic = new CustomQuest(200, mindPlateReward, 'Capture 200 Psychic type Pokémon', () => {
             return pokemonMap.filter(p => p.type.includes(PokemonType.Psychic)).map(p => App.game.statistics.pokemonCaptured[p.id]()).reduce((a,b) => a + b, 0);
@@ -94,7 +102,12 @@ class QuestLineHelper {
 
         // Reach stage 100 in battle frontier
         const reachStage100Reward = () => {
-            Notifier.notify({ title: deoxysQuestLine.name, message: 'Quest line completed!<br/><i>You have uncovered the Mystery of Deoxys</i>', type: GameConstants.NotificationOption.success, timeout: 3e4 });
+            Notifier.notify({
+                title: deoxysQuestLine.name,
+                message: 'Quest line completed!<br/><i>You have uncovered the Mystery of Deoxys</i>',
+                type: NotificationConstants.NotificationOption.success,
+                timeout: 3e4,
+            });
         };
         const reachStage100 = new CustomQuest(100, reachStage100Reward, 'Defeat stage 100 in the Battle Frontier', App.game.statistics.battleFrontierHighestStageCompleted, 0);
         deoxysQuestLine.addQuest(reachStage100);
@@ -116,7 +129,7 @@ class QuestLineHelper {
             Notifier.notify({
                 title: undergroundQuestLine.name,
                 message: 'You have gained an Old Amber fossil!<br/><i>You can breed this in the hatchery.</i>',
-                type: GameConstants.NotificationOption.success,
+                type: NotificationConstants.NotificationOption.success,
                 timeout: GameConstants.MINUTE,
             });
         };

--- a/src/scripts/quests/Quests.ts
+++ b/src/scripts/quests/Quests.ts
@@ -43,7 +43,10 @@ class Quests implements Saveable {
         if (this.canStartNewQuest() && quest && !quest.inProgress() && !quest.isCompleted()) {
             quest.begin();
         } else {
-            Notifier.notify({ message: 'You cannot start more quests', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You cannot start more quests',
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
     }
 
@@ -53,7 +56,10 @@ class Quests implements Saveable {
         if (quest && quest.inProgress()) {
             quest.quit(shouldConfirm);
         } else {
-            Notifier.notify({ message: 'You cannot quit this quest', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You cannot quit this quest',
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
     }
 
@@ -68,7 +74,10 @@ class Quests implements Saveable {
             }
         } else {
             console.trace('cannot claim quest..');
-            Notifier.notify({ message: 'You cannot claim this quest', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You cannot claim this quest',
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
     }
 
@@ -81,7 +90,12 @@ class Quests implements Saveable {
 
         // Refresh the list each time a player levels up
         if (this.level() > currentLevel) {
-            Notifier.notify({ message: 'Your quest level has increased!', type: GameConstants.NotificationOption.success, timeout: 1e4, sound: GameConstants.NotificationSound.quest_level_increased });
+            Notifier.notify({
+                message: 'Your quest level has increased!',
+                type: NotificationConstants.NotificationOption.success,
+                timeout: 1e4,
+                sound: NotificationConstants.NotificationSound.quest_level_increased,
+            });
             this.refreshQuests(true);
         }
     }
@@ -108,7 +122,10 @@ class Quests implements Saveable {
             GameHelper.incrementObservable(this.refreshes);
             this.generateQuestList();
         } else {
-            Notifier.notify({ message: 'You cannot afford to do that!', type: GameConstants.NotificationOption.danger });
+            Notifier.notify({
+                message: 'You cannot afford to do that!',
+                type: NotificationConstants.NotificationOption.danger,
+            });
         }
     }
 

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -125,7 +125,10 @@ class Safari {
             App.game.gameState = GameConstants.GameState.safari;
             $('#safariModal').modal({backdrop: 'static', keyboard: false});
         } else {
-            Notifier.notify({ message: 'You need the Safari Pass to access this location.<br/><i>Visit the Gym in Fuschia City</i>', type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: 'You need the Safari Pass to access this location.<br/><i>Visit the Gym in Fuschia City</i>',
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 

--- a/src/scripts/safari/SafariPokemon.ts
+++ b/src/scripts/safari/SafariPokemon.ts
@@ -43,7 +43,12 @@ class SafariPokemon implements PokemonInterface {
         this.type2 = data.type2;
         this.shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_SAFARI);
         if (this.shiny) {
-            Notifier.notify({ message: `✨ You encountered a shiny ${name}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.encountered_shiny });
+            Notifier.notify({
+                message: `✨ You encountered a shiny ${name}! ✨`,
+                type: NotificationConstants.NotificationOption.warning,
+                sound: NotificationConstants.NotificationSound.shiny_long,
+                setting: NotificationConstants.NotificationSetting.encountered_shiny,
+            });
         }
         this.baseCatchFactor = data.catchRate * 1 / 6;
         this.baseEscapeFactor = 30;

--- a/src/scripts/settings/Settings.ts
+++ b/src/scripts/settings/Settings.ts
@@ -112,13 +112,13 @@ Settings.add(new BooleanSetting('disableAutoDownloadBackupSaveOnUpdate', 'Disabl
 
 
 // Sound settings
-Object.values(GameConstants.NotificationSound).forEach(sound => {
+Object.values(NotificationConstants.NotificationSound).forEach(sound => {
     Settings.add(new BooleanSetting(`sound.${sound.name}`, sound.name, true));
 });
 Settings.add(new RangeSetting('sound.volume', 'Volume', 0, 100, 1, 100));
 
 // Notification settings
-Object.values(GameConstants.NotificationSetting).forEach(setting => {
+Object.values(NotificationConstants.NotificationSetting).forEach(setting => {
     Settings.add(setting);
 });
 

--- a/src/scripts/shards/Shards.ts
+++ b/src/scripts/shards/Shards.ts
@@ -104,7 +104,10 @@ class Shards implements Feature {
         if (this.canAccess()) {
             $('#shardModal').modal('show');
         } else {
-            Notifier.notify({ message: 'You do not have the Shard Case', type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: 'You do not have the Shard Case',
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 }

--- a/src/scripts/specialEvents/SpecialEvent.ts
+++ b/src/scripts/specialEvents/SpecialEvent.ts
@@ -56,9 +56,16 @@ class SpecialEvent {
         return this.status == SpecialEventStatus.ended;
     }
 
-    notify(time: string, timeout: number, type = GameConstants.NotificationOption.info) {
+    notify(time: string, timeout: number, type = NotificationConstants.NotificationOption.info) {
         timeout -= 1000;
-        Notifier.notify({ title: `[EVENT] ${this.title}`, message: `${this.description}<br/><br/><strong>Start time:</strong> ${this.startTime.toLocaleString()}<br/><strong>End time:</strong> ${this.endTime.toLocaleString()}`, type, time, timeout, setting: GameConstants.NotificationSetting.event_start_end });
+        Notifier.notify({
+            title: `[EVENT] ${this.title}`,
+            message: `${this.description}<br/><br/><strong>Start time:</strong> ${this.startTime.toLocaleString()}<br/><strong>End time:</strong> ${this.endTime.toLocaleString()}`,
+            type,
+            time,
+            timeout,
+            setting: NotificationConstants.NotificationSetting.event_start_end,
+        });
     }
 
     checkStart() {
@@ -117,7 +124,7 @@ class SpecialEvent {
 
         // We only wan't the notification displayed for 1 hour, or until the event is over
         const timeTillEventEnd = this.timeTillEnd();
-        this.notify('on now!', Math.min(1 * GameConstants.HOUR, timeTillEventEnd), GameConstants.NotificationOption.success);
+        this.notify('on now!', Math.min(1 * GameConstants.HOUR, timeTillEventEnd), NotificationConstants.NotificationOption.success);
 
         this.startFunction();
         // Start checking when the event should be ending
@@ -143,7 +150,7 @@ class SpecialEvent {
             const sendNotificationTimeout = Math.max(timeTillEventEnd - 1 * GameConstants.HOUR, 0);
             const notificationTimeout = sendNotificationTimeout ? 1 * GameConstants.HOUR : timeTillEventEnd;
             setTimeout(() => {
-                this.notify(`ends in ${GameConstants.formatTimeShortWords(notificationTimeout)}!`, notificationTimeout, GameConstants.NotificationOption.warning);
+                this.notify(`ends in ${GameConstants.formatTimeShortWords(notificationTimeout)}!`, notificationTimeout, NotificationConstants.NotificationOption.warning);
             }, sendNotificationTimeout);
         }
 
@@ -156,7 +163,7 @@ class SpecialEvent {
     end() {
         // Update event status
         this.status = SpecialEventStatus.ended;
-        this.notify('just ended!', 1 * GameConstants.HOUR, GameConstants.NotificationOption.danger);
+        this.notify('just ended!', 1 * GameConstants.HOUR, NotificationConstants.NotificationOption.danger);
         this.endFunction();
     }
 }

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -251,7 +251,10 @@ class Mine {
             if (Mine.checkItemRevealed(Mine.rewardNumbers[i])) {
                 Underground.gainMineItem(Mine.rewardNumbers[i]);
                 const itemName = Underground.getMineItemById(Mine.rewardNumbers[i]).name;
-                Notifier.notify({ message: `You found ${GameHelper.anOrA(itemName)} ${GameConstants.humanifyString(itemName)}`, type: GameConstants.NotificationOption.success });
+                Notifier.notify({
+                    message: `You found ${GameHelper.anOrA(itemName)} ${GameConstants.humanifyString(itemName)}`,
+                    type: NotificationConstants.NotificationOption.success,
+                });
                 Mine.itemsFound(Mine.itemsFound() + 1);
                 GameHelper.incrementObservable(App.game.statistics.undergroundItemsFound);
                 Mine.rewardNumbers.splice(i, 1);
@@ -290,7 +293,10 @@ class Mine {
     }
 
     private static completed() {
-        Notifier.notify({ message: 'You dig deeper...', type: GameConstants.NotificationOption.info });
+        Notifier.notify({
+            message: 'You dig deeper...',
+            type: NotificationConstants.NotificationOption.info,
+        });
         ko.cleanNode(document.getElementById('mineBody'));
         Mine.loadMine();
         ko.applyBindings(null, document.getElementById('mineBody'));

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -109,7 +109,13 @@ class Underground {
             const oakMultiplier = App.game.oakItems.calculateBonus(OakItems.OakItem.Cell_Battery);
             this.energy = Math.min(this.getMaxEnergy(), this.energy + (oakMultiplier * this.getEnergyGain()));
             if (this.energy === this.getMaxEnergy()) {
-                Notifier.notify({ message: 'Your mining energy has reached maximum capacity!', type: GameConstants.NotificationOption.success, timeout: 1e4, sound: GameConstants.NotificationSound.underground_energy_full, setting: GameConstants.NotificationSetting.underground_energy_full });
+                Notifier.notify({
+                    message: 'Your mining energy has reached maximum capacity!',
+                    type: NotificationConstants.NotificationOption.success,
+                    timeout: 1e4,
+                    sound: NotificationConstants.NotificationSound.underground_energy_full,
+                    setting: NotificationConstants.NotificationSetting.underground_energy_full,
+                });
             }
         }
     }
@@ -119,7 +125,10 @@ class Underground {
         const effect: number = GameConstants.EnergyRestoreEffect[GameConstants.EnergyRestoreSize[item]];
         const gain = Math.min(this.getMaxEnergy() - this.energy, effect * this.getMaxEnergy());
         this.energy = this.energy + gain;
-        Notifier.notify({ message: `You restored ${gain} mining energy!`, type: GameConstants.NotificationOption.success });
+        Notifier.notify({
+            message: `You restored ${gain} mining energy!`,
+            type: NotificationConstants.NotificationOption.success,
+        });
     }
 
     public static sortMineItems(prop: string, flip = true) {
@@ -200,7 +209,10 @@ class Underground {
         if (this.canAccess()) {
             $('#mineModal').modal('show');
         } else {
-            Notifier.notify({ message: 'You need the Explorer Kit to access this location.<br/><i>Check out the shop at Cinnabar Island</i>', type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: 'You need the Explorer Kit to access this location.<br/><i>Check out the shop at Cinnabar Island</i>',
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 

--- a/src/scripts/upgrades/Upgrade.ts
+++ b/src/scripts/upgrades/Upgrade.ts
@@ -63,7 +63,10 @@ class Upgrade implements Saveable {
             App.game.wallet.loseAmount(this.calculateCost());
             this.levelUp();
         } else {
-            Notifier.notify({ message: 'You cannot afford to buy this upgrade yet', type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: 'You cannot afford to buy this upgrade yet',
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -27,7 +27,10 @@ class MapHelper {
             GameController.applyRouteBindings();
         } else {
             if (!MapHelper.routeExist(route, region)) {
-                return Notifier.notify({ message: `Route ${route} does not exist in the ${GameConstants.Region[region]} region.`, type: GameConstants.NotificationOption.warning });
+                return Notifier.notify({
+                    message: `Route ${route} does not exist in the ${GameConstants.Region[region]} region.`,
+                    type: NotificationConstants.NotificationOption.warning,
+                });
             }
 
             const routeData = Routes.getRoute(region, route);
@@ -39,7 +42,10 @@ class MapHelper {
                 }
             });
 
-            Notifier.notify({ message: `You don't have access to that route yet.<br/>${reqsList.join('<br/>')}`, type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: `You don't have access to that route yet.<br/>${reqsList.join('<br/>')}`,
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     };
 
@@ -163,7 +169,10 @@ class MapHelper {
                 }
             });
 
-            Notifier.notify({ message: `You don't have access to that location yet.<br/>${reqsList.join('<br/>')}`, type: GameConstants.NotificationOption.warning });
+            Notifier.notify({
+                message: `You don't have access to that location yet.<br/>${reqsList.join('<br/>')}`,
+                type: NotificationConstants.NotificationOption.warning,
+            });
         }
     }
 
@@ -197,7 +206,10 @@ class MapHelper {
                     return;
                 }
         }
-        Notifier.notify({ message: 'You cannot access this dock yet', type: GameConstants.NotificationOption.warning });
+        Notifier.notify({
+            message: 'You cannot access this dock yet',
+            type: NotificationConstants.NotificationOption.warning,
+        });
     }
 
     public static ableToTravel() {


### PR DESCRIPTION
This is needed in order to begin reducing the number of circular dependencies within the code, and support the eventual move to proper TypeScript dependencies and type checking. An example of a circular dependency for `GameConstants.ts` (there are ~136) is `GameConstants.ts > utilities/Sound.ts > settings/Settings.ts > GameConstants.ts`, and the only reason these haven't cause a noticeable issue is because everything is pushed into `window` and most of the code isn't set up to import the types that it uses.

Despite being such a large number of lines changed, the changes can be summarized as:
* Move the three `Notification*` enums into a `NotificationConstants.ts` file
* Split most of the `Notifier.notify` calls onto multiple lines to improve readability (some lines were ~300 characters long)
* Replace `GameConstants.Notification` with `NotificationConstants.Notification` (case by case, instead of using replace all, just to double check everything)