### PR TITLE
chore: recommend `npm ci` over `npm i` for exact dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ cache:
   directories:
     - node_modules
 install:
-- npm install
+# Use clean install to ensure we're getting identical versions to package-lock.json
+- npm ci
 script:
 #  Compile, fail on any error
 - tsc

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First make sure you have git and npm available as command-line utilities (so you
 
 Open a command line interface in the directory that contains this README file, and use the following command to install PokéClicker's other dependencies locally:
 ```cmd
-npm install
+npm clean-install
 ```
 
 Then finally, run the following command in the command line interface to start a browser running PokéClicker.
@@ -33,7 +33,7 @@ This means you don't need to compile TypeScript yourself. Gulp will do this for 
 ## Use Google cloud shell _(alternative)_
 [![Google Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pokeclicker/pokeclicker&git_branch=develop&page=editor&open_in_editor=README.md)
 ```cmd
-npm install
+npm clean-install
 npm start
 ```
 


### PR DESCRIPTION
`npm i` will install the latest packages that match the version range in `package.json`, and may result in a bug in a nested dependency. `npm ci` will use the exact versions defined in `package-lock.json`, and will often install the packages faster (with the exception of Windows due to NTFS struggling with thousands of files)