### PR TITLE
Skip preloading disabled features like towns

### DIFF
--- a/_config.js
+++ b/_config.js
@@ -5,4 +5,7 @@ module.exports = {
     DEV_BANNER: (() => process.env.HEROKU)(),                               // optional (false) - If the development banner should be shown
     DISCORD_CLIENT_ID: false,                                               // optional (false) - Discord bot ID
     DISCORD_LOGIN_URI: false,                                               // optional (false) - Discord login proxy link (example: https://gist.github.com/RedSparr0w/46000c523b21e846adbc912d9800e5b8)
+    FEATURE_FLAGS: {                                                        // optional - Toggle feature flags for development
+        preloadUnreleasedTowns: false,                                      // optional (false) - Enable preloading images for unreleased towns
+    },
 };

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -31,6 +31,9 @@ config = Object.assign({
     DEV_BANNER: false,
     DISCORD_CLIENT_ID: false,
     DISCORD_LOGIN_URI: false,
+    FEATURE_FLAGS: {
+        preloadUnreleasedTowns: false,
+    },
 }, config);
 
 const escapeRegExp = (string) => {
@@ -127,6 +130,7 @@ gulp.task('compile-html', (done) => {
         .pipe(replace('$GOOGLE_ANALYTICS_ID', config.GOOGLE_ANALYTICS_ID))
         .pipe(replace('$GIT_BRANCH', process.env.GIT_BRANCH))
         .pipe(replace('$DEV_DESCRIPTION', process.env.DEV_DESCRIPTION !== undefined ? process.env.DEV_DESCRIPTION : ''))
+        .pipe(replace('$FEATURE_FLAGS', process.env.NODE_ENV === 'production' ? '{}' : JSON.stringify(config.FEATURE_FLAGS)))
         .pipe(ejs())
         .pipe(gulp.dest(htmlDest))
         .pipe(browserSync.reload({stream: true}));

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,7 @@
             <td data-bind="text: level">Lvl</td>
         </tr>
     </script>
+    <script>window.featureFlags = $FEATURE_FLAGS;</script>
 
     <!--jQuery-->
     <script src="libs/jquery.min.js"></script>

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -842,10 +842,4 @@ namespace GameConstants {
         'Castelia City',
         'Coumarine City',
     ];
-
-    // These regions (and their towns) will be skipped by the preloader
-    export const UnreleasedRegions = [
-        GameConstants.Region.unova,
-        GameConstants.Region.kalos,
-    ];
 }

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -842,4 +842,10 @@ namespace GameConstants {
         'Castelia City',
         'Coumarine City',
     ];
+
+    // These regions (and their towns) will be skipped by the preloader
+    export const UnreleasedRegions = [
+        GameConstants.Region.unova,
+        GameConstants.Region.kalos,
+    ];
 }

--- a/src/scripts/towns/PokemonLeague.ts
+++ b/src/scripts/towns/PokemonLeague.ts
@@ -3,8 +3,8 @@
 class PokemonLeague extends Town {
     public gymList: KnockoutObservableArray<KnockoutObservable<Gym>>;
 
-    constructor(name: string, requirements: Requirement[], shop: Shop, gyms: string[]) {
-        super(name, requirements, shop);
+    constructor(name: string, region: GameConstants.Region, requirements: Requirement[], shop: Shop, gyms: string[]) {
+        super(name, region, { requirements, shop });
         this.gym(null);
         this.gymList = ko.observableArray<KnockoutObservable<Gym>>();
         for (const gym of gyms) {
@@ -31,18 +31,51 @@ const indigoPlateauShop = new Shop([
 ]);
 
 const indigoPlateauKanto = ['Elite Lorelei', 'Elite Bruno', 'Elite Agatha', 'Elite Lance', 'Champion Blue'];
-TownList['Indigo Plateau Kanto'] = new PokemonLeague('Indigo Plateau Kanto', [new RouteKillRequirement(10, 23), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road'))], indigoPlateauShop, indigoPlateauKanto);
+TownList['Indigo Plateau Kanto'] = new PokemonLeague(
+    'Indigo Plateau Kanto',
+    GameConstants.Region.kanto,
+    [
+        new RouteKillRequirement(10, 23),
+        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road')),
+    ],
+    indigoPlateauShop,
+    indigoPlateauKanto
+);
 (<PokemonLeague>TownList['Indigo Plateau Kanto']).setupGymTowns();
 
 const indigoPlateauJohto = ['Elite Will', 'Elite Koga', 'Elite Bruno2', 'Elite Karen', 'Champion Lance'];
-TownList['Indigo Plateau Johto'] = new PokemonLeague('Indigo Plateau Johto', [new RouteKillRequirement(10, 27)], indigoPlateauShop, indigoPlateauJohto);
+TownList['Indigo Plateau Johto'] = new PokemonLeague(
+    'Indigo Plateau Johto',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 27)],
+    indigoPlateauShop,
+    indigoPlateauJohto
+);
 (<PokemonLeague>TownList['Indigo Plateau Johto']).setupGymTowns();
 
 const pokemonLeagueHoenn = ['Elite Sidney', 'Elite Phoebe', 'Elite Glacia', 'Elite Drake', 'Champion Wallace'];
-TownList['Pokemon League Hoenn'] = new PokemonLeague('Pokemon League Hoenn', [new RouteKillRequirement(10, 128), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Hoenn'))], indigoPlateauShop, pokemonLeagueHoenn);
+TownList['Pokemon League Hoenn'] = new PokemonLeague(
+    'Pokemon League Hoenn',
+    GameConstants.Region.hoenn,
+    [
+        new RouteKillRequirement(10, 128),
+        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Hoenn')),
+    ],
+    indigoPlateauShop,
+    pokemonLeagueHoenn
+);
 (<PokemonLeague>TownList['Pokemon League Hoenn']).setupGymTowns();
 
 const pokemonLeagueSinnoh = ['Elite Aaron', 'Elite Bertha', 'Elite Flint', 'Elite Lucian', 'Champion Cynthia'];
-TownList['Pokemon League Sinnoh'] = new PokemonLeague('Pokemon League Sinnoh', [new RouteKillRequirement(10, 223), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Sinnoh'))], indigoPlateauShop, pokemonLeagueSinnoh);
+TownList['Pokemon League Sinnoh'] = new PokemonLeague(
+    'Pokemon League Sinnoh',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 223),
+        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Sinnoh')),
+    ],
+    indigoPlateauShop,
+    pokemonLeagueSinnoh
+);
 (<PokemonLeague>TownList['Pokemon League Sinnoh']).setupGymTowns();
 

--- a/src/scripts/towns/PokemonLeague.ts
+++ b/src/scripts/towns/PokemonLeague.ts
@@ -30,7 +30,6 @@ const indigoPlateauShop = new Shop([
     ItemList['Protein'],
 ]);
 
-const indigoPlateauKanto = ['Elite Lorelei', 'Elite Bruno', 'Elite Agatha', 'Elite Lance', 'Champion Blue'];
 TownList['Indigo Plateau Kanto'] = new PokemonLeague(
     'Indigo Plateau Kanto',
     GameConstants.Region.kanto,
@@ -39,21 +38,19 @@ TownList['Indigo Plateau Kanto'] = new PokemonLeague(
         new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road')),
     ],
     indigoPlateauShop,
-    indigoPlateauKanto
+    ['Elite Lorelei', 'Elite Bruno', 'Elite Agatha', 'Elite Lance', 'Champion Blue']
 );
 (<PokemonLeague>TownList['Indigo Plateau Kanto']).setupGymTowns();
 
-const indigoPlateauJohto = ['Elite Will', 'Elite Koga', 'Elite Bruno2', 'Elite Karen', 'Champion Lance'];
 TownList['Indigo Plateau Johto'] = new PokemonLeague(
     'Indigo Plateau Johto',
     GameConstants.Region.johto,
     [new RouteKillRequirement(10, 27)],
     indigoPlateauShop,
-    indigoPlateauJohto
+    ['Elite Will', 'Elite Koga', 'Elite Bruno2', 'Elite Karen', 'Champion Lance']
 );
 (<PokemonLeague>TownList['Indigo Plateau Johto']).setupGymTowns();
 
-const pokemonLeagueHoenn = ['Elite Sidney', 'Elite Phoebe', 'Elite Glacia', 'Elite Drake', 'Champion Wallace'];
 TownList['Pokemon League Hoenn'] = new PokemonLeague(
     'Pokemon League Hoenn',
     GameConstants.Region.hoenn,
@@ -62,11 +59,10 @@ TownList['Pokemon League Hoenn'] = new PokemonLeague(
         new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Hoenn')),
     ],
     indigoPlateauShop,
-    pokemonLeagueHoenn
+    ['Elite Sidney', 'Elite Phoebe', 'Elite Glacia', 'Elite Drake', 'Champion Wallace']
 );
 (<PokemonLeague>TownList['Pokemon League Hoenn']).setupGymTowns();
 
-const pokemonLeagueSinnoh = ['Elite Aaron', 'Elite Bertha', 'Elite Flint', 'Elite Lucian', 'Champion Cynthia'];
 TownList['Pokemon League Sinnoh'] = new PokemonLeague(
     'Pokemon League Sinnoh',
     GameConstants.Region.sinnoh,
@@ -75,7 +71,7 @@ TownList['Pokemon League Sinnoh'] = new PokemonLeague(
         new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Sinnoh')),
     ],
     indigoPlateauShop,
-    pokemonLeagueSinnoh
+    ['Elite Aaron', 'Elite Bertha', 'Elite Flint', 'Elite Lucian', 'Champion Cynthia']
 );
 (<PokemonLeague>TownList['Pokemon League Sinnoh']).setupGymTowns();
 

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -2,8 +2,17 @@
 ///<reference path="../achievements/GymBadgeRequirement.ts"/>
 ///<reference path="../achievements/OneFromManyRequirement.ts"/>
 ///<reference path="NPC.ts"/>
+
+type TownOptionalArgument = {
+    requirements?: (Requirement | OneFromManyRequirement)[],
+    shop?: Shop,
+    dungeon?: Dungeon,
+    npcs?: NPC[],
+};
+
 class Town {
     public name: KnockoutObservable<string>;
+    public region: KnockoutObservable<GameConstants.Region>;
     public gym?: KnockoutObservable<Gym>;
     public requirements: (Requirement | OneFromManyRequirement)[];
     public shop?: KnockoutObservable<Shop>;
@@ -11,13 +20,20 @@ class Town {
     public npcs?: KnockoutObservableArray<NPC>;
     public startingTown: boolean;
 
-    constructor(name: string, requirements: (Requirement | OneFromManyRequirement)[] = [], shop?: Shop, dungeon?: Dungeon, npcs?: NPC[]) {
+    constructor(
+        name: string,
+        region: GameConstants.Region,
+        // Optional arguments are in a named object, so that we don't need
+        // to pass undefined to get to the one we want
+        optional: TownOptionalArgument = {}
+    ) {
         this.name = ko.observable(name);
+        this.region = ko.observable(region);
         this.gym = ko.observable(gymList[name]);
-        this.requirements = requirements || [];
-        this.shop = ko.observable(shop);
-        this.dungeon = ko.observable(dungeon);
-        this.npcs = ko.observableArray(npcs);
+        this.requirements = optional.requirements || [];
+        this.shop = ko.observable(optional.shop);
+        this.dungeon = ko.observable(optional.dungeon);
+        this.npcs = ko.observableArray(optional.npcs);
         this.startingTown = GameConstants.StartingTowns.includes(this.name());
     }
 
@@ -27,8 +43,8 @@ class Town {
 }
 
 class DungeonTown extends Town {
-    constructor(name: string, requirements: (Requirement | OneFromManyRequirement)[] = []) {
-        super(name, requirements, null, dungeonList[name]);
+    constructor(name: string, region: GameConstants.Region, requirements: (Requirement | OneFromManyRequirement)[] = []) {
+        super(name, region, { requirements, dungeon: dungeonList[name] });
     }
 }
 
@@ -118,28 +134,157 @@ const CinnabarIslandResearcher = new NPC('Researcher', [
   
 
 //Kanto Towns
-TownList['Pewter City'] = new Town('Pewter City', [new RouteKillRequirement(10, 2), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Viridian Forest'))], PewterCityShop);
-TownList['Cerulean City'] = new Town('Cerulean City', [new RouteKillRequirement(10, 4)], CeruleanCityShop, dungeonList['Cerulean Cave']);
-TownList['Vermillion City'] = new Town('Vermillion City', [new RouteKillRequirement(10, 6)], VermillionCityShop);
-TownList['Celadon City'] = new Town('Celadon City', [new RouteKillRequirement(10, 8)], CeladonCityShop);
-TownList['Saffron City'] = new Town('Saffron City', [new GymBadgeRequirement(BadgeCase.Badge.Rainbow)], SaffronCityShop);
-TownList['Fuchsia City'] = new Town('Fuchsia City', [new OneFromManyRequirement([new RouteKillRequirement(10, 18), new RouteKillRequirement(10, 15)])], FuchsiaCityShop);
-TownList['Cinnabar Island'] = new Town('Cinnabar Island', [new OneFromManyRequirement([new RouteKillRequirement(10, 20), new RouteKillRequirement(10, 21)])], CinnabarIslandShop, dungeonList['Pokemon Mansion'], [CinnabarIslandResearcher]);
-TownList['Viridian City'] = new Town('Viridian City', [new RouteKillRequirement(10, 1)], ViridianCityShop, undefined, [ViridianCityOldMan]);
-TownList['Pallet Town'] = new Town('Pallet Town', []);
-TownList['Lavender Town'] = new Town('Lavender Town', [new RouteKillRequirement(10, 10)], LavenderTownShop, dungeonList['Pokemon Tower']);
+TownList['Pewter City'] = new Town(
+    'Pewter City',
+    GameConstants.Region.kanto,
+    {
+        requirements: [
+            new RouteKillRequirement(10, 2),
+            new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Viridian Forest')),
+        ],
+        shop: PewterCityShop,
+    }
+);
+TownList['Cerulean City'] = new Town(
+    'Cerulean City',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new RouteKillRequirement(10, 4)],
+        shop: CeruleanCityShop,
+        dungeon: dungeonList['Cerulean Cave'],
+    }
+);
+TownList['Vermillion City'] = new Town(
+    'Vermillion City',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new RouteKillRequirement(10, 6)],
+        shop: VermillionCityShop,
+    }
+);
+TownList['Celadon City'] = new Town(
+    'Celadon City',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new RouteKillRequirement(10, 8)],
+        shop: CeladonCityShop,
+    }
+);
+TownList['Saffron City'] = new Town(
+    'Saffron City',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new GymBadgeRequirement(BadgeCase.Badge.Rainbow)],
+        shop: SaffronCityShop,
+    }
+);
+TownList['Fuchsia City'] = new Town(
+    'Fuchsia City',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new OneFromManyRequirement([
+            new RouteKillRequirement(10, 18),
+            new RouteKillRequirement(10, 15),
+        ])],
+        shop: FuchsiaCityShop,
+    }
+);
+TownList['Cinnabar Island'] = new Town(
+    'Cinnabar Island',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new OneFromManyRequirement([
+            new RouteKillRequirement(10, 20),
+            new RouteKillRequirement(10, 21),
+        ])],
+        shop: CinnabarIslandShop,
+        dungeon: dungeonList['Pokemon Mansion'],
+        npcs: [CinnabarIslandResearcher],
+    }
+);
+TownList['Viridian City'] = new Town(
+    'Viridian City',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new RouteKillRequirement(10, 1)],
+        shop: ViridianCityShop,
+        npcs: [ViridianCityOldMan],
+    }
+);
+TownList['Pallet Town'] = new Town('Pallet Town', GameConstants.Region.kanto);
+TownList['Lavender Town'] = new Town(
+    'Lavender Town',
+    GameConstants.Region.kanto,
+    {
+        requirements: [new RouteKillRequirement(10, 10)],
+        shop: LavenderTownShop,
+        dungeon: dungeonList['Pokemon Tower'],
+    }
+);
 
 //Kanto Dungeons
-TownList['Viridian Forest'] = new DungeonTown('Viridian Forest', [new RouteKillRequirement(10, 2)]);
-TownList['Mt. Moon'] = new DungeonTown('Mt. Moon', [new RouteKillRequirement(10,3)]);
-TownList['Digletts Cave'] = new DungeonTown('Digletts Cave', [new RouteKillRequirement(10, 6)]);
-TownList['Rock Tunnel'] = new DungeonTown('Rock Tunnel', [new RouteKillRequirement(10, 9), new GymBadgeRequirement(BadgeCase.Badge.Cascade)]);
-TownList['Power Plant'] = new DungeonTown('Power Plant', [new RouteKillRequirement(10, 9), new GymBadgeRequirement(BadgeCase.Badge.Soul)]);
-TownList['Pokemon Tower'] = new DungeonTown('Pokemon Tower', [new RouteKillRequirement(10, 10), new GymBadgeRequirement(BadgeCase.Badge.Rainbow)]);
-TownList['Seafoam Islands'] = new DungeonTown('Seafoam Islands', [new RouteKillRequirement(10, 19)]);
-TownList['Pokemon Mansion'] = new DungeonTown('Pokemon Mansion', [new OneFromManyRequirement([new RouteKillRequirement(10, 20), new RouteKillRequirement(10, 21)])]);
-TownList['Victory Road'] = new DungeonTown('Victory Road', [new RouteKillRequirement(10, 23)]);
-TownList['Cerulean Cave'] = new DungeonTown('Cerulean Cave', [new GymBadgeRequirement(BadgeCase.Badge.Elite_KantoChampion)]);
+TownList['Viridian Forest'] = new DungeonTown(
+    'Viridian Forest',
+    GameConstants.Region.kanto,
+    [new RouteKillRequirement(10, 2)]
+);
+TownList['Mt. Moon'] = new DungeonTown(
+    'Mt. Moon',
+    GameConstants.Region.kanto,
+    [new RouteKillRequirement(10,3)]
+);
+TownList['Digletts Cave'] = new DungeonTown(
+    'Digletts Cave',
+    GameConstants.Region.kanto,
+    [new RouteKillRequirement(10, 6)]
+);
+TownList['Rock Tunnel'] = new DungeonTown(
+    'Rock Tunnel',
+    GameConstants.Region.kanto,
+    [
+        new RouteKillRequirement(10, 9),
+        new GymBadgeRequirement(BadgeCase.Badge.Cascade),
+    ]
+);
+TownList['Power Plant'] = new DungeonTown(
+    'Power Plant',
+    GameConstants.Region.kanto,
+    [
+        new RouteKillRequirement(10, 9),
+        new GymBadgeRequirement(BadgeCase.Badge.Soul),
+    ]
+);
+TownList['Pokemon Tower'] = new DungeonTown(
+    'Pokemon Tower',
+    GameConstants.Region.kanto,
+    [
+        new RouteKillRequirement(10, 10),
+        new GymBadgeRequirement(BadgeCase.Badge.Rainbow),
+    ]
+);
+TownList['Seafoam Islands'] = new DungeonTown(
+    'Seafoam Islands',
+    GameConstants.Region.kanto,
+    [new RouteKillRequirement(10, 19)]
+);
+TownList['Pokemon Mansion'] = new DungeonTown(
+    'Pokemon Mansion',
+    GameConstants.Region.kanto,
+    [new OneFromManyRequirement([
+        new RouteKillRequirement(10, 20),
+        new RouteKillRequirement(10, 21),
+    ])]
+);
+TownList['Victory Road'] = new DungeonTown(
+    'Victory Road',
+    GameConstants.Region.kanto,
+    [new RouteKillRequirement(10, 23)]
+);
+TownList['Cerulean Cave'] = new DungeonTown(
+    'Cerulean Cave',
+    GameConstants.Region.kanto,
+    [new GymBadgeRequirement(BadgeCase.Badge.Elite_KantoChampion)]
+);
 
 //Johto Shops
 const NewBarkTownShop = new Shop([
@@ -184,30 +329,155 @@ const BlackthornCityShop = new Shop([
 ]);
 
 //Johto Towns
-TownList['New Bark Town'] = new Town('New Bark Town', [], NewBarkTownShop);
-TownList['Cherrygrove City'] = new Town('Cherrygrove City', [new RouteKillRequirement(10, 29)], CherrygroveCityShop);
-TownList['Violet City'] = new Town('Violet City', [new RouteKillRequirement(10, 31)], VioletCityShop, dungeonList['Sprout Tower']);
-TownList['Azalea Town'] = new Town('Azalea Town', [new RouteKillRequirement(10, 33)], AzaleaTownShop, dungeonList['Slowpoke Well']);
-TownList['Goldenrod City'] = new Town('Goldenrod City', [new RouteKillRequirement(10, 34)], GoldenrodCityShop);
-TownList['Ecruteak City'] = new Town('Ecruteak City', [new RouteKillRequirement(10, 37)], EcruteakCityShop);
-TownList['Olivine City'] = new Town('Olivine City', [new RouteKillRequirement(10, 39)], OlivineCityShop);
-TownList['Cianwood City'] = new Town('Cianwood City', [new RouteKillRequirement(10, 41)], CianwoodCityShop);
-TownList['Mahogany Town'] = new Town('Mahogany Town', [new RouteKillRequirement(10, 42)], MahoganyTownShop);
-TownList['Blackthorn City'] = new Town('Blackthorn City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ice Path'))], BlackthornCityShop);
+TownList['New Bark Town'] = new Town(
+    'New Bark Town',
+    GameConstants.Region.johto,
+    {
+        shop: NewBarkTownShop,
+    }
+);
+TownList['Cherrygrove City'] = new Town(
+    'Cherrygrove City',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 29)],
+        shop: CherrygroveCityShop,
+    }
+);
+TownList['Violet City'] = new Town(
+    'Violet City',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 31)],
+        shop: VioletCityShop,
+        dungeon: dungeonList['Sprout Tower'],
+    }
+);
+TownList['Azalea Town'] = new Town(
+    'Azalea Town',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 33)],
+        shop: AzaleaTownShop,
+        dungeon: dungeonList['Slowpoke Well'],
+    }
+);
+TownList['Goldenrod City'] = new Town(
+    'Goldenrod City',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 34)],
+        shop: GoldenrodCityShop,
+    }
+);
+TownList['Ecruteak City'] = new Town(
+    'Ecruteak City',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 37)],
+        shop: EcruteakCityShop,
+    }
+);
+TownList['Olivine City'] = new Town(
+    'Olivine City',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 39)],
+        shop: OlivineCityShop,
+    }
+);
+TownList['Cianwood City'] = new Town(
+    'Cianwood City',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 41)],
+        shop: CianwoodCityShop,
+    }
+);
+TownList['Mahogany Town'] = new Town(
+    'Mahogany Town',
+    GameConstants.Region.johto,
+    {
+        requirements: [new RouteKillRequirement(10, 42)],
+        shop: MahoganyTownShop,
+    }
+);
+TownList['Blackthorn City'] = new Town(
+    'Blackthorn City',
+    GameConstants.Region.johto,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ice Path'))],
+        shop: BlackthornCityShop,
+    }
+);
 
 //Johto Dungeons
