### PR TITLE
Add Achievement Tracker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,7 +1944,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -9966,7 +9967,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/src/components/achievementTrackerContainer.html
+++ b/src/components/achievementTrackerContainer.html
@@ -1,6 +1,7 @@
 <div
   id="achivementTrackerContainer"
   class="card sortable border-secondary mb-3"
+  data-bind="visible: App.game.achievementTracker.canAccess()"
 >
   <div class="card-header p-0" data-toggle="collapse" href="#achievementTrackerBody">
     <span style="text-align: center">Achievement Tracker</span>

--- a/src/components/achievementTrackerContainer.html
+++ b/src/components/achievementTrackerContainer.html
@@ -1,0 +1,59 @@
+<div
+  id="achivementTrackerContainer"
+  class="card sortable border-secondary mb-3"
+>
+  <div class="card-header p-0" data-toggle="collapse" href="#achievementTrackerBody">
+    <span style="text-align: center">Achievement Tracker</span>
+  </div>
+  <button
+    class="btn btn-sm btn-primary"
+    style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px;"
+    data-toggle="modal"
+    href="#achievementsModal"
+  >
+    List
+  </button>
+  <div
+    id="achievementTrackerBody"
+    class="card-body show p-0"
+  >
+    <!-- ko if: !AchievementHandler.hasTrackedAchievement() -->
+    <div
+      class="clickable table-warning text-light p-2"
+      href="#achievementsModal"
+      data-toggle="modal"
+    >
+      Select an achievement to track!
+    </div>
+    <!-- /ko -->
+
+    <!-- ko if: AchievementHandler.hasTrackedAchievement() -->
+    <table class="table table-sm m-0">
+      <tbody>
+        <tr>
+          <td colspan="2" data-bind="text:AchievementHandler.trackedAchievement().description">
+            Achievement Description
+          </td>
+        </tr>
+        <tr>
+          <td class="p-0">
+            <div class="progress p-0">
+              <div
+                class="progress-bar bg-primary"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                data-bind="attr:{ style: 'width:' + AchievementHandler.trackedAchievement().getProgressPercentage() + '%'}, css: {
+                           'bg-success': AchievementHandler.trackedAchievement().isCompleted(),
+                           'bg-primary': !AchievementHandler.trackedAchievement().isCompleted()
+                         }">
+                <span data-bind="text: AchievementHandler.trackedAchievement().getProgressText">0 / 1000</span>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <!-- /ko -->
+  </div>
+ </div>

--- a/src/components/achievementTrackerContainer.html
+++ b/src/components/achievementTrackerContainer.html
@@ -17,7 +17,7 @@
     id="achievementTrackerBody"
     class="card-body show p-0"
   >
-    <!-- ko if: !AchievementHandler.hasTrackedAchievement() -->
+    <!-- ko if: !App.game.achievementTracker.hasTrackedAchievement() -->
     <div
       class="clickable table-warning text-light p-2"
       href="#achievementsModal"
@@ -27,11 +27,11 @@
     </div>
     <!-- /ko -->
 
-    <!-- ko if: AchievementHandler.hasTrackedAchievement() -->
+    <!-- ko if: App.game.achievementTracker.hasTrackedAchievement()-->
     <table class="table table-sm m-0">
       <tbody>
         <tr>
-          <td colspan="2" data-bind="text:AchievementHandler.trackedAchievement().description">
+          <td colspan="2" data-bind="text: App.game.achievementTracker.trackedAchievement().description">
             Achievement Description
           </td>
         </tr>
@@ -43,11 +43,11 @@
                 role="progressbar"
                 aria-valuemin="0"
                 aria-valuemax="100"
-                data-bind="attr:{ style: 'width:' + AchievementHandler.trackedAchievement().getProgressPercentage() + '%'}, css: {
-                           'bg-success': AchievementHandler.trackedAchievement().isCompleted(),
-                           'bg-primary': !AchievementHandler.trackedAchievement().isCompleted()
+                data-bind="attr:{ style: 'width:' + App.game.achievementTracker.trackedAchievement().getProgressPercentage() + '%'}, css: {
+                           'bg-success': App.game.achievementTracker.trackedAchievement().isCompleted(),
+                           'bg-primary': !App.game.achievementTracker.trackedAchievement().isCompleted()
                          }">
-                <span data-bind="text: AchievementHandler.trackedAchievement().getProgressText">0 / 1000</span>
+                <span data-bind="text: App.game.achievementTracker.trackedAchievement().getProgressText">0 / 1000</span>
               </div>
             </div>
           </td>

--- a/src/components/achievementsModal.html
+++ b/src/components/achievementsModal.html
@@ -55,9 +55,7 @@ aria-labelledby="AchievementsModalLabel" aria-hidden="true">
                         data-bind=" css: {disabled: AchievementHandler.navigateIndex() === 0}">
                     <img src="assets/images/leftarrow.png">
                 </button>
