### PR TITLE
Add a link to the discord in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A game about catching Pokémon, defeating gym leaders, and watching numbers get 
 
 NOTE: PokéClicker is still in development!
 
-You can try out the current state at https://pokeclicker.github.io/pokeclicker/
+You can try out the current state at https://www.pokeclicker.com/
 
 You can reach out on discord to discuss your ideas and how to implement them: https://discordapp.com/invite/rHF3V54
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ NOTE: PokéClicker is still in development!
 
 You can try out the current state at https://pokeclicker.github.io/pokeclicker/
 
+You can reach out on discord to discuss your ideas and how to implement them: https://discordapp.com/invite/rHF3V54
+
 # Developer instructions
 
 ## Building from Source


### PR DESCRIPTION
If you arrive at the github repo, it would be good to immediately be
able to find the development community to discuss ideas and how to go
about implementing them. This commit adds the invite link currently
listed on the subreddit.