### PR TITLE
Fixup the link to images for Pokémon on the dynamic background

### DIFF
--- a/src/scripts/DynamicBackground.ts
+++ b/src/scripts/DynamicBackground.ts
@@ -76,7 +76,7 @@ class DynamicBackground {
 
         const pokeElement = document.createElement('div');
         pokeElement.style.bottom = flying ? `${Math.floor(Math.random() * 70) + 20}vh` : `${Math.floor(Math.random() * 10) + 5}vh`;
-        pokeElement.style.backgroundImage = `url('/assets/images/dynamic-background/pokemon/${id.toString().padStart(3, 0)}${shiny ? 's' : ''}.png')`;
+        pokeElement.style.backgroundImage = `url('assets/images/dynamic-background/pokemon/${id.toString().padStart(3, 0)}${shiny ? 's' : ''}.png')`;
         pokeElement.classList.add('pokemon');
         pokeElement.classList.add('walkLeft');
         document.getElementById('dynamic-background').appendChild(pokeElement);


### PR DESCRIPTION
Currently the images are linking to `/assets/` which will be looking from the root of the site.

This is only really a problem for pages that aren't hosting it on the base domain such as GitHub pages.