-
                 <div data-bind="text: AchievementHandler.navigateIndex()+1 + '/' + (AchievementHandler.numberOfTabs()+1)"></div>
-                
                 <button class="btn btn-secondary" onclick="AchievementHandler.navigateRight()"
                         data-bind=" css: {disabled: AchievementHandler.navigateIndex() ===  AchievementHandler.numberOfTabs()}">
                     <img src="assets/images/rightarrow.png">
@@ -67,7 +65,9 @@ aria-labelledby="AchievementsModalLabel" aria-hidden="true">
     </div>
 
     <script type="text/html" id="achievementListTemplate">
-        <tr data-bind="css: { 'table-success': isCompleted() , 'table-danger': !isCompleted() }">
+        <tr
+            class="achievement-row"
+            data-bind="css: { 'table-success': isCompleted() , 'table-danger': !isCompleted() }, click: () => {AchievementHandler.trackAchievement($data); $('#achievementsModal').modal('hide');}">
             <td style="text-align:left;vertical-align:middle;"><b><span data-bind="text: name">Name</span></b><br>
                 <small><span data-bind="text: description">Description</span></small>
             </td>

--- a/src/components/achievementsModal.html
+++ b/src/components/achievementsModal.html
@@ -67,7 +67,7 @@ aria-labelledby="AchievementsModalLabel" aria-hidden="true">
     <script type="text/html" id="achievementListTemplate">
         <tr
             class="achievement-row"
-            data-bind="css: { 'table-success': isCompleted() , 'table-danger': !isCompleted() }, click: () => {AchievementHandler.trackAchievement($data); $('#achievementsModal').modal('hide');}">
+            data-bind="css: { 'table-success': isCompleted() , 'table-danger': !isCompleted() }, click: () => {App.game.achievementTracker.trackAchievement($data); $('#achievementsModal').modal('hide');}">
             <td style="text-align:left;vertical-align:middle;"><b><span data-bind="text: name">Name</span></b><br>
                 <small><span data-bind="text: description">Description</span></small>
             </td>

--- a/src/index.html
+++ b/src/index.html
@@ -124,8 +124,10 @@
 
         <!--Middle column-->
         <div id="middle-column" class="col-lg-6 col-md-12 order-md-first">
-            <!-- Achievement Tracker -->
-            @import "achievementTrackerContainer.html"
+            <div id="middle-top-sort-column">
+                <!-- Achievement Tracker -->
+                @import "achievementTrackerContainer.html"
+            </div>
 
             <div id="battleContainer" class="card sortable-disabled border-secondary mb-3">
 
@@ -373,7 +375,7 @@
             <!-- Battle Frontier Information Container  -->
             @import "battleFrontierInfo.html"
 
-            <div id="middle-sort-column">
+            <div id="middle-bottom-sort-column">
                 <div id="townMap" class="card sortable border-secondary mb-3" data-bind="visible: App.game.keyItems.hasKeyItem(KeyItems.KeyItem.Town_map) && (App.game.gameState === GameConstants.GameState.fighting || App.game.gameState === GameConstants.GameState.gym || App.game.gameState === GameConstants.GameState.town||
                     App.game.gameState === GameConstants.GameState.shop || App.game.gameState === GameConstants.GameState.farm || App.game.gameState === GameConstants.GameState.paused)">
                     <div class="card-header p-0" data-toggle="collapse" href="#mapBody">

--- a/src/index.html
+++ b/src/index.html
@@ -124,6 +124,9 @@
 
         <!--Middle column-->
         <div id="middle-column" class="col-lg-6 col-md-12 order-md-first">
+            <!-- Achievement Tracker -->
+            @import "achievementTrackerContainer.html"
+
             <div id="battleContainer" class="card sortable-disabled border-secondary mb-3">
 
                 <div class="card-header p-0" data-bind="visible: (App.game.gameState === GameConstants.GameState.fighting ||