-TownList['Sprout Tower'] = new DungeonTown('Sprout Tower', [new RouteKillRequirement(10, 31)]);
-TownList['Ruins of Alph'] = new DungeonTown('Ruins of Alph', [new RouteKillRequirement(10, 32)]);
-TownList['Union Cave'] = new DungeonTown('Union Cave', [new RouteKillRequirement(10, 32)]);
-TownList['Slowpoke Well'] = new DungeonTown('Slowpoke Well', [new RouteKillRequirement(10, 33)]);
-TownList['Ilex Forest'] = new DungeonTown('Ilex Forest', [new GymBadgeRequirement(BadgeCase.Badge.Hive)]);
-TownList['Burned Tower'] = new DungeonTown('Burned Tower', [new RouteKillRequirement(10, 37)]);
-TownList['Tin Tower'] = new DungeonTown('Tin Tower', [new GymBadgeRequirement(BadgeCase.Badge.Mineral), new GymBadgeRequirement(BadgeCase.Badge.Glacier)]);
-TownList['Whirl Islands'] = new DungeonTown('Whirl Islands', [new GymBadgeRequirement(BadgeCase.Badge.Mineral), new GymBadgeRequirement(BadgeCase.Badge.Glacier)]);
-TownList['Mt Mortar'] = new DungeonTown('Mt Mortar', [new RouteKillRequirement(10, 42)]);
-TownList['Ice Path'] = new DungeonTown('Ice Path', [new RouteKillRequirement(10, 44)]);
-TownList['Dark Cave'] = new DungeonTown('Dark Cave', [new RouteKillRequirement(10, 45)]);
-TownList['Mt Silver'] = new DungeonTown('Mt Silver', [new RouteKillRequirement(10, 28)]);
+TownList['Sprout Tower'] = new DungeonTown(
+    'Sprout Tower',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 31)]
+);
+TownList['Ruins of Alph'] = new DungeonTown(
+    'Ruins of Alph',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 32)]
+);
+TownList['Union Cave'] = new DungeonTown(
+    'Union Cave',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 32)]
+);
+TownList['Slowpoke Well'] = new DungeonTown(
+    'Slowpoke Well',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 33)]
+);
+TownList['Ilex Forest'] = new DungeonTown(
+    'Ilex Forest',
+    GameConstants.Region.johto,
+    [new GymBadgeRequirement(BadgeCase.Badge.Hive)]
+);
+TownList['Burned Tower'] = new DungeonTown(
+    'Burned Tower',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 37)]
+);
+TownList['Tin Tower'] = new DungeonTown(
+    'Tin Tower',
+    GameConstants.Region.johto,
+    [
+        new GymBadgeRequirement(BadgeCase.Badge.Mineral),
+        new GymBadgeRequirement(BadgeCase.Badge.Glacier),
+    ]
+);
+TownList['Whirl Islands'] = new DungeonTown(
+    'Whirl Islands',
+    GameConstants.Region.johto,
+    [
+        new GymBadgeRequirement(BadgeCase.Badge.Mineral),
+        new GymBadgeRequirement(BadgeCase.Badge.Glacier),
+    ]
+);
+TownList['Mt Mortar'] = new DungeonTown(
+    'Mt Mortar',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 42)]
+);
+TownList['Ice Path'] = new DungeonTown(
+    'Ice Path',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 44)]
+);
+TownList['Dark Cave'] = new DungeonTown(
+    'Dark Cave',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 45)]
+);
+TownList['Mt Silver'] = new DungeonTown(
+    'Mt Silver',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, 28)]
+);
 
 //Hoenn Shops
 const LittleRootTownShop = new Shop([
@@ -278,41 +548,244 @@ const BattleFrontierShop = new Shop([
 ]);
 
 //Hoenn Towns
-TownList['Littleroot Town'] = new Town('Littleroot Town', [], LittleRootTownShop);
-TownList['Oldale Town'] = new Town('Oldale Town', [new RouteKillRequirement(10, 101)]);
-TownList['Petalburg City'] = new Town('Petalburg City', [new RouteKillRequirement(10, 102)]);
-TownList['Rustboro City'] = new Town('Rustboro City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Petalburg Woods'))], RustboroCityShop);
-TownList['Dewford Town'] = new Town('Dewford Town', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Rusturf Tunnel'))], DewfordTownShop);
-TownList['Slateport City'] = new Town('Slateport City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Granite Cave')), new GymBadgeRequirement(BadgeCase.Badge.Knuckle)], SlateportCityShop);
-TownList['Mauville City'] = new Town('Mauville City', [new RouteKillRequirement(10, 110)], MauvilleCityShop);
-TownList['Verdanturf Town'] = new Town('Verdanturf Town', [new RouteKillRequirement(10, 117)], VerdanturfTownShop);
-TownList['Lavaridge Town'] = new Town('Lavaridge Town', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Jagged Pass'))], LavaridgeTownShop);
-TownList['Fallarbor Town'] = new Town('Fallarbor Town', [new RouteKillRequirement(10, 113)], FallarborTownShop);
-TownList['Fortree City'] = new Town('Fortree City', [new RouteKillRequirement(10, 119)], FortreeCityShop);
-TownList['LilyCove City'] = new Town('LilyCove City', [new RouteKillRequirement(10, 121)], LilyCoveCityShop);
-TownList['Mossdeep City'] = new Town('Mossdeep City', [new RouteKillRequirement(10, 125)], MossdeepCityShop);
-TownList['Sootopolis City'] = new Town('Sootopolis City', [new RouteKillRequirement(10, 126), new GymBadgeRequirement(BadgeCase.Badge.Mind)], SootopolisCityShop);
-TownList['Ever Grande City'] = new Town('Ever Grande City', [new GymBadgeRequirement(BadgeCase.Badge.Rain)], EverGrandeCityShop);
-TownList['Pokemon League Hoenn'] = new Town('Pokemon League', [new RouteKillRequirement(10, 128), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Hoenn'))]);
-TownList['Pacifidlog Town'] = new Town('Pacifidlog Town', [new RouteKillRequirement(10, 131)], PacifidlogTownShop);
-TownList['Battle Frontier'] = new Town('Battle Frontier', [new GymBadgeRequirement(BadgeCase.Badge.Elite_HoennChampion)], BattleFrontierShop);
+TownList['Littleroot Town'] = new Town(
+    'Littleroot Town',
+    GameConstants.Region.hoenn,
+    {
+        shop: LittleRootTownShop,
+    }
+);
+TownList['Oldale Town'] = new Town(
+    'Oldale Town',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 101)],
+    }
+);
+TownList['Petalburg City'] = new Town(
+    'Petalburg City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 102)],
+    }
+);
+TownList['Rustboro City'] = new Town(
+    'Rustboro City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Petalburg Woods'))],
+        shop: RustboroCityShop,
+    }
+);
+TownList['Dewford Town'] = new Town(
+    'Dewford Town',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Rusturf Tunnel'))],
+        shop: DewfordTownShop,
+    }
+);
+TownList['Slateport City'] = new Town(
+    'Slateport City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [
+            new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Granite Cave')),
+            new GymBadgeRequirement(BadgeCase.Badge.Knuckle),
+        ],
+        shop: SlateportCityShop,
+    }
+);
+TownList['Mauville City'] = new Town(
+    'Mauville City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 110)],
+        shop: MauvilleCityShop,
+    }
+);
+TownList['Verdanturf Town'] = new Town(
+    'Verdanturf Town',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 117)],
+        shop: VerdanturfTownShop,
+    }
+);
+TownList['Lavaridge Town'] = new Town(
+    'Lavaridge Town',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Jagged Pass'))],
+        shop: LavaridgeTownShop,
+    }
+);
+TownList['Fallarbor Town'] = new Town(
+    'Fallarbor Town',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 113)],
+        shop: FallarborTownShop,
+    }
+);
+TownList['Fortree City'] = new Town(
+    'Fortree City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 119)],
+        shop: FortreeCityShop,
+    }
+);
+TownList['LilyCove City'] = new Town(
+    'LilyCove City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 121)],
+        shop: LilyCoveCityShop,
+    }
+);
+TownList['Mossdeep City'] = new Town(
+    'Mossdeep City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 125)],
+        shop: MossdeepCityShop,
+    }
+);
+TownList['Sootopolis City'] = new Town(
+    'Sootopolis City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 126), new GymBadgeRequirement(BadgeCase.Badge.Mind)],
+        shop: SootopolisCityShop,
+    }
+);
+TownList['Ever Grande City'] = new Town(
+    'Ever Grande City',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new GymBadgeRequirement(BadgeCase.Badge.Rain)],
+        shop: EverGrandeCityShop,
+    }
+);
+TownList['Pokemon League Hoenn'] = new Town(
+    'Pokemon League',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [
+            new RouteKillRequirement(10, 128),
+            new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Hoenn')),
+        ],
+    }
+);
+TownList['Pacifidlog Town'] = new Town(
+    'Pacifidlog Town',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new RouteKillRequirement(10, 131)],
+        shop: PacifidlogTownShop,
+    }
+);
+TownList['Battle Frontier'] = new Town(
+    'Battle Frontier',
+    GameConstants.Region.hoenn,
+    {
+        requirements: [new GymBadgeRequirement(BadgeCase.Badge.Elite_HoennChampion)],
+        shop: BattleFrontierShop,
+    }
+);
 
 //Hoenn Dungeons
