### PR TITLE
Makes Oak Item popover display levels consistently

### DIFF
--- a/src/scripts/oakItems/OakItem.ts
+++ b/src/scripts/oakItems/OakItem.ts
@@ -70,6 +70,6 @@ class OakItem extends ExpUpgrade {
     }
 
     tooltip = ko.pureComputed(() => {
-        return `<u>${this.displayName}</u><br/><p>${this.description}</p>Level: <strong>${this.level}${this.isMaxLevel() ? '' : '/' + this.maxLevel}</strong><br/>Bonus: <strong>${this.calculateBonusIfActive()}${this.displayName != 'Magic Ball' ? '×' : '%'}</strong>`;
+        return `<u>${this.displayName}</u><br/><p>${this.description}</p>Level: <strong>${this.level}/${this.maxLevel}</strong><br/>Bonus: <strong>${this.calculateBonusIfActive()}${this.displayName != 'Magic Ball' ? '×' : '%'}</strong>`;
     });
 }


### PR DESCRIPTION
The move to show both current and max level in the Oak Item popovers is
a good one, but it would be more consistent and more clear if the
Level: x / y format was retained at all levels.

Currently, the format changes when you reach max level (indicated most
clearly by the MAX LEVEL label), but there doesn't see to be any benefit
in doing so. On the other hand, if Oak Items ever have varying max
levels (as factored for in the OakItem.maxLevel property), having the
varied format may be confusing (why does this one change format at 5,
and THIS one change format at 10?).