### PR TITLE
fix(lint): adds Radix argument to all calls to parseInt

### DIFF
--- a/src/components/shopModal.html
+++ b/src/components/shopModal.html
@@ -51,8 +51,8 @@
                         </div>
                         <input id="amountOfItems" type="number" class="outline-dark form-control form-control-number"
                                 value="1" min="1" required name="amountOfItems"
-                                oninput="ShopHandler.amount(parseInt($(this).val().toString()) || 0);"
-                                onchange="ShopHandler.amount(parseInt($(this).val().toString()) || 0);" title=""/>
+                                oninput="ShopHandler.amount(parseInt($(this).val().toString(), 10) || 0);"
+                                onchange="ShopHandler.amount(parseInt($(this).val().toString(), 10) || 0);" title=""/>
                         <div class="input-group-append">
                             <button class="btn btn-secondary smallButton smallFont" type="button" onclick="ShopHandler.increaseAmount(10)">
                                 +10

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -28,7 +28,7 @@ class ItemHandler {
 
     public static increaseAmount(n: number) {
         const input = $("input[name='amountOfItems']");
-        const newVal = (parseInt(input.val().toString()) || 0) + n;
+        const newVal = (parseInt(input.val().toString(), 10) || 0) + n;
         input.val(newVal > 1 ? newVal : 1).change();
     }
 

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -71,7 +71,7 @@ class PokedexHelper {
             }
             
             // If not showing this region
-            const region: (GameConstants.Region | null) = filter['region'] ? parseInt(filter['region']) : null;
+            const region: (GameConstants.Region | null) = filter['region'] ? parseInt(filter['region'], 10) : null;
             if (region != null && region != nativeRegion) {
                 return false;
             }
@@ -92,8 +92,8 @@ class PokedexHelper {
             }
 
             // Check if either of the types match
-            const type1: (PokemonType | null) = filter['type1'] ? parseInt(filter['type1']) : null;
-            const type2: (PokemonType | null) = filter['type2'] ? parseInt(filter['type2']) : null;
+            const type1: (PokemonType | null) = filter['type1'] ? parseInt(filter['type1'], 10) : null;
+            const type2: (PokemonType | null) = filter['type2'] ? parseInt(filter['type2'], 10) : null;
             if ([type1, type2].includes(PokemonType.None)) {
                 const type = (type1 == PokemonType.None) ? type2 : type1;
                 if (!PokedexHelper.isPureType(pokemon, type)) {

--- a/src/scripts/settings/Settings.ts
+++ b/src/scripts/settings/Settings.ts
@@ -119,7 +119,7 @@ Object.values(GameConstants.NotificationSetting).forEach(setting => {
  */
 const sortsettings = Object.keys(SortOptionConfigs).map(
     function(opt) {
-        return new SettingOption(SortOptionConfigs[opt].text, parseInt(opt));
+        return new SettingOption(SortOptionConfigs[opt].text, parseInt(opt, 10));
     }
 );
 Settings.add(new MultipleChoiceSetting('partySort', 'Sort:',

--- a/src/scripts/shop/ShopHandler.ts
+++ b/src/scripts/shop/ShopHandler.ts
@@ -31,7 +31,7 @@ class ShopHandler {
 
     public static increaseAmount(n: number) {
         const input = $("input[name='amountOfItems']");
-        const newVal = (parseInt(input.val().toString()) || 0) + n;
+        const newVal = (parseInt(input.val().toString(), 10) || 0) + n;
         input.val(newVal > 1 ? newVal : 1).change();
     }
 

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -254,7 +254,7 @@ class Underground {
 
 $(document).ready(function () {
     $('body').on('click', '.mineSquare', function () {
-        Mine.click(parseInt(this.dataset.i), parseInt(this.dataset.j));
+        Mine.click(parseInt(this.dataset.i, 10), parseInt(this.dataset.j, 10));
     });
 });
 


### PR DESCRIPTION
`parseInt` should always be called with the radix argument to ensure it parses the number as a base-10 number. Certain values may trigger it to assume a different radix if one is not provided. This is less of an issue with modern browsers, but should help to prevent an obscure bug from appearing down the road

More info:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#Description
- https://eslint.org/docs/rules/radix