-TownList['Petalburg Woods'] = new DungeonTown('Petalburg Woods', [new RouteKillRequirement(10, 104)]);
-TownList['Rusturf Tunnel'] = new DungeonTown('Rusturf Tunnel', [new RouteKillRequirement(10, 116), new GymBadgeRequirement(BadgeCase.Badge.Stone)]);
-TownList['Granite Cave'] = new DungeonTown('Granite Cave', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Rusturf Tunnel'))]);
-TownList['Fiery Path'] = new DungeonTown('Fiery Path', [new RouteKillRequirement(10, 112)]);
-TownList['Meteor Falls'] = new DungeonTown('Meteor Falls', [new RouteKillRequirement(10, 114)]);
-TownList['Mt. Chimney'] = new DungeonTown('Mt. Chimney', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Meteor Falls'))]);
-TownList['Jagged Pass'] = new DungeonTown('Jagged Pass', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Mt. Chimney'))]);
-TownList['New Mauville'] = new DungeonTown('New Mauville', [new GymBadgeRequirement(BadgeCase.Badge.Balance)]);
-TownList['Mt. Pyre'] = new DungeonTown('Mt. Pyre', [new RouteKillRequirement(10, 122)]);
-TownList['Shoal Cave'] = new DungeonTown('Shoal Cave', [new RouteKillRequirement(10, 125)]);
-TownList['Cave of Origin'] = new DungeonTown('Cave of Origin', [new RouteKillRequirement(10, 126),new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Seafloor Cavern'))]);
-TownList['Seafloor Cavern'] = new DungeonTown('Seafloor Cavern', [new RouteKillRequirement(10, 128), new GymBadgeRequirement(BadgeCase.Badge.Mind)]);
-TownList['Sky Pillar'] = new DungeonTown('Sky Pillar', [new RouteKillRequirement(10, 131), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Cave of Origin'))]);
-TownList['Victory Road Hoenn'] = new DungeonTown('Victory Road Hoenn', [new GymBadgeRequirement(BadgeCase.Badge.Rain)]);
-TownList['Sealed Chamber'] = new DungeonTown('Sealed Chamber', [new RouteKillRequirement(10, 134),new GymBadgeRequirement(BadgeCase.Badge.Mind)]);
+TownList['Petalburg Woods'] = new DungeonTown(
+    'Petalburg Woods',
+    GameConstants.Region.hoenn,
+    [new RouteKillRequirement(10, 104)]
+);
+TownList['Rusturf Tunnel'] = new DungeonTown(
+    'Rusturf Tunnel',
+    GameConstants.Region.hoenn,
+    [
+        new RouteKillRequirement(10, 116),
+        new GymBadgeRequirement(BadgeCase.Badge.Stone),
+    ]
+);
+TownList['Granite Cave'] = new DungeonTown(
+    'Granite Cave',
+    GameConstants.Region.hoenn,
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Rusturf Tunnel'))]
+);
+TownList['Fiery Path'] = new DungeonTown(
+    'Fiery Path',
+    GameConstants.Region.hoenn,
+    [new RouteKillRequirement(10, 112)]
+);
+TownList['Meteor Falls'] = new DungeonTown(
+    'Meteor Falls',
+    GameConstants.Region.hoenn,
+    [new RouteKillRequirement(10, 114)]
+);
+TownList['Mt. Chimney'] = new DungeonTown(
+    'Mt. Chimney',
+    GameConstants.Region.hoenn,
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Meteor Falls'))]
+);
+TownList['Jagged Pass'] = new DungeonTown(
+    'Jagged Pass',
+    GameConstants.Region.hoenn,
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Mt. Chimney'))]
+);
+TownList['New Mauville'] = new DungeonTown(
+    'New Mauville',
+    GameConstants.Region.hoenn,
+    [new GymBadgeRequirement(BadgeCase.Badge.Balance)]
+);
+TownList['Mt. Pyre'] = new DungeonTown(
+    'Mt. Pyre',
+    GameConstants.Region.hoenn,
+    [new RouteKillRequirement(10, 122)]
+);
+TownList['Shoal Cave'] = new DungeonTown(
+    'Shoal Cave',
+    GameConstants.Region.hoenn,
+    [new RouteKillRequirement(10, 125)]
+);
+TownList['Cave of Origin'] = new DungeonTown(
+    'Cave of Origin',
+    GameConstants.Region.hoenn,
+    [
+        new RouteKillRequirement(10, 126),
+        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Seafloor Cavern')),
+    ]
+);
+TownList['Seafloor Cavern'] = new DungeonTown(
+    'Seafloor Cavern',
+    GameConstants.Region.hoenn,
+    [
+        new RouteKillRequirement(10, 128),
+        new GymBadgeRequirement(BadgeCase.Badge.Mind),
+    ]
+);
+TownList['Sky Pillar'] = new DungeonTown(
+    'Sky Pillar',
+    GameConstants.Region.hoenn,
+    [
+        new RouteKillRequirement(10, 131),
+        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Cave of Origin')),
+    ]
+);
+TownList['Victory Road Hoenn'] = new DungeonTown(
+    'Victory Road Hoenn',
+    GameConstants.Region.hoenn,
+    [new GymBadgeRequirement(BadgeCase.Badge.Rain)]
+);
+TownList['Sealed Chamber'] = new DungeonTown(
+    'Sealed Chamber',
+    GameConstants.Region.hoenn,
+    [
+        new RouteKillRequirement(10, 134),
+        new GymBadgeRequirement(BadgeCase.Badge.Mind),
+    ]
+);
 
 //Sinnoh Shops
 const TwinleafTownShop = new Shop([
@@ -380,47 +853,295 @@ const PastoriaShop = new Shop([
 ]);
 
 //Sinnoh Towns
-TownList['Twinleaf Town'] = new Town('Twinleaf Town', [], TwinleafTownShop);
-TownList['Sandgem Town'] = new Town('Sandgem Town', [new RouteKillRequirement(10, 201)]);
-TownList['Jubilife City'] = new Town('Jubilife City', [new RouteKillRequirement(10, 202)]);
-TownList['Oreburgh City'] = new Town('Oreburgh City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Oreburgh Gate'))], OreburghCityShop);
-TownList['Floaroma Town'] = new Town('Floaroma Town', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ravaged Path'))]);
-TownList['Eterna City'] = new Town('Eterna City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Eterna Forest'))], EternaCityShop);
-TownList['Hearthome City'] = new Town('Hearthome City', [new RouteKillRequirement(10, 208)], HearthomeCityShop);
-TownList['Solaceon Town'] = new Town('Solaceon Town', [new RouteKillRequirement(10, 209)], SolaceonTownShop);
-TownList['Veilstone City'] = new Town('Veilstone City', [new RouteKillRequirement(10, 215)], VeilstoneCityShop);
-TownList['Pastoria City'] = new Town('Pastoria City', [new RouteKillRequirement(10, 213)], PastoriaShop);
-TownList['Celestic Town'] = new Town('Celestic Town', [new RouteKillRequirement(10, 210), new GymBadgeRequirement(BadgeCase.Badge.Fen)], CelesticTownShop);
-TownList['Pal Park'] = new Town('Pal Park', [new RouteKillRequirement(10, 221)], PalParkShop);
-TownList['Canalave City'] = new Town('Canalave City', [new RouteKillRequirement(10, 218)], CanalaveCityShop);
-TownList['Snowpoint City'] = new Town('Snowpoint City', [new RouteKillRequirement(10, 217)]);
-TownList['Sunyshore City'] = new Town('Sunyshore City', [new RouteKillRequirement(10, 222)], SunyshoreCityShop);
-TownList['Pokemon League Sinnoh'] = new Town('Pokemon League Sinnoh', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Sinnoh'))]);
-TownList['Fight Area'] = new Town('Fight Area', [new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]);
-TownList['Survival Area'] = new Town('Survival Area', [new RouteKillRequirement(10, 225)], SurvivalAreaShop);
-TownList['Resort Area'] = new Town('Resort Area', [new RouteKillRequirement(10, 229)], ResortAreaShop);
+TownList['Twinleaf Town'] = new Town(
+    'Twinleaf Town',
+    GameConstants.Region.sinnoh,
+    {
+        shop: TwinleafTownShop,
+    }
+);
+TownList['Sandgem Town'] = new Town(
+    'Sandgem Town',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 201)],
+    }
+);
+TownList['Jubilife City'] = new Town(
+    'Jubilife City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 202)],
+    }
+);
+TownList['Oreburgh City'] = new Town(
+    'Oreburgh City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Oreburgh Gate'))],
+        shop: OreburghCityShop,
+    }
+);
+TownList['Floaroma Town'] = new Town(
+    'Floaroma Town',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ravaged Path'))],
+    }
+);
+TownList['Eterna City'] = new Town(
+    'Eterna City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Eterna Forest'))],
+        shop: EternaCityShop,
+    }
+);
+TownList['Hearthome City'] = new Town(
+    'Hearthome City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 208)],
+        shop: HearthomeCityShop,
+    }
+);
+TownList['Solaceon Town'] = new Town(
+    'Solaceon Town',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 209)],
+        shop: SolaceonTownShop,
+    }
+);
+TownList['Veilstone City'] = new Town(
+    'Veilstone City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 215)],
+        shop: VeilstoneCityShop,
+    }
+);
+TownList['Pastoria City'] = new Town(
+    'Pastoria City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 213)],
+        shop: PastoriaShop,
+    }
+);
+TownList['Celestic Town'] = new Town(
+    'Celestic Town',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [
+            new RouteKillRequirement(10, 210),
+            new GymBadgeRequirement(BadgeCase.Badge.Fen),
+        ],
+        shop: CelesticTownShop,
+    }
+);
+TownList['Pal Park'] = new Town(
+    'Pal Park',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 221)],
+        shop: PalParkShop,
+    }
+);
+TownList['Canalave City'] = new Town(
+    'Canalave City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 218)],
+        shop: CanalaveCityShop,
+    }
+);
+TownList['Snowpoint City'] = new Town(
+    'Snowpoint City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 217)],
+    }
+);
+TownList['Sunyshore City'] = new Town(
+    'Sunyshore City',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 222)],
+        shop: SunyshoreCityShop,
+    }
+);
+TownList['Pokemon League Sinnoh'] = new Town(
+    'Pokemon League Sinnoh',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Sinnoh'))],
+    }
+);
+TownList['Fight Area'] = new Town(
+    'Fight Area',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)],
+    }
+);
+TownList['Survival Area'] = new Town(
+    'Survival Area',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 225)],
+        shop: SurvivalAreaShop,
+    }
+);
+TownList['Resort Area'] = new Town(
+    'Resort Area',
+    GameConstants.Region.sinnoh,
+    {
+        requirements: [new RouteKillRequirement(10, 229)],
+        shop: ResortAreaShop,
+    }
+);
 
 //Sinnoh Dungeons
