### PR TITLE
[Suggestion] Remove fully grown dragons from eggs

### DIFF
--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -55,10 +55,10 @@ class Breeding implements Feature {
             ['Pachirisu', 'Shinx'],
         ];
         this.hatchList[EggType.Dragon] = [
-            ['Dratini', 'Dragonair', 'Dragonite'],
+            ['Dratini'],
             [],
-            ['Bagon', 'Shelgon', 'Salamence'],
-            ['Gible', 'Gabite', 'Garchomp'],
+            ['Bagon'],
+            ['Gible'],
         ];
         BreedingController.initialize();
     }

--- a/src/scripts/items/EggItem.ts
+++ b/src/scripts/items/EggItem.ts
@@ -52,6 +52,6 @@ ItemList['Water_egg']    = new EggItem(GameConstants.EggItemType.Water_egg, 1000
 ItemList['Grass_egg']    = new EggItem(GameConstants.EggItemType.Grass_egg, 1000);
 ItemList['Fighting_egg'] = new EggItem(GameConstants.EggItemType.Fighting_egg, 1000);
 ItemList['Electric_egg'] = new EggItem(GameConstants.EggItemType.Electric_egg, 1000);
-ItemList['Dragon_egg']   = new EggItem(GameConstants.EggItemType.Dragon_egg, 1000);
+ItemList['Dragon_egg']   = new EggItem(GameConstants.EggItemType.Dragon_egg, 1500);
 ItemList['Pokemon_egg']  = new EggItem(GameConstants.EggItemType.Pokemon_egg, 1000);
 ItemList['Mystery_egg']  = new EggItem(GameConstants.EggItemType.Mystery_egg, 700);


### PR DESCRIPTION
This PR removes the evolved forms of dragons from the Dragon Eggs, and slightly increases the cost of the Dragon Eggs to balance out the reduced randomness.

Reasoning:
* Having three stages of the same pokemon in the same egg is obnoxious for dex completion
* This contributes to the post-E4 wall in Kanto since egg costs are especially painful given how players will have both fewer quest slots and plenty of competing uses for the QP they do get (e.g. evolution stones, other eggs)
* These are the only typed eggs to contain evolved Pokemon (barring the Gen 1 mons that get pre-evos in Gen 2)
* Increasing the base cost of Dragon Eggs somewhat balances out the reduced variability, gives the dragons the impression of being rarer than the other type eggs, and is still an overall expected reduction in QP spent to complete the dex.

Previous Weights:
 
Region | Chance to get first stage dragon | Expected QP cost to get first stage dragon at 1000 QP per egg
--- | --- | ---
Kanto | 1/3 | 3000
Hoenn | 1/6 | 6000
Sinnoh | 1/6 | 6000

New Weights:

Region | Chance to get first stage dragon | Expected QP cost to get first stage dragon at 1500 QP per egg
--- | --- | ---
Kanto | 1/1 | 1500
Hoenn | 1/2 | 3000
Sinnoh | 1/2 | 3000