--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -10,7 +10,7 @@ class App {
 
         Preload.load(App.debug).then(() => {
             ko.options.deferUpdates = true;
-            
+
             console.log(`[${GameConstants.formatDate(new Date())}] %cLoading Game Data..`, 'color:#8e44ad;font-weight:900;');
             // Needs to be loaded first so save data can be updated (specifically "player" data)
             const update = new Update();
@@ -33,7 +33,8 @@ class App {
                 new Statistics(),
                 new Quests(),
                 new SpecialEvents(),
-                new Discord()
+                new Discord(),
+                new AchievementTracker()
             );
 
             console.log(`[${GameConstants.formatDate(new Date())}] %cGame loaded`, 'color:#8e44ad;font-weight:900;');

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -28,7 +28,8 @@ class Game {
         public statistics: Statistics,
         public quests: Quests,
         public specialEvents: SpecialEvents,
-        public discord: Discord
+        public discord: Discord,
+        public achievementTracker: AchievementTracker
     ) {
         this._gameState = ko.observable(GameConstants.GameState.paused);
 

--- a/src/scripts/Sortable.ts
+++ b/src/scripts/Sortable.ts
@@ -1,7 +1,7 @@
 declare const Sortable: any;
 
 $(() => {
-    const columns = ['left-column', 'middle-sort-column', 'right-column'];
+    const columns = ['left-column', 'middle-top-sort-column', 'middle-bottom-sort-column', 'right-column'];
 
     // Enable sorting of items
     columns.forEach(column => {

--- a/src/scripts/achievements/Achievement.ts
+++ b/src/scripts/achievements/Achievement.ts
@@ -32,4 +32,8 @@ class Achievement {
         const max = AchievementHandler.maxBonus()[this.region] ;
         return (this.bonus / max * 100).toFixed(2);
     }
+
+    public getProgressText: KnockoutComputed<string> = ko.pureComputed(() => {
+        return this.getProgress() + " / " + this.property.requiredValue;
+    })
 }

--- a/src/scripts/achievements/Achievement.ts
+++ b/src/scripts/achievements/Achievement.ts
@@ -34,6 +34,6 @@ class Achievement {
     }
 
     public getProgressText: KnockoutComputed<string> = ko.pureComputed(() => {
-        return this.getProgress() + " / " + this.property.requiredValue;
+        return `${this.getProgress()}/${this.property.requiredValue}`;
     })
 }

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -6,7 +6,6 @@ class AchievementHandler {
     public static maxBonus: KnockoutObservableArray<number> = ko.observableArray([]);
     public static achievementListFiltered: KnockoutObservableArray<Achievement> = ko.observableArray([]);
     public static numberOfTabs: KnockoutObservable<number> = ko.observable(0);
-    public static trackedAchievement: KnockoutObservable<Achievement> = ko.observable(null);
 
     public static navigateRight() {
         if (AchievementHandler.navigateIndex() < AchievementHandler.numberOfTabs()) {
@@ -99,17 +98,8 @@ class AchievementHandler {
         return `${(100 * AchievementHandler.achievementBonus()).toFixed(2)}%`;
     }
 
-    // TODO mephistic - we might not need this one? Decide how we load
-    public static trackAchievementByIndex(indexToTrack: number) {
-        AchievementHandler.trackAchievement(AchievementHandler.achievementList[indexToTrack]);
-    }
-
-    public static trackAchievement(achievement: Achievement) {
-        AchievementHandler.trackedAchievement(achievement);
-    }
-
-    public static hasTrackedAchievement(): boolean {
-       return AchievementHandler.trackedAchievement() !== null;
+    public static findByName(name: string): Achievement {
+        return AchievementHandler.achievementList.find((achievement) => achievement.name === name);
     }
 
     public static initialize() {
@@ -250,9 +240,6 @@ class AchievementHandler {
                 AchievementHandler.addAchievement(`${dungeon} hermit`, 'Clear 1,000 times', new ClearDungeonRequirement(1000, Statistics.getDungeonIndex(dungeon)), 3, region);
             });
         });
-
-        AchievementHandler.achievementList
-
 
         AchievementHandler.calculateMaxBonus();
         AchievementHandler.calculateAchievementTypes();

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -6,6 +6,7 @@ class AchievementHandler {
     public static maxBonus: KnockoutObservableArray<number> = ko.observableArray([]);
     public static achievementListFiltered: KnockoutObservableArray<Achievement> = ko.observableArray([]);
     public static numberOfTabs: KnockoutObservable<number> = ko.observable(0);
+    public static trackedAchievement: KnockoutObservable<Achievement> = ko.observable(null);
 
     public static navigateRight() {
         if (AchievementHandler.navigateIndex() < AchievementHandler.numberOfTabs()) {
@@ -96,6 +97,19 @@ class AchievementHandler {
 
     public static achievementBonusPercent(): string {
         return `${(100 * AchievementHandler.achievementBonus()).toFixed(2)}%`;
+    }
+
+    // TODO mephistic - we might not need this one? Decide how we load
+    public static trackAchievementByIndex(indexToTrack: number) {
+        AchievementHandler.trackAchievement(AchievementHandler.achievementList[indexToTrack]);
+    }
+
+    public static trackAchievement(achievement: Achievement) {
+        AchievementHandler.trackedAchievement(achievement);
+    }
+
+    public static hasTrackedAchievement(): boolean {
+       return AchievementHandler.trackedAchievement() !== null;
     }
 
     public static initialize() {
@@ -236,6 +250,9 @@ class AchievementHandler {
                 AchievementHandler.addAchievement(`${dungeon} hermit`, 'Clear 1,000 times', new ClearDungeonRequirement(1000, Statistics.getDungeonIndex(dungeon)), 3, region);
             });
         });
+
+        AchievementHandler.achievementList
+
 
         AchievementHandler.calculateMaxBonus();
         AchievementHandler.calculateAchievementTypes();

--- a/src/scripts/achievements/AchievementTracker.ts
+++ b/src/scripts/achievements/AchievementTracker.ts
@@ -1,0 +1,51 @@
+class AchievementTracker implements Feature {
+    name = 'AchievementTracker';
+    saveKey = 'achievementTracker';
+    trackedAchievement: KnockoutObservable<Achievement>;
+
+    defaults = {
+        'trackedAchievement': null
+    };
+
+    constructor() {
+        this.trackedAchievement = ko.observable(this.defaults.trackedAchievement)
+    }
+
+    initialize(): void {
+
+    }
+
+    canAccess(): boolean {
+        return App.game.party.caughtPokemon.length > 110;
+    }
+
+    update(delta: number): void {
+    }
+
+    fromJSON(json: Record<string, any>): void {
+        if (json == null) {
+            return;
+        }
+
+        if (!!json.trackedAchievementName) {
+            let achievement: Achievement = AchievementHandler.findByName(json.trackedAchievementName);
+            if (!!achievement) {
+                this.trackedAchievement(achievement)
+            }
+        }
+    }
+
+    toJSON(): Record<string, any> {
+        return {
+            trackedAchievementName: this.hasTrackedAchievement() ? this.trackedAchievement().name : null
+        }
+    }
+
+    trackAchievement(achievement: Achievement): void {
+        this.trackedAchievement(achievement);
+    }
+
+    hasTrackedAchievement(): boolean {
+        return this.trackedAchievement() !== null;
+    }
+}

--- a/src/scripts/achievements/AchievementTracker.ts
+++ b/src/scripts/achievements/AchievementTracker.ts
@@ -16,7 +16,7 @@ class AchievementTracker implements Feature {
     }
 
     canAccess(): boolean {
-        return App.game.party.caughtPokemon.length > 110;
+        return App.game.party.caughtPokemon.length >= 110;
     }
 
     update(delta: number): void {

--- a/src/scripts/achievements/AchievementTracker.ts
+++ b/src/scripts/achievements/AchievementTracker.ts
@@ -4,11 +4,11 @@ class AchievementTracker implements Feature {
     trackedAchievement: KnockoutObservable<Achievement>;
 
     defaults = {
-        'trackedAchievement': null
+        'trackedAchievement': null,
     };
 
     constructor() {
-        this.trackedAchievement = ko.observable(this.defaults.trackedAchievement)
+        this.trackedAchievement = ko.observable(this.defaults.trackedAchievement);
     }
 
     initialize(): void {
@@ -28,17 +28,17 @@ class AchievementTracker implements Feature {
         }
 
         if (!!json.trackedAchievementName) {
-            let achievement: Achievement = AchievementHandler.findByName(json.trackedAchievementName);
+            const achievement: Achievement = AchievementHandler.findByName(json.trackedAchievementName);
             if (!!achievement) {
-                this.trackedAchievement(achievement)
+                this.trackedAchievement(achievement);
             }
         }
     }
 
     toJSON(): Record<string, any> {
         return {
-            trackedAchievementName: this.hasTrackedAchievement() ? this.trackedAchievement().name : null
-        }
+            trackedAchievementName: this.hasTrackedAchievement() ? this.trackedAchievement().name : null,
+        };
     }
 
     trackAchievement(achievement: Achievement): void {

--- a/src/styles/achievement.less
+++ b/src/styles/achievement.less
@@ -1,0 +1,8 @@
+.achievement-tracker-name {
+  font-weight: bold;
+  font-size: 1.2em;
+}
+
+.achievement-row {
+  cursor: pointer;
+}


### PR DESCRIPTION
Saw this was requested a few times in the Discord - this PR adds an Achievement Tracker bar to the top. Players can click on an achievement in the Achievements list to track it on the main screen.

Unselected:
<img width="1365" alt="Screen Shot 2020-10-04 at 11 18 29 AM" src="https://user-images.githubusercontent.com/2694761/95019558-0f518980-0634-11eb-8f5e-c8da071323a8.png">
Achievement in Progress:
<img width="1141" alt="Screen Shot 2020-10-04 at 11 17 07 AM" src="https://user-images.githubusercontent.com/2694761/95019566-14163d80-0634-11eb-8e9d-5e4dd84dd696.png">
Completed Achievement:
<img width="1341" alt="Screen Shot 2020-10-04 at 11 18 03 AM" src="https://user-images.githubusercontent.com/2694761/95019573-18daf180-0634-11eb-95e1-03229ebf4be6.png">
