### PR TITLE
Fix minor button UI styling for Underground

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -48,7 +48,7 @@ style="cursor:default" tabindex="-1">
                         <div class='col-12 col-md-4'>
                             <button class='btn' data-bind="text: Mine.itemsFound() + ' / ' + Mine.itemsBuried() + ' items found'"></button>
                             <button id="mine-prospect-result" type="button" class="btn btn-info" data-html="true"
-                                    style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px; padding: 4px;"
+                                    style="position: absolute; right: 0px; top: 0px; width: auto; height: 100%; padding: 4px;"
                                     data-bind="tooltip: { title: () => Mine.prospectResult() || 'Prospect to get more details', trigger: 'hover', placement:'left' }">
                                 ?
                             </button>


### PR DESCRIPTION
Before: (the button actually extends into the skip layer button).
![image](https://user-images.githubusercontent.com/33099029/95806160-a8d00980-0ccc-11eb-9ba3-f11d90128801.png)

After:
![image](https://user-images.githubusercontent.com/33099029/95806214-c8673200-0ccc-11eb-8d73-c9612f022c1d.png)



We also might want to create a CSS class for this, since the info button styling is used in a lot of places.