### PR TITLE
Add breeding queue functionality

### DIFF
--- a/src/components/breeding.html
+++ b/src/components/breeding.html
@@ -23,6 +23,13 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                 <li class="nav-item"><a class="nav-link" href="#breeding-fossils" data-toggle="tab">Fossils</a></li>
             </ul>
 
+            <p class="bg-danger my-0" data-bind="visible: !App.game.breeding.hasFreeEggSlot()">
+                You don't have any free eggslots.
+            </p>
+            <p class="bg-danger my-0" data-bind="visible: !App.game.breeding.hasFreeQueueSlot() && App.game.breeding.queueSlots()">
+                Your breeding queue is full.
+            </p>
+
             <div class="tab-content p-3">
                 <div class="tab-pane active" id="breeding-pokemon">
                     <div class="text-left">
@@ -97,35 +104,28 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                             </div>
                         </div>
                     </div>
-                    <div data-bind="visible: App.game.breeding.hasFreeEggSlot()">
+                    <div>
                         <!-- Check if the player has any level 100 Pokemon or if they have any eggs -->
-                        <p class="text-danger" data-bind="visible: !App.game.party.hasMaxLevelPokemon()">
+                        <p class="bg-danger my-0" data-bind="visible: !App.game.party.hasMaxLevelPokemon()">
                             Unfortunately, you don't have any pokémon of level 100 to breed.
                         </p>
                         <!-- ko if: App.game.party.hasMaxLevelPokemon() -->
                         <ul class="row justify-content-center p-0" data-bind="foreach: BreedingController.breedableList()">
-                            <li class="col-sm-4 col-md-3 col-lg-2 pokedexEntry text-nowrap" data-bind="style:{background: PokedexHelper.getBackgroundColors($data.name)}">
+                            <li class="eggSlot col-sm-4 col-md-3 col-lg-2 pokedexEntry text-nowrap" data-bind="style:{background: PokedexHelper.getBackgroundColors($data.name)}, class: App.game.breeding.hasFreeEggSlot() || App.game.breeding.hasFreeQueueSlot() ? '' : 'disabled'">
                                 <span style="top: 0; border-top-left-radius: 6px; border-top-right-radius: 6px;" data-bind="text: $data.name">name</span>
                                 <div data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)" style="position: absolute;right: 0px;top: 0px;">✨</div>
                                 <img src="" width="80px" data-bind="attr:{ src: PokedexHelper.getImage($data.id)}">
                                 <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: BreedingController.getDisplayValue($data)">value</span>
-                                <a class="overlay" href="#breed" data-bind="click: function() { App.game.breeding.gainPokemonEgg($data); BreedingController.filterBreedableList();if (!App.game.breeding.hasFreeEggSlot()) {$('#breedingModal').modal('hide');}}"></a>
+                                <a class="overlay" href="#breed" data-bind="click: function() { App.game.breeding.addPokemonToHatchery($data); BreedingController.filterBreedableList(); App.game.breeding.checkCloseModal();}"></a>
                             </li>
                         </ul>
                         <!-- /ko -->
                     </div>
-                    <p class="text-danger" data-bind="visible: !App.game.breeding.hasFreeEggSlot()">
-                        Unfortunately, you don't have any free eggslots.
-                    </p>
                 </div>
 
                 <div class="tab-pane" id="breeding-eggs">
-                    <p class="text-danger" data-bind="visible: !App.game.breeding.hasFreeEggSlot()">
-                        Unfortunately, you don't have any free eggslots.
-                    </p>
-
-                    <p class="text-danger" data-bind="visible: !Object.keys(GameConstants.EggItemType).filter(e=>isNaN(e)).filter(x=>player._itemList[x]()).length">
-                        <span data-bind="text: App.game.breeding.hasFreeEggSlot() ? 'Unfortunately,' : 'Even more unfortunately,'"></span> you don't have any eggs to breed.
+                    <p class="bg-warning my-0" data-bind="visible: !Object.keys(GameConstants.EggItemType).filter(e=>isNaN(e)).filter(x=>player._itemList[x]()).length">
+                        you don't have any eggs to breed.
                     </p>
                     <!-- ko if: Object.keys(GameConstants.EggItemType).filter(e=>isNaN(e)).filter(x=>player._itemList[x]()).length -->
                     <ul class="row justify-content-center p-0" data-bind="foreach: Object.keys(GameConstants.EggItemType).filter(e=>isNaN(e)).filter(x=>player._itemList[x]())">
