### PR TITLE
Make route level based on order and region

### DIFF
--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -42,7 +42,7 @@ class PokemonFactory {
     }
 
     public static routeLevel(route: number, region: GameConstants.Region): number {
-        return route * 2;
+        return Math.floor(MapHelper.normalizeRoute(route, region) * 2 + 20 * Math.pow(region, 2.3));
     }
 
     public static routeHealth(route: number, region: GameConstants.Region): number {
@@ -62,7 +62,7 @@ class PokemonFactory {
     public static routeDungeonTokens(route: number, region: GameConstants.Region): number {
         route = MapHelper.normalizeRoute(route, region);
 
-        const tokens = Math.max(1, 6 * Math.pow(this.routeLevel(route,region) / (3 / Math.round(1 + region / 3)), 1.05));
+        const tokens = Math.max(1, 6 * Math.pow(route * 2 / (3 / Math.round(1 + region / 3)), 1.05));
 
         return tokens;
     }


### PR DESCRIPTION
Level of wild pokemon spawned is currently just route number * 2. Level is only used as a flat multiplier for exp gained. Egg steps, money, hp, and tokens are based on the route order instead of route number. The sixth route in Kanto (25) has almost the same level (and therefore exp) as the second to last route in Johto (26). Also, Unova starts at route 1, which would be a big hit to exp gained under the current system.

The main intent is to fix the order issues while keeping the level per region approximately the same. With this formula, overall Kanto route levels are the same, Johto around 20% higher, Hoenn 2% lower, and Sinnoh 3% higher. Unova would also be higher than Sinnoh instead of the same as Kanto.

A simpler method would just be route order * 2, though that would be a big hit to current exp gains.

![exp](https://user-images.githubusercontent.com/41541662/95005906-feb0fd00-05ba-11eb-96d5-7f8d4c736c02.png)