-TownList['Oreburgh Gate'] = new DungeonTown('Oreburgh Gate', [new RouteKillRequirement(10, 203)]);
-TownList['Ravaged Path'] = new DungeonTown('Ravaged Path', [new RouteKillRequirement(10, 204), new GymBadgeRequirement(BadgeCase.Badge.Coal)]);
-TownList['Eterna Forest'] = new DungeonTown('Eterna Forest', [new RouteKillRequirement(10, 205), new GymBadgeRequirement(BadgeCase.Badge.Coal)]);
-TownList['Old Chateau'] = new DungeonTown('Old Chateau', [new RouteKillRequirement(10, 205), new GymBadgeRequirement(BadgeCase.Badge.Forest)]);
-TownList['Wayward Cave'] = new DungeonTown('Wayward Cave', [new RouteKillRequirement(10, 206)]);
-TownList['Mt. Coronet South'] = new DungeonTown('Mt. Coronet South', [new RouteKillRequirement(10, 207)]);
-TownList['Iron Island'] = new DungeonTown('Iron Island', [new RouteKillRequirement(10, 218)]);
-TownList['Mt. Coronet North'] = new DungeonTown('Mt. Coronet North', [new RouteKillRequirement(10, 211), new GymBadgeRequirement(BadgeCase.Badge.Mine)]);
-TownList['Distortion World'] = new DungeonTown('Distortion World', [new RouteKillRequirement(10, 214), new GymBadgeRequirement(BadgeCase.Badge.Icicle)]);
-TownList['Lake Valor'] = new DungeonTown('Lake Valor', [new RouteKillRequirement(10, 213), new GymBadgeRequirement(BadgeCase.Badge.Icicle)]);
-TownList['Lake Verity'] = new DungeonTown('Lake Verity', [new RouteKillRequirement(10, 201), new GymBadgeRequirement(BadgeCase.Badge.Icicle)]);
-TownList['Lake Acuity'] = new DungeonTown('Lake Acuity', [new RouteKillRequirement(10, 217), new GymBadgeRequirement(BadgeCase.Badge.Icicle)]);
-TownList['Victory Road Sinnoh'] = new DungeonTown('Victory Road Sinnoh', [new RouteKillRequirement(10, 223), new GymBadgeRequirement(BadgeCase.Badge.Beacon)]);
-TownList['Spear Pillar'] = new DungeonTown('Spear Pillar', [new RouteKillRequirement(10, 211), new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]);
-TownList['Hall of Origin'] = new DungeonTown('Hall of Origin', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Spear Pillar'))]);
-TownList['Fullmoon Island'] = new DungeonTown('Fullmoon Island', [new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]);
-TownList['Newmoon Island'] = new DungeonTown('Newmoon Island', [new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]);
-TownList['Flower Paradise'] = new DungeonTown('Flower Paradise', [new RouteKillRequirement(10, 224), new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]);
-TownList['Stark Mountain'] = new DungeonTown('Stark Mountain', [new RouteKillRequirement(10, 227), new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]);
-TownList['Snowpoint Temple'] = new DungeonTown('Snowpoint Temple', [new RouteKillRequirement(10, 217), new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]);
+TownList['Oreburgh Gate'] = new DungeonTown(
+    'Oreburgh Gate',
+    GameConstants.Region.sinnoh,
+    [new RouteKillRequirement(10, 203)]
+);
+TownList['Ravaged Path'] = new DungeonTown(
+    'Ravaged Path',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 204),
+        new GymBadgeRequirement(BadgeCase.Badge.Coal),
+    ]
+);
+TownList['Eterna Forest'] = new DungeonTown(
+    'Eterna Forest',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 205),
+        new GymBadgeRequirement(BadgeCase.Badge.Coal),
+    ]
+);
+TownList['Old Chateau'] = new DungeonTown(
+    'Old Chateau',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 205),
+        new GymBadgeRequirement(BadgeCase.Badge.Forest),
+    ]
+);
+TownList['Wayward Cave'] = new DungeonTown(
+    'Wayward Cave',
+    GameConstants.Region.sinnoh,
+    [new RouteKillRequirement(10, 206)]
+);
+TownList['Mt. Coronet South'] = new DungeonTown(
+    'Mt. Coronet South',
+    GameConstants.Region.sinnoh,
+    [new RouteKillRequirement(10, 207)]
+);
+TownList['Iron Island'] = new DungeonTown(
+    'Iron Island',
+    GameConstants.Region.sinnoh,
+    [new RouteKillRequirement(10, 218)]
+);
+TownList['Mt. Coronet North'] = new DungeonTown(
+    'Mt. Coronet North',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 211),
+        new GymBadgeRequirement(BadgeCase.Badge.Mine),
+    ]
+);
+TownList['Distortion World'] = new DungeonTown(
+    'Distortion World',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 214),
+        new GymBadgeRequirement(BadgeCase.Badge.Icicle),
+    ]
+);
+TownList['Lake Valor'] = new DungeonTown(
+    'Lake Valor',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 213),
+        new GymBadgeRequirement(BadgeCase.Badge.Icicle),
+    ]
+);
+TownList['Lake Verity'] = new DungeonTown(
+    'Lake Verity',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 201),
+        new GymBadgeRequirement(BadgeCase.Badge.Icicle),
+    ]
+);
+TownList['Lake Acuity'] = new DungeonTown(
+    'Lake Acuity',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 217),
+        new GymBadgeRequirement(BadgeCase.Badge.Icicle),
+    ]
+);
+TownList['Victory Road Sinnoh'] = new DungeonTown(
+    'Victory Road Sinnoh',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 223),
+        new GymBadgeRequirement(BadgeCase.Badge.Beacon),
+    ]
+);
+TownList['Spear Pillar'] = new DungeonTown(
+    'Spear Pillar',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 211),
+        new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion),
+    ]
+);
+TownList['Hall of Origin'] = new DungeonTown(
+    'Hall of Origin',
+    GameConstants.Region.sinnoh,
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Spear Pillar'))]
+);
+TownList['Fullmoon Island'] = new DungeonTown(
+    'Fullmoon Island',
+    GameConstants.Region.sinnoh,
+    [new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]
+);
+TownList['Newmoon Island'] = new DungeonTown(
+    'Newmoon Island',
+    GameConstants.Region.sinnoh,
+    [new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion)]
+);
+TownList['Flower Paradise'] = new DungeonTown(
+    'Flower Paradise',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 224),
+        new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion),
+    ]
+);
+TownList['Stark Mountain'] = new DungeonTown(
+    'Stark Mountain',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 227),
+        new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion),
+    ]
+);
+TownList['Snowpoint Temple'] = new DungeonTown(
+    'Snowpoint Temple',
+    GameConstants.Region.sinnoh,
+    [
+        new RouteKillRequirement(10, 217),
+        new GymBadgeRequirement(BadgeCase.Badge.Elite_SinnohChampion),
+    ]
+);
 
 //Unova Shops
 const AspertiaCityShop = new Shop([
@@ -482,75 +1203,339 @@ const AccumulaTownShop = new Shop([
 ]);
 
 //Unova Towns
-TownList['Aspertia City'] = new Town('Aspertia City', [], AspertiaCityShop);
-TownList['Floccesy Town'] = new Town('Floccesy Town', [new RouteKillRequirement(10, 19)]);
-TownList['Virbank City'] = new Town('Virbank City', [new GymBadgeRequirement(BadgeCase.Badge.Basic)], VirbankCityShop);
-TownList['Castelia City'] = new Town('Castelia City', [new GymBadgeRequirement(BadgeCase.Badge.Toxic)], CasteliaCityShop, dungeonList['Castelia Sewers']);
-TownList['Nimbasa City'] = new Town('Nimbasa City', [new RouteKillRequirement(10, 4), new GymBadgeRequirement(BadgeCase.Badge.Insect)], NimbasaCityShop);
-TownList['Driftveil City'] = new Town('Driftveil City', [new RouteKillRequirement(10,5), new GymBadgeRequirement(BadgeCase.Badge.Bolt)]);
-TownList['Mistralton City'] = new Town('Mistralton City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Chargestone Cave')), new GymBadgeRequirement(BadgeCase.Badge.Quake)], MistraltonCityShop);
-TownList['Lentimas Town'] = new Town('Lentimas Town', [new GymBadgeRequirement(BadgeCase.Badge.Jet)], LentimasTownShop);
-TownList['Undella Town'] = new Town('Undella Town', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Reversal Mountain'))]);
-TownList['Lacunosa Town'] = new Town('Lacunosa Town', [new RouteKillRequirement(10, 13)], LacunosaTownShop);
-TownList['Opelucid City'] = new Town('Opelucid City', [new RouteKillRequirement(10, 11)], OpelucidCityShop);
-TownList['Humilau City'] = new Town('Humilau City', [new RouteKillRequirement(10, 21)]);
-TownList['Pokemon League Unova'] = new Town('Pokemon League Unova', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Unova'))]);
-TownList['Icirrus City'] = new Town('Icirrus City', [new OneFromManyRequirement([new RouteKillRequirement(10, 8), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Twist Mountain'))])], IcirrusCityShop);
-TownList['Black and White Park'] = new Town('Black and White Park', [
-    new OneFromManyRequirement([
-        new MultiRequirement([
-            new GymBadgeRequirement(BadgeCase.Badge.Elite_UnovaChampion),
-            new RouteKillRequirement(10, 14),
-        ]),
-        new RouteKillRequirement(10, 15),
-    ]),
-], BlackAndWhiteParkShop);
-TownList['Nacrene City'] = new Town('Nacrene City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Pinwheel Forest'))], NacreneCityShop);
-TownList['Striatorn City'] = new Town('Striatorn City', [new RouteKillRequirement(10, 3)], StriatornCityShop);
-TownList['Accumula Town'] = new Town('Accumula Town', [new RouteKillRequirement(10, 2)], AccumulaTownShop);
-TownList['Nuvema Town'] = new Town('Nuvema Town', [new RouteKillRequirement(10, 1)]);
+TownList['Aspertia City'] = new Town(
+    'Aspertia City',
+    GameConstants.Region.unova,
+    {
+        shop: AspertiaCityShop,
+    }
+);
+TownList['Floccesy Town'] = new Town(
+    'Floccesy Town',
+    GameConstants.Region.unova,
+    {
+        requirements: [new RouteKillRequirement(10, 19)],
+    }
+);
+TownList['Virbank City'] = new Town(
+    'Virbank City',
+    GameConstants.Region.unova,
+    {
+        requirements: [new GymBadgeRequirement(BadgeCase.Badge.Basic)],
+        shop: VirbankCityShop,
+    }
+);
+TownList['Castelia City'] = new Town(
+    'Castelia City',
+    GameConstants.Region.unova,
+    {
+        requirements: [new GymBadgeRequirement(BadgeCase.Badge.Toxic)],
+        shop: CasteliaCityShop,
+        dungeon: dungeonList['Castelia Sewers'],
+    }
+);
+TownList['Nimbasa City'] = new Town(
+    'Nimbasa City',
+    GameConstants.Region.unova,
+    {
+        requirements: [
+            new RouteKillRequirement(10, 4),
+            new GymBadgeRequirement(BadgeCase.Badge.Insect),
+        ],
+        shop: NimbasaCityShop,
+    }
+);
+TownList['Driftveil City'] = new Town(
+    'Driftveil City',
+    GameConstants.Region.unova,
+    {
+        requirements: [
+            new RouteKillRequirement(10,5),
+            new GymBadgeRequirement(BadgeCase.Badge.Bolt),
+        ],
+    }
+);
+TownList['Mistralton City'] = new Town(
+    'Mistralton City',
+    GameConstants.Region.unova,
+    {
+        requirements: [
+            new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Chargestone Cave')),
+            new GymBadgeRequirement(BadgeCase.Badge.Quake),
+        ],
+        shop: MistraltonCityShop,
+    }
+);
+TownList['Lentimas Town'] = new Town(
+    'Lentimas Town',
+    GameConstants.Region.unova,
+    {
+        requirements: [new GymBadgeRequirement(BadgeCase.Badge.Jet)],
+        shop: LentimasTownShop,
+    }
+);
+TownList['Undella Town'] = new Town(
+    'Undella Town',
+    GameConstants.Region.unova,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Reversal Mountain'))],
+    }
+);
+TownList['Lacunosa Town'] = new Town(
+    'Lacunosa Town',
+    GameConstants.Region.unova,
+    {
+        requirements: [new RouteKillRequirement(10, 13)],
+        shop: LacunosaTownShop,
+    }
+);
+TownList['Opelucid City'] = new Town(
+    'Opelucid City',
+    GameConstants.Region.unova,
+    {
+        requirements: [new RouteKillRequirement(10, 11)],
+        shop: OpelucidCityShop,
+    }
+);
+TownList['Humilau City'] = new Town(
+    'Humilau City',
+    GameConstants.Region.unova,
+    {
+        requirements: [new RouteKillRequirement(10, 21)],
+    }
+);
+TownList['Pokemon League Unova'] = new Town(
+    'Pokemon League Unova',
+    GameConstants.Region.unova,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Unova'))],
+    }
+);
+TownList['Icirrus City'] = new Town(
+    'Icirrus City',
+    GameConstants.Region.unova,
+    {
+        requirements: [new OneFromManyRequirement([
+            new RouteKillRequirement(10, 8),
+            new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Twist Mountain')),
+        ])],
+        shop: IcirrusCityShop,
+    }
+);
+TownList['Black and White Park'] = new Town(
+    'Black and White Park',
+    GameConstants.Region.unova,
+    {
+        requirements: [new OneFromManyRequirement([
+            new MultiRequirement([
+                new GymBadgeRequirement(BadgeCase.Badge.Elite_UnovaChampion),
+                new RouteKillRequirement(10, 14),
+            ]),
+            new RouteKillRequirement(10, 15),
+        ])],
+        shop: BlackAndWhiteParkShop,
+    }
+);
+TownList['Nacrene City'] = new Town(
+    'Nacrene City',
+    GameConstants.Region.unova,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Pinwheel Forest'))],
+        shop: NacreneCityShop,
+    }
+);
+TownList['Striatorn City'] = new Town(
+    'Striatorn City',
+    GameConstants.Region.unova,
+    {
+        requirements: [new RouteKillRequirement(10, 3)],
+        shop: StriatornCityShop,
+    }
+);
+TownList['Accumula Town'] = new Town(
+    'Accumula Town',
+    GameConstants.Region.unova,
+    {
+        requirements: [new RouteKillRequirement(10, 2)],
+        shop: AccumulaTownShop,
+    }
+);
+TownList['Nuvema Town'] = new Town(
+    'Nuvema Town',
+    GameConstants.Region.unova,
+    {
+        requirements: [new RouteKillRequirement(10, 1)],
+    }
+);
 
 //Unova Dungeons
