### PR TITLE
fix: adds git/editorconfig settings for using LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset and indentation style
+[*.{ts,tsx,js,html,css,scss,less}]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+# Matches the exact files, as these are using a different indentation style
+[{package.json,.tsconfig.json,tslint.json,.eslintrc.js}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.ts		text eol=lf
+*.tsx		text eol=lf
+*.js		text eol=lf
+*.html		text eol=lf
+*.css		text eol=lf
+*.scss		text eol=lf
+*.less		text eol=lf

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ You can reach out on discord to discuss your ideas and how to implement them: ht
 
 # Developer instructions
 
+## Editor/IDE setup
+
+We have an [EditorConfig](https://editorconfig.org/) and linting configured, to help everyone write similar code. You will find our recommended plugins for VSCode below, however you should be able to find a plugin for other IDEs as well.
+
+* [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
+* [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+
 ## Building from Source
 
 First make sure you have git and npm available as command-line utilities (so you should install Git and NodeJS if you don't have them already).


### PR DESCRIPTION
This will set up an [EditorConfig](https://editorconfig.org/) and `.gitattributes` file that should allow for consistent line endings (and indentation) within the project. It will work best if everyone installs the [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) plugin in VSCode (or their IDE of choice), since it will ensure that new files have the correct line endings prior to being committed (otherwise ESLint may complain), but it is not required (`npm run eslint-fix` will resolve the issue as well)

LF endings were chosen over CLRF as most/all Windows editors can handle LF endings, but CLRF often shows additional characters on some Mac/Linux editors. This follows the [recommendation from Git](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration) to use LF line endings when committing code on projects that are not exclusive to Windows.