@@ -133,7 +133,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                             <span style="top: 0; border-top-left-radius: 6px; border-top-right-radius: 6px;" data-bind="text: GameConstants.humanifyString($data)">egg</span>
                             <img src="" width="80px" data-bind="attr:{ src: `assets/images/breeding/${$data}.png` }">
                             <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: 'Amount: ' + player._itemList[$data]()">amount</span>
-                            <a class="overlay" href="#breed" data-bind="click: function() { ItemList[$data].use(); if (!App.game.breeding.hasFreeEggSlot()) {$('#breedingModal').modal('hide'); } }"></a>
+                            <a class="overlay" href="#breed" data-bind="click: function() { ItemList[$data].use(); App.game.breeding.checkCloseModal(); }"></a>
                             <knockout style="position: absolute; right: 2px; top: -14px;"
                                 data-bind="template: { name: 'caughtStatusTemplate', data: { status: ItemList[$data].getCaughtStatus() }, if: (ItemList[$data] instanceof CaughtIndicatingItem) }"/>
                         </li>
@@ -142,12 +142,8 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                 </div> 
 
                 <div class="tab-pane" id="breeding-fossils">
-                    <p class="text-danger" data-bind="visible: !App.game.breeding.hasFreeEggSlot()">
-                        Unfortunately, you don't have any free eggslots.
-                    </p>
-
-                    <p class="text-danger" data-bind="visible: !Object.keys(GameConstants.FossilToPokemon).filter(f => player.mineInventory.find(i => i.name == f && i.amount())).length">
-                        <span data-bind="text: App.game.breeding.hasFreeEggSlot() ? 'Unfortunately,' : 'Even more unfortunately,'"></span> you don't have any fossils to breed.
+                    <p class="bg-warning my-0" data-bind="visible: !Object.keys(GameConstants.FossilToPokemon).filter(f => player.mineInventory.find(i => i.name == f && i.amount())).length">
+                        you don't have any fossils to breed.
                     </p>
 
                     <!-- ko if: Object.keys(GameConstants.FossilToPokemon).filter(f => player.mineInventory.find(i => i.name == f && i.amount())).length -->
@@ -156,7 +152,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                             <span style="top: 0; border-top-left-radius: 6px; border-top-right-radius: 6px;" data-bind="text: GameConstants.humanifyString($data.name)">fossil</span>
                             <img src="" width="80px" data-bind="attr:{ src: `assets/images/breeding/${$data.name}.png` }">
                             <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: 'Amount: ' + $data.amount()">amount</span>
-                            <a class="overlay" href="#breed" data-bind="click: function() { Underground.sellMineItem($data.id); if (!App.game.breeding.hasFreeEggSlot()) {$('#breedingModal').modal('hide'); } }"></a>
+                            <a class="overlay" href="#breed" data-bind="click: function() { Underground.sellMineItem($data.id); App.game.breeding.checkCloseModal(); }"></a>
                         </li>
                     </ul>
                     <!-- /ko -->

--- a/src/components/breedingDisplay.html
+++ b/src/components/breedingDisplay.html
@@ -54,4 +54,11 @@
         </div>
       </div>
     </div>
+    <!-- ko if: App.game.breeding.queueList().length -->
+    <div id="hatcheryQueue" class="card-footer p-1" data-bind="foreach: App.game.breeding.queueList()">
+      <div class="queuePokemon clickable bg-primary" data-bind="click: function(){ App.game.breeding.removeFromQueue($index()) }">
+        <img src="" data-bind="attr: { src: PokemonHelper.getImage(pokemonMap[$data], App.game.party.alreadyCaughtPokemon(pokemonMap[$data].id, true)) }">
+      </div>
+    </div>
+    <!-- /ko -->
 </div>

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -31,6 +31,7 @@
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('breedingDisplay')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('shopButtons')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('eggAnimation')}"></tr>
+                                <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('hideHatchery')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showCurrencyGainedAnimation')}"></tr>
                             </tbody>
                         </table>