-TownList['Pledge Grove'] = new DungeonTown('Pledge Grove', [new ObtainedPokemonRequirement(pokemonMap.Keldeo)]);
-TownList['Floccesy Ranch'] = new DungeonTown('Floccesy Ranch', [new RouteKillRequirement(10, 20)]);
-TownList['Virbank Complex'] = new DungeonTown('Virbank Complex', [new GymBadgeRequirement(BadgeCase.Badge.Basic)]);    //Optional dungeon, no unique mons, safe to scrap
-TownList['Liberty Garden'] = new DungeonTown('Liberty Garden', [new GymBadgeRequirement(BadgeCase.Badge.Toxic)]);    //Victini dungeon, maybe unlock later
-TownList['Castelia Sewers'] = new DungeonTown('Castelia Sewers', [new GymBadgeRequirement(BadgeCase.Badge.Toxic)]);
-TownList['Relic Passage'] = new DungeonTown('Relic Passage', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Castelia Sewers'))]);
-TownList['Desert Resort'] = new DungeonTown('Desert Resort', [new RouteKillRequirement(10, 4), new GymBadgeRequirement(BadgeCase.Badge.Insect)]);    //Should really be a route
-TownList['Relic Castle'] = new DungeonTown('Relic Castle', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Desert Resort'))]);
-TownList['Lostlorn Forest'] = new DungeonTown('Lostlorn Forest', [new RouteKillRequirement(10, 16)]);
-TownList['Chargestone Cave'] = new DungeonTown('Chargestone Cave', [new RouteKillRequirement(10, 6)]);
-TownList['Mistralton Cave'] = new DungeonTown('Mistralton Cave', [new GymBadgeRequirement(BadgeCase.Badge.Quake)]);
-TownList['Celestial Tower'] = new DungeonTown('Celestial Tower', [new RouteKillRequirement(10, 7)]);
-TownList['Reversal Mountain'] = new DungeonTown('Reversal Mountain', [new GymBadgeRequirement(BadgeCase.Badge.Jet)]);
-TownList['Strange House'] = new DungeonTown('Strange House', [new GymBadgeRequirement(BadgeCase.Badge.Jet)]);    //Optional dungeon, no unique mons, safe to scrap
-TownList['Undella Bay'] = new DungeonTown('Undella Bay', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Reversal Mountain'))]);    //Should really be a route
-TownList['Seaside Cave'] = new DungeonTown('Seaside Cave', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Undella Bay')), new GymBadgeRequirement(BadgeCase.Badge.Legend)]);
-TownList['Giant Chasm'] = new DungeonTown('Giant Chasm', [new RouteKillRequirement(10, 22), new GymBadgeRequirement(BadgeCase.Badge.Wave)]);
-TownList['Cave of Being'] = new DungeonTown('Cave of Being', [new RouteKillRequirement(10, 23)]);
-TownList['Abundant Shrine'] = new DungeonTown('Abundant Shrine', [new RouteKillRequirement(10, 23), new ObtainedPokemonRequirement(pokemonMap.Tornadus), new ObtainedPokemonRequirement(pokemonMap.Thundurus)]);
-TownList['Victory Road'] = new DungeonTown('Victory Road', [new RouteKillRequirement(10, 23)]);
-TownList['Twist Mountain'] = new DungeonTown('Twist Mountain', [
-    new OneFromManyRequirement([
+TownList['Pledge Grove'] = new DungeonTown(
+    'Pledge Grove',
+    GameConstants.Region.unova,
+    [new ObtainedPokemonRequirement(pokemonMap.Keldeo)]
+);
+TownList['Floccesy Ranch'] = new DungeonTown(
+    'Floccesy Ranch',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 20)]
+);
+TownList['Virbank Complex'] = new DungeonTown(
+    'Virbank Complex',
+    GameConstants.Region.unova,
+    //Optional dungeon, no unique mons, safe to scrap
+    [new GymBadgeRequirement(BadgeCase.Badge.Basic)]
+);
+TownList['Liberty Garden'] = new DungeonTown(
+    'Liberty Garden',
+    GameConstants.Region.unova,
+    //Victini dungeon, maybe unlock later
+    [new GymBadgeRequirement(BadgeCase.Badge.Toxic)]
+);
+TownList['Castelia Sewers'] = new DungeonTown(
+    'Castelia Sewers',
+    GameConstants.Region.unova,
+    [new GymBadgeRequirement(BadgeCase.Badge.Toxic)]
+);
+TownList['Relic Passage'] = new DungeonTown(
+    'Relic Passage',
+    GameConstants.Region.unova,
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Castelia Sewers'))]
+);
+TownList['Desert Resort'] = new DungeonTown(
+    'Desert Resort',
+    GameConstants.Region.unova,
+    [
+        new RouteKillRequirement(10, 4),
+        new GymBadgeRequirement(BadgeCase.Badge.Insect), // Should really be a route
+    ]
+);
+TownList['Relic Castle'] = new DungeonTown(
+    'Relic Castle',
+    GameConstants.Region.unova,
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Desert Resort'))]
+);
+TownList['Lostlorn Forest'] = new DungeonTown(
+    'Lostlorn Forest',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 16)]
+);
+TownList['Chargestone Cave'] = new DungeonTown(
+    'Chargestone Cave',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 6)]
+);
+TownList['Mistralton Cave'] = new DungeonTown(
+    'Mistralton Cave',
+    GameConstants.Region.unova,
+    [new GymBadgeRequirement(BadgeCase.Badge.Quake)]
+);
+TownList['Celestial Tower'] = new DungeonTown(
+    'Celestial Tower',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 7)]
+);
+TownList['Reversal Mountain'] = new DungeonTown(
+    'Reversal Mountain',
+    GameConstants.Region.unova,
+    [new GymBadgeRequirement(BadgeCase.Badge.Jet)]
+);
+TownList['Strange House'] = new DungeonTown(
+    'Strange House',
+    GameConstants.Region.unova,
+    // Optional dungeon, no unique mons, safe to scrap
+    [new GymBadgeRequirement(BadgeCase.Badge.Jet)]
+);
+TownList['Undella Bay'] = new DungeonTown(
+    'Undella Bay',
+    GameConstants.Region.unova,
+    // Should really be a route
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Reversal Mountain'))]
+);
+TownList['Seaside Cave'] = new DungeonTown(
+    'Seaside Cave',
+    GameConstants.Region.unova,
+    [
+        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Undella Bay')),
+        new GymBadgeRequirement(BadgeCase.Badge.Legend),
+    ]
+);
+TownList['Giant Chasm'] = new DungeonTown(
+    'Giant Chasm',
+    GameConstants.Region.unova,
+    [
+        new RouteKillRequirement(10, 22),
+        new GymBadgeRequirement(BadgeCase.Badge.Wave),
+    ]
+);
+TownList['Cave of Being'] = new DungeonTown(
+    'Cave of Being',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 23)]
+);
+TownList['Abundant Shrine'] = new DungeonTown(
+    'Abundant Shrine',
+    GameConstants.Region.unova,
+    [
+        new RouteKillRequirement(10, 23),
+        new ObtainedPokemonRequirement(pokemonMap.Tornadus),
+        new ObtainedPokemonRequirement(pokemonMap.Thundurus),
+    ]
+);
+TownList['Victory Road'] = new DungeonTown(
+    'Victory Road',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 23)]
+);
+TownList['Twist Mountain'] = new DungeonTown(
+    'Twist Mountain',
+    GameConstants.Region.unova,
+    [new OneFromManyRequirement([
         new MultiRequirement([
             new GymBadgeRequirement(BadgeCase.Badge.Elite_UnovaChampion),
             new RouteKillRequirement(10, 7),
         ]),
         new RouteKillRequirement(10, 8),
-    ]),
-]);
-TownList['Dragonspiral Tower'] = new DungeonTown('Dragonspiral Tower', [
-    new OneFromManyRequirement([
+    ])]
+);
+TownList['Dragonspiral Tower'] = new DungeonTown(
+    'Dragonspiral Tower',
+    GameConstants.Region.unova,
+    [new OneFromManyRequirement([
         new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Twist Mountain')),
         new RouteKillRequirement(10, 8),
-    ]),
-]);
-TownList['Moor of Icirrus'] = new DungeonTown('Moor of Icirrus', [new RouteKillRequirement(10, 8), new ObtainedPokemonRequirement(pokemonMap.Cobalion), new ObtainedPokemonRequirement(pokemonMap.Terrakion), new ObtainedPokemonRequirement(pokemonMap.Virizion)]);
-TownList['Pinwheel Forest'] = new DungeonTown('Pinwheel Forest', [new GymBadgeRequirement(BadgeCase.Badge.Elite_UnovaChampion)]);
-TownList['Wellspring Cave'] = new DungeonTown('Wellspring Cave', [new RouteKillRequirement(10, 3)]);    //Optional dungeon, no unique mons, safe to scrap
-TownList['Dreamyard'] = new DungeonTown('Dreamyard', [new RouteKillRequirement(10, 3)]);
-TownList['P2 Laboratory'] = new DungeonTown('P2 Laboratory', [new RouteKillRequirement(10, 17)]);
+    ])]
+);
+TownList['Moor of Icirrus'] = new DungeonTown(
+    'Moor of Icirrus',
+    GameConstants.Region.unova,
+    [
+        new RouteKillRequirement(10, 8),
+        new ObtainedPokemonRequirement(pokemonMap.Cobalion),
+        new ObtainedPokemonRequirement(pokemonMap.Terrakion),
+        new ObtainedPokemonRequirement(pokemonMap.Virizion),
+    ]
+);
+TownList['Pinwheel Forest'] = new DungeonTown(
+    'Pinwheel Forest',
+    GameConstants.Region.unova,
+    [new GymBadgeRequirement(BadgeCase.Badge.Elite_UnovaChampion)]
+);
+TownList['Wellspring Cave'] = new DungeonTown(
+    'Wellspring Cave',
+    GameConstants.Region.unova,
+    // Optional dungeon, no unique mons, safe to scrap
+    [new RouteKillRequirement(10, 3)]
+);
+TownList['Dreamyard'] = new DungeonTown(
+    'Dreamyard',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 3)]
+);
+TownList['P2 Laboratory'] = new DungeonTown(
+    'P2 Laboratory',
+    GameConstants.Region.unova,
+    [new RouteKillRequirement(10, 17)]
+);
 
 //Kalos Shops
 const VanivilleTownShop = new Shop([
@@ -592,43 +1577,191 @@ const CouriwayTownShop = new Shop([
 ]);
 
 //Kalos Towns
-TownList['Vaniville Town'] = new Town('Vaniville Town', [], VanivilleTownShop);
-TownList['Aquacorde Town'] = new Town('Aquacorde Town');
-TownList['Santalune City'] = new Town('Santalune City', [new RouteKillRequirement(10, 3)], SantaluneCityShop);
-TownList['Lumiose City'] = new Town('Lumiose City', [new RouteKillRequirement(10, 3)], LumioseCityShop);
-TownList['Camphrier Town'] = new Town('Camphrier Town', [new RouteKillRequirement(10, 4)]);
-TownList['Ambrette Town'] = new Town('Ambrette Town', [new RouteKillRequirement(10, 8)], AmbretteTownShop);
-TownList['Cyllage City'] = new Town('Cyllage City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Glittering Cave'))]);
-TownList['Geosenge Town'] = new Town('Geosenge Town', [new RouteKillRequirement(10, 10)], GeosengeTownShop);
-TownList['Shalour City'] = new Town('Shalour City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Reflection Cave'))], ShalourCityShop);
-TownList['Coumarine City'] = new Town('Coumarine City', [new RouteKillRequirement(10, 12)], CoumarineCityShop);
-TownList['Laverre City'] = new Town('Laverre City', [new RouteKillRequirement(10, 14)], LaverreCityShop);
-TownList['Dendemille Town'] = new Town('Dendemille Town', [new RouteKillRequirement(10, 15)], DendemilleTownShop);
-TownList['Anistar City'] = new Town('Anistar City', [new RouteKillRequirement(10, 17)], AnistarCityShop);
-TownList['Couriway Town'] = new Town('Couriway Town', [new RouteKillRequirement(10, 18)], CouriwayTownShop);
-TownList['Snowbelle City'] = new Town('Snowbelle City', [new RouteKillRequirement(10, 19)]);
-TownList['Pokémon League Kalos'] = new Town('Pokémon League Kalos', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Kalos'))]);
+TownList['Vaniville Town'] = new Town(
+    'Vaniville Town',
+    GameConstants.Region.kalos,
+    {
+        shop: VanivilleTownShop,
+    }
+);
+TownList['Aquacorde Town'] = new Town('Aquacorde Town', GameConstants.Region.kalos);
+TownList['Santalune City'] = new Town(
+    'Santalune City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 3)],
+        shop: SantaluneCityShop,
+    }
+);
+TownList['Lumiose City'] = new Town(
+    'Lumiose City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 3)],
+        shop: LumioseCityShop,
+    }
+);
+TownList['Camphrier Town'] = new Town(
+    'Camphrier Town',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 4)],
+    }
+);
+TownList['Ambrette Town'] = new Town(
+    'Ambrette Town',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 8)],
+        shop: AmbretteTownShop,
+    }
+);
+TownList['Cyllage City'] = new Town(
+    'Cyllage City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Glittering Cave'))],
+    }
+);
+TownList['Geosenge Town'] = new Town(
+    'Geosenge Town',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 10)],
+        shop: GeosengeTownShop,
+    }
+);
+TownList['Shalour City'] = new Town(
+    'Shalour City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Reflection Cave'))],
+        shop: ShalourCityShop,
+    }
+);
+TownList['Coumarine City'] = new Town(
+    'Coumarine City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 12)],
+        shop: CoumarineCityShop,
+    }
+);
+TownList['Laverre City'] = new Town(
+    'Laverre City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 14)],
+        shop: LaverreCityShop,
+    }
+);
+TownList['Dendemille Town'] = new Town(
+    'Dendemille Town',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 15)],
+        shop: DendemilleTownShop,
+    }
+);
+TownList['Anistar City'] = new Town(
+    'Anistar City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 17)],
+        shop: AnistarCityShop,
+    }
+);
+TownList['Couriway Town'] = new Town(
+    'Couriway Town',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 18)],
+        shop: CouriwayTownShop,
+    }
+);
+TownList['Snowbelle City'] = new Town(
+    'Snowbelle City',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new RouteKillRequirement(10, 19)],
+    }
+);
+TownList['Pokémon League Kalos'] = new Town(
+    'Pokémon League Kalos',
+    GameConstants.Region.kalos,
+    {
+        requirements: [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Victory Road Kalos'))],
+    }
+);
 
 //Kalos Dungeons
-TownList['Santalune Forest'] = new DungeonTown('Santalune Forest', [new RouteKillRequirement(10, 2)]);
-TownList['Parfum Palace'] = new DungeonTown('Parfum Palace', [new RouteKillRequirement(10, 6)]);
-TownList['Connecting Cave'] = new DungeonTown('Connecting Cave', [new RouteKillRequirement(10, 7)]);
-TownList['Glittering Cave'] = new DungeonTown('Glittering Cave', [new RouteKillRequirement(10, 9)]);
-TownList['Reflection Cave'] = new DungeonTown('Reflection Cave', [new RouteKillRequirement(10, 11)]);
+TownList['Santalune Forest'] = new DungeonTown(
+    'Santalune Forest',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 2)]
+);
+TownList['Parfum Palace'] = new DungeonTown(
+    'Parfum Palace',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 6)]
+);
+TownList['Connecting Cave'] = new DungeonTown(
+    'Connecting Cave',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 7)]
+);
+TownList['Glittering Cave'] = new DungeonTown(
+    'Glittering Cave',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 9)]
+);
+TownList['Reflection Cave'] = new DungeonTown(
+    'Reflection Cave',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 11)]
+);
 //Tower of Mastery?
