### PR TITLE
Add 1px space between type sections of damage calc bar

### DIFF
--- a/src/styles/damagecalc.less
+++ b/src/styles/damagecalc.less
@@ -1,6 +1,7 @@
 .type-damage-bar {
     height: 25px;
     cursor: pointer;
+    margin: 0 1px;
 }
 
 #damageCalcTypeDetailTable td {


### PR DESCRIPTION
To help with identifying where one section ends and another begins. Useful when the sections are very thin, or the player has difficulty distinguishing the colours.