### PR TITLE
Make eggs all fit on one line when in middle column

### DIFF
--- a/src/styles/breeding.less
+++ b/src/styles/breeding.less
@@ -139,6 +139,11 @@
   background-color: #aaa;
 }
 
+#middle-column .eggSlot {
+  flex-basis: 25%;
+  max-width: 25%;
+}
+
 @eggMainColors:
   "Bug" #9df68e,
   "Dark" #3d3d3d,


### PR DESCRIPTION
Eggs are huge when the module is dropped into the middle column, this PR makes them squeeze into a single line like mobile view.

Images of how it looks with this addition:

In the middle column
![Middle Column](https://cdn.discordapp.com/attachments/697242377311617104/763132942104526848/unknown.png)

In a side column
![Side Column](https://cdn.discordapp.com/attachments/697242377311617104/763133767149027368/unknown.png)

On mobile
![Mobile View](https://cdn.discordapp.com/attachments/697242377311617104/763133649117249576/unknown.png)

Using images I uploaded to discord... hopefully they don't disappear