-TownList['Azure bay'] = new DungeonTown('Azure bay', [new RouteKillRequirement(10, 12)]);
+TownList['Azure bay'] = new DungeonTown(
+    'Azure bay',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 12)]
+);
 //Sea Spirit's Den?
 //Kalos Power Plant?
-TownList['Lost Hotel'] = new DungeonTown('Lost Hotel', [new RouteKillRequirement(10, 15)]);
-TownList['Frost Cavern'] = new DungeonTown('Frost Cavern', [new RouteKillRequirement(10, 15)]);
-TownList['Team Flare Secret HQ'] = new DungeonTown('Team Flare Secret HQ', [new GymBadgeRequirement(BadgeCase.Badge.Psychic)]);
-TownList['Terminus Cave'] = new DungeonTown('Terminus Cave', [new RouteKillRequirement(10, 18)]);
-TownList['Pokémon Village'] = new DungeonTown('Pokémon Village', [new RouteKillRequirement(10, 20)]);
-TownList['Victory Road Kalos'] = new DungeonTown('Victory Road Kalos', [
-    new GymBadgeRequirement(BadgeCase.Badge.Iceberg),
-    new OneFromManyRequirement([
-        new RouteKillRequirement(10, 21),
-        new RouteKillRequirement(10, 22),
-    ]),
-]);
+TownList['Lost Hotel'] = new DungeonTown(
+    'Lost Hotel',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 15)]
+);
+TownList['Frost Cavern'] = new DungeonTown(
+    'Frost Cavern',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 15)]
+);
+TownList['Team Flare Secret HQ'] = new DungeonTown(
+    'Team Flare Secret HQ',
+    GameConstants.Region.kalos,
+    [new GymBadgeRequirement(BadgeCase.Badge.Psychic)]
+);
+TownList['Terminus Cave'] = new DungeonTown(
+    'Terminus Cave',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 18)]
+);
+TownList['Pokémon Village'] = new DungeonTown(
+    'Pokémon Village',
+    GameConstants.Region.kalos,
+    [new RouteKillRequirement(10, 20)]
+);
+TownList['Victory Road Kalos'] = new DungeonTown(
+    'Victory Road Kalos',
+    GameConstants.Region.kalos,
+    [
+        new GymBadgeRequirement(BadgeCase.Badge.Iceberg),
+        new OneFromManyRequirement([
+            new RouteKillRequirement(10, 21),
+            new RouteKillRequirement(10, 22),
+        ]),
+    ]
+);
 //Unknown Cave?