--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -7,18 +7,25 @@ class Breeding implements Feature {
     saveKey = 'breeding';
 
     defaults = {
-        'eggList': [ko.observable(new Egg()), ko.observable(new Egg()), ko.observable(new Egg()), ko.observable(new Egg())],
-        'eggSlots': 1,
+        eggList: [ko.observable(new Egg()), ko.observable(new Egg()), ko.observable(new Egg()), ko.observable(new Egg())],
+        eggSlots: 1,
+        queueList: ko.observableArray([]),
+        queueSlots: 0,
     };
 
     private _eggList: Array<KnockoutObservable<Egg>>;
     private _eggSlots: KnockoutObservable<number>;
+
+    private queueList: KnockoutObservableArray<string>;
+    private queueSlots: KnockoutObservable<number>;
 
     public hatchList: { [name: number]: string[][] } = {};
 
     constructor() {
         this._eggList = this.defaults.eggList;
         this._eggSlots = ko.observable(this.defaults.eggSlots);
+        this.queueList = this.defaults.queueList;
+        this.queueSlots = ko.observable(this.defaults.queueSlots);
 
         this._eggList.forEach((egg) => {
             egg.extend({deferred: true});
@@ -116,21 +123,22 @@ class Breeding implements Feature {
                 }
             }
         }
+        this.queueSlots(json['queueSlots'] ?? this.defaults.queueSlots);
+        this.queueList(json['queueList'] ? json['queueList'] : this.defaults.queueList);
     }
 
 
     toJSON(): Record<string, any> {
-        const breedingSave = {};
-        breedingSave['eggList'] = this.eggList.map(function (egg: any) {
-            return egg() === null ? new Egg() : egg().toJSON();
-        }
-        );
-        breedingSave['eggSlots'] = this.eggSlots;
-        return breedingSave;
+        return {
+            eggList: this.eggList.map(egg => egg() === null ? new Egg() : egg().toJSON()),
+            eggSlots: this.eggSlots,
+            queueList: this.queueList(),
+            queueSlots: this.queueSlots(),
+        };
     }
 
     public canBreedPokemon(): boolean {
-        return App.game.party.hasMaxLevelPokemon() && this.hasFreeEggSlot();
+        return App.game.party.hasMaxLevelPokemon() && (this.hasFreeEggSlot() || this.hasFreeQueueSlot());
     }
 
     public hasFreeEggSlot(): boolean {
@@ -141,6 +149,11 @@ class Breeding implements Feature {
             }
         }
         return counter < this._eggSlots();
+    }
+
+    public hasFreeQueueSlot(): boolean {
+        const queueSize = this.queueList().length;
+        return queueSize < this.queueSlots();
     }
 
     public gainEgg(e: Egg) {
@@ -170,9 +183,53 @@ class Breeding implements Feature {
         amount *= App.game.oakItems.calculateBonus(OakItems.OakItem.Blaze_Cassette);
 
         amount = Math.round(amount);
-        for (const egg of this._eggList) {
+        this.eggList.forEach((egg, index) => {
             egg().addSteps(amount);
+            if (this.queueList().length && egg().progress() >= 100) {
+                this.hatchPokemonEgg(index);
+            }
+        });
+    }
+
+    public addPokemonToHatchery(pokemon: PartyPokemon): boolean {
+        // If they have a free eggslot, add the pokemon to the egg now
+        if (this.hasFreeEggSlot()) {
+            return this.gainPokemonEgg(pokemon);
         }
+        // If they have a free queue, add the pokemon to the queue now
+        if (this.hasFreeQueueSlot()) {
+            return this.addToQueue(pokemon);
+        }
+        let message = "You don't have any free egg slots";
+        if (this.queueSlots()) {
+            message += '<br/>Your queue is full';
+        }
+        Notifier.notify({
+            message,
+            type: NotificationConstants.NotificationOption.warning,
+        });
+        return false;
+    }
+
+    public addToQueue(pokemon: PartyPokemon): boolean {
+        const queueSize = this.queueList().length;
+        if (queueSize < this.queueSlots()) {
+            pokemon.breeding = true;
+            this.queueList.push(pokemon.name);
+            return true;
+        }
+        return false;
+    }
+
+    public removeFromQueue(index: number): boolean {
+        console.log('remove from queue:', index);
+        const queueSize = this.queueList().length;
+        if (queueSize > index) {
+            const pokemonName = this.queueList.splice(index, 1)[0];
+            App.game.party._caughtPokemon().find(p => p.name == pokemonName).breeding = false;
+            return true;
+        }
+        return false;
     }
 
     public gainPokemonEgg(pokemon: PartyPokemon): boolean {
@@ -194,6 +251,10 @@ class Breeding implements Feature {
         if (hatched) {
             this._eggList[index](new Egg());
             this.moveEggs();
+            if (this.queueList().length) {
+                const nextEgg = this.createEgg(this.queueList.shift());
+                this.gainEgg(nextEgg);
+            }
         }
     }
 
@@ -252,10 +313,6 @@ class Breeding implements Feature {
         }
     }
 
-    public getEggSlotCost(slot: number): number {
-        return 500 * slot;
-    }
-
     public calculateBaseForm(pokemonName: string): string {
         const devolution = pokemonDevolutionMap[pokemonName];
         // Base form of Pokemon depends on which regions players unlocked
@@ -269,7 +326,11 @@ class Breeding implements Feature {
         }
     }
 
-    public buyEggSlot() {
+    public getEggSlotCost(slot: number): number {
+        return 500 * slot;
+    }
+
+    public buyEggSlot(): void {
         const cost: Amount = this.nextEggSlotCost();
         if (App.game.wallet.hasAmount(cost)) {
             App.game.wallet.loseAmount(cost);
@@ -290,12 +351,16 @@ class Breeding implements Feature {
         this._eggSlots(value);
     }
 
-    public gainEggSlot() {
+    public gainEggSlot(): void {
         if (this.eggSlots === this.eggList.length) {
             console.error('Cannot gain another eggslot.');
             return;
         }
         this.eggSlots += 1;
+    }
+
+    public gainQueueSlot(): void {
+        GameHelper.incrementObservable(this.queueSlots);
     }
 
     get eggList(): Array<KnockoutObservable<Egg>> {
@@ -325,6 +390,15 @@ class Breeding implements Feature {
         return hatchable.reduce((status: CaughtStatus, pname: string) => {
             return Math.min(status, PartyController.getCaughtStatusByName(pname));
         }, CaughtStatus.CaughtShiny);
+    }
+
+    checkCloseModal(): void {
+        if (Settings.getSetting('hideHatchery').value == 'queue' && !this.hasFreeEggSlot() && !this.hasFreeQueueSlot()) {
+            $('#breedingModal').modal('hide');
+        }
+        if (Settings.getSetting('hideHatchery').value == 'egg' && !this.hasFreeEggSlot()) {
+            $('#breedingModal').modal('hide');
+        }
     }
 
 }

--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -9,7 +9,7 @@ class Breeding implements Feature {
     defaults = {
         eggList: [ko.observable(new Egg()), ko.observable(new Egg()), ko.observable(new Egg()), ko.observable(new Egg())],
         eggSlots: 1,
-        queueList: ko.observableArray([]),
+        queueList: [],
         queueSlots: 0,
     };
 
@@ -24,7 +24,7 @@ class Breeding implements Feature {
     constructor() {
         this._eggList = this.defaults.eggList;
         this._eggSlots = ko.observable(this.defaults.eggSlots);
-        this.queueList = this.defaults.queueList;
+        this.queueList = ko.observableArray(this.defaults.queueList);
         this.queueSlots = ko.observable(this.defaults.queueSlots);
 
         this._eggList.forEach((egg) => {

--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -152,8 +152,8 @@ class Breeding implements Feature {
     }
 
     public hasFreeQueueSlot(): boolean {
-        const queueSize = this.queueList().length;
-        return queueSize < this.queueSlots();
+        const slots = this.queueSlots();
+        return slots && this.queueList().length < slots;
     }
 
     public gainEgg(e: Egg) {

--- a/src/scripts/settings/Settings.ts
+++ b/src/scripts/settings/Settings.ts
@@ -114,7 +114,7 @@ Settings.add(new MultipleChoiceSetting('eggAnimation', 'Egg Hatching Animation:'
     ],
     'full'
 ));
-Settings.add(new MultipleChoiceSetting('hideHatchery', 'Hide Hatchery:',
+Settings.add(new MultipleChoiceSetting('hideHatchery', 'Hide Hatchery Modal:',
     [
         new SettingOption('Never', 'never'),
         new SettingOption('Egg Slots Full', 'egg'),

--- a/src/scripts/settings/Settings.ts
+++ b/src/scripts/settings/Settings.ts
@@ -114,6 +114,14 @@ Settings.add(new MultipleChoiceSetting('eggAnimation', 'Egg Hatching Animation:'
     ],
     'full'
 ));
+Settings.add(new MultipleChoiceSetting('hideHatchery', 'Hide Hatchery:',
+    [
+        new SettingOption('Never', 'never'),
+        new SettingOption('Egg Slots Full', 'egg'),
+        new SettingOption('Queue Slots Full', 'queue'),
+    ],
+    'queue'
+));
 
 // Other settings
 Settings.add(new BooleanSetting('disableAutoDownloadBackupSaveOnUpdate', 'Disable automatic backup save downloading when game updates', false));

--- a/src/styles/breeding.less
+++ b/src/styles/breeding.less
@@ -35,7 +35,6 @@
   }
 }
 
-
 .breedingListItem {
   text-align: left;
   margin-bottom: 3px;
@@ -142,6 +141,23 @@
 #middle-column .eggSlot {
   flex-basis: 25%;
   max-width: 25%;
+}
+
+#hatcheryQueue {
+  overflow: hidden;
+  overflow-x: auto;
+  white-space: nowrap;
+  text-align: left;
+  .queuePokemon {
+    border-radius: 50%;
+    border: 1px solid rgba(51, 51, 51, 0.5);
+    padding: 0px;
+    width: 23%;
+    display: inline-block;
+    img {
+      width: 100%;
+    }
+  }
 }
 
 @eggMainColors:

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -464,6 +464,7 @@ img {
 *::-webkit-scrollbar
 {
 	width: 8px;
+	height: 8px;
 	background-color: #F5F5F5;
 }
 


### PR DESCRIPTION
Added Breeding/Hatchery Queue functionality.
Added new setting to hide the hatchery screen (never, when egg slots full, when queue full).
Changed the "egg slots full" warning to take up less space.

_Currently there is no way to obtain any queue slots without the console, not sure on the best way._

Every Pokémon added to the queue their attack is taken away from total attack straight away (as if they were breeding).

If there is Pokémon in the queue, eggs will auto hatch and be replaced by the first Pokémon in the queue.

If the queue is empty, the eggs will not auto hatch.

Click the Pokémon in the queue to remove them from the queue.

Example images:
![image](https://user-images.githubusercontent.com/7288322/95972726-495e2f00-0e6f-11eb-89a4-4afe8f6c9fba.png)
![image](https://user-images.githubusercontent.com/7288322/95972790-5bd86880-0e6f-11eb-9fbd-a6aabcc9bd28.png)
![image](https://user-images.githubusercontent.com/7288322/95972525-0b610b00-0e6f-11eb-9fab-04286d6473f5.png)![image](https://user-images.githubusercontent.com/7288322/95972539-0ef49200-0e6f-11eb-98fb-3f5373412cf3.png)
