### PR TITLE
Removed sort option invert to fix sorting

### DIFF
--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -45,15 +45,12 @@ class PartyController {
 
     public static compareBy(option: SortOptions, direction: boolean): (a: PartyPokemon, b: PartyPokemon) => number {
         return function (a, b) {
-            let res, dir = (direction) ? -1 : 1;
+            let res: number;
+            const dir = (direction) ? -1 : 1;
             const config = SortOptionConfigs[option];
 
             const aValue = config.getValue(a);
             const bValue = config.getValue(b);
-
-            if (config.invert) {
-                dir *= -1;
-            }
 
             //Compare by provided property
             if (aValue == bValue) {

--- a/src/scripts/settings/SortOptions.ts
+++ b/src/scripts/settings/SortOptions.ts
@@ -15,9 +15,6 @@ type SortOptionConfig = {
 
     // How to get the comparison value from a PartyPokemon
     getValue: (p: PartyPokemon) => any;
-
-    // true if the default sort direction should be descending
-    invert?: boolean;
 }
 
 const SortOptionConfigs: Record<SortOptions, SortOptionConfig> = {
@@ -34,31 +31,26 @@ const SortOptionConfigs: Record<SortOptions, SortOptionConfig> = {
     [SortOptions.attack]: {
         'text': 'Attack',
         'getValue': p => p.calculateAttack(),
-        'invert': true,
     },
 
     [SortOptions.level]: {
         'text': 'Level',
         'getValue': p => p.level,
-        'invert': true,
     },
 
     [SortOptions.shiny]: {
         'text': 'Shiny',
         'getValue': p => +App.game.party.shinyPokemon.includes(p.id),
-        'invert': true,
     },
 
     [SortOptions.baseAttack]: {
         'text': 'Base Attack',
         'getValue': p => p.baseAttack,
-        'invert': true,
     },
 
     [SortOptions.breedingEfficiency]: {
         'text': 'Breeding Efficiency',
         'getValue': p => (p.baseAttack / pokemonMap[p.name].eggCycles),
-        'invert': true,
     },
 
     [SortOptions.eggCycles]: {


### PR DESCRIPTION
In reference to #877 
I'm not sure the original purpose of the invert flag, but it was causing Attack, Base Attack, and Breeding Efficiency to be sorted in incorrect order when looking at ascending vs descending. Now they all have the same behavior.

Feel free to close this PR if the invert is still necessary for something I didn't see.