--- a/src/scripts/utilities/Preload.ts
+++ b/src/scripts/utilities/Preload.ts
@@ -86,8 +86,11 @@ class Preload {
     private static loadTowns() {
         const p = Array<Promise<number>>();
         for (const name in TownList) {
-            // Skip unreleased towns
-            if (GameConstants.UnreleasedRegions.includes(TownList[name].region())) {
+            // Skip unreleased towns unless a feature flag has enabled them
+            if (
+                !((<any>window).featureFlags && (<any>window).featureFlags.preloadUnreleasedTowns) &&
+                GameConstants.UnreleasedRegions.includes(TownList[name].region())
+            ) {
                 continue;
             }
             // Skip fake towns that exist for the Elite

--- a/src/scripts/utilities/Preload.ts
+++ b/src/scripts/utilities/Preload.ts
@@ -88,8 +88,7 @@ class Preload {
         for (const name in TownList) {
             // Skip unreleased towns unless a feature flag has enabled them
             if (
-                !((<any>window).featureFlags && (<any>window).featureFlags.preloadUnreleasedTowns) &&
-                GameConstants.UnreleasedRegions.includes(TownList[name].region())
+                !(<any>window).featureFlags?.preloadUnreleasedTowns && TownList[name].region() > GameConstants.MAX_AVAILABLE_REGION
             ) {
                 continue;
             }

--- a/src/scripts/utilities/Preload.ts
+++ b/src/scripts/utilities/Preload.ts
@@ -86,6 +86,11 @@ class Preload {
     private static loadTowns() {
         const p = Array<Promise<number>>();
         for (const name in TownList) {
+            // Skip unreleased towns
+            if (GameConstants.UnreleasedRegions.includes(TownList[name].region())) {
+                continue;
+            }
+            // Skip fake towns that exist for the Elite
             if (name.includes('Elite') || name.includes('Champion')) {
                 continue;
             }


### PR DESCRIPTION
This is based off a discussion in #835, and will disable the preloading of unreleased towns (avoiding pointless requests and console warnings) unless the feature flag has been enabled and a development build is running. It is a quick and dirty feature flag system, but should do the trick for now.

Changes:
* `FEATURE_FLAGS` from `config.js` is injected into `window.featureFlags`
* If `window.featureFlags && window.featureFlags.preloadUnreleasedTowns`, the preloader will try (and currently fail) to load images for towns in Unova and Kalos, otherwise it will skip them (no warnings in a prod build)
* `Town` has been reworked to accept 3 arguments instead of the previous 6. This avoids the need for passing `null` or `undefined` to get to the argument that you want, and makes the instantiation of the class a bit more clear:
  * `name: string` - Required
  * `region: GameConstants.Region` - Required
  * `optional: {}`
    * `requirements?: (Requirement | OneFromManyRequirement)[]`
    *`shop?: Shop`
    * `dungeon?: Dungeon`
* `DungeonTown` and `PokemonLeague` have been updated to match
    * `npcs?: NPC[]`