### PR TITLE
fix(party): rework party list layout to fit in small layouts

### DIFF
--- a/src/components/pokemonListContainer.html
+++ b/src/components/pokemonListContainer.html
@@ -11,17 +11,11 @@
         <td>
             <div>
                 <div class="pokemonName">
-                    <span data-bind="text: name, class: name.length > 15 ? 'squeeze' : ''">Name</span>
+                    <span data-bind="text: name">Name</span>
                     <sup data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)">✨</sup>
                 </div>
-                <div class="pokemonAttack">
-                    Atk: 
-                    <span data-bind="text: attack"></span>
-                </div>
-                <div class="pokemonLevel">
-                    Lvl: 
-                    <span data-bind="text: level"></span>
-                </div>
+                <div class="pokemonAttack" data-bind="text: attack.toLocaleString()"></div>
+                <div class="pokemonLevel" data-bind="text: level"></div>
             </div>
         </td>
     </tr>
@@ -37,6 +31,20 @@
             id="pokemonList"
             class="table table-striped table-hover table-sm m-0"
         >
+            <thead>
+                <tr>
+                    <td></td>
+                    <td>
+                        <div>
+                            <div class="pokemonName">
+                                <span>Name</span>
+                            </div>
+                            <div class="pokemonAttack">Attack</div>
+                            <div class="pokemonLevel">Level</div>
+                        </div>
+                    </td>
+                </tr>
+            </thead>
             <tbody data-bind="template: { name: 'pokemonListTemplate', foreach: PartyController.getSortedList() }"></tbody>
         </table>
     </div>

--- a/src/components/pokemonListContainer.html
+++ b/src/components/pokemonListContainer.html
@@ -1,3 +1,31 @@
+<script type="text/html" id="pokemonListTemplate">
+    <tr>
+        <td>
+            <img
+                class="smallImage"
+                data-bind="attr: { src: PokemonHelper.getImage($data, App.game.party.alreadyCaughtPokemon($data.id, true)) }"
+                src=""
+                alt=""
+            />
+        </td>
+        <td>
+            <div>
+                <div class="pokemonName">
+                    <span data-bind="text: name, class: name.length > 15 ? 'squeeze' : ''">Name</span>
+                    <sup data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)">✨</sup>
+                </div>
+                <div class="pokemonAttack">
+                    Atk: 
+                    <span data-bind="text: attack"></span>
+                </div>
+                <div class="pokemonLevel">
+                    Lvl: 
+                    <span data-bind="text: level"></span>
+                </div>
+            </div>
+        </td>
+    </tr>
+</script>
 <div id="pokemonListContainer" class="card sortable border-secondary mb-3" data-bind="visible: player.starter != GameConstants.Starter.None">
     <div class="card-header p-0" data-toggle="collapse" href="#pokemonListBody">
         <span>Pokémon List</span>
@@ -5,18 +33,11 @@
     <div id="pokemonListBody" class="card-body p-0 show table-responsive">
         <div data-bind="template: { name: 'PartySortSettingTemplate', data: Settings.getSetting('partySort')}"></div>
 
-        <table id="pokemonList" class="table table-striped table-hover table-sm m-0">
-            <thead>
-
-            <tr>
-                <th>Name</th>
-                <th>Atk</th>
-                <th>Lvl</th>
-            </tr>
-            </thead>
-            <tbody data-bind="template: { name: 'pokemonListTemplate', foreach: PartyController.getSortedList() }">
-
-            </tbody>
+        <table
+            id="pokemonList"
+            class="table table-striped table-hover table-sm m-0"
+        >
+            <tbody data-bind="template: { name: 'pokemonListTemplate', foreach: PartyController.getSortedList() }"></tbody>
         </table>
     </div>
 

--- a/src/components/pokemonListContainer.html
+++ b/src/components/pokemonListContainer.html
@@ -1,3 +1,32 @@
+<script type="text/html" id="PartySortSettingTemplate">
+    <div class="row no-gutters" style="align-items: center">
+        <div class="input-group">
+            <select
+                class="custom-select"
+                onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])"
+                data-bind="foreach: $data.options, attr: {name}"
+            >
+                <option data-bind="text: $data.text, value: $data.value, attr:{ selected: $parent.observableValue() == $data.value}"></option>
+            </select>
+            <div class="input-group-append bg-primary text-light">
+                <label
+                    for="partySortDirection"
+                    class="clickable m-0 pl-2 pr-2"
+                    style="font-size: 22px;"
+                    data-bind="text: Settings.getSetting('partySortDirection').observableValue() ? '⥄' : '⥂'"
+                >⥂</label>
+                <input
+                    id="partySortDirection"
+                    style="vertical-align: middle"
+                    class="hidden"
+                    type="checkbox"
+                    data-bind="checked: Settings.getSetting('partySortDirection').observableValue()"
+                    onchange="Settings.setSettingByName('partySortDirection', this.checked)"
+                />
+            </div>
+        </div>
+    </div>
+</script>
 <script type="text/html" id="pokemonListTemplate">
     <tr>
         <td>
@@ -48,20 +77,4 @@
             <tbody data-bind="template: { name: 'pokemonListTemplate', foreach: PartyController.getSortedList() }"></tbody>
         </table>
     </div>
-
-    <script type="text/html" id="PartySortSettingTemplate">
-        <div class="row no-gutters" style="align-items: center">
-            <div class="col-2">Sort:</div>
-            <select class="col-9" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])"
-                    data-bind="foreach: $data.options, attr: {name}">
-                <option data-bind="text: $data.text, value: $data.value, attr:{ selected: $parent.observableValue() == $data.value}"></option>
-            </select>
-            <div class="col-1">
-                <label for="partySortDirection" class="clickable" style="font-size: 24px;" data-bind="text: Settings.getSetting('partySortDirection').observableValue() ? '⥄' : '⥂'">⥂</label>
-                <input id="partySortDirection" style="vertical-align: middle" class="hidden" type='checkbox'
-                       data-bind="checked: Settings.getSetting('partySortDirection').observableValue()"
-                       onchange="Settings.setSettingByName('partySortDirection', this.checked)"/>
-            </div>
-        </div>
-    </script>
 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -5,18 +5,6 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta charset="utf-8"/>
     <link href="assets/images/favicon.ico" rel="icon" type="image/x-icon"/>
-    <script type="text/html" id="pokemonListTemplate">
-        <tr data-bind='ifnot: $data.breeding'>
-            <td class="text-nowrap">
-                <img class="smallImage"
-                     data-bind="attr:{ src: PokemonHelper.getImage($data, App.game.party.alreadyCaughtPokemon($data.id, true)) }"
-                     src=""/>
-                <span data-bind="text: name">Name</span><sup data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)">✨</sup>
-            </td>
-            <td data-bind="text: attack">Atk</td>
-            <td data-bind="text: level">Lvl</td>
-        </tr>
-    </script>
     <script>window.featureFlags = $FEATURE_FLAGS;</script>
 
     <!--jQuery-->

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -27,7 +27,7 @@
   }
 }
 
-  
+
 @media (min-width: 768px) {
   #left-column, #middle-sort-column, #right-column {
     &:empty {
@@ -224,23 +224,33 @@ body:hover {
 #pokemonList {
   span {
     vertical-align: middle;
-  }
-  td {
-    vertical-align: middle;
-    padding: 0 @tablePaddingWidth;
+    line-height: inherit;
   }
 
-  td:first-child {
-    min-width: 60%;
-    text-align: left;
-  }
-  th:first-child {
-    text-align: left;
-  }
-  th {
-    text-align: center;
-    //padding: 0 @tablePaddingWidth;
+  td {
     vertical-align: middle;
+    // Use the width as the height padding as well
+    padding: @tablePaddingWidth;
+
+    > div {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  }
+
+  // Fill the line when we're in small mode
+  .pokemonName { width: 100%; }
+
+  // Name should grow faster than attack and level
+  .pokemonName { flex-grow: 10; }
+  .pokemonAttack, .pokemonLevel { flex-grow: 1; }
+
+  .pokemonAttack { text-align: left; }
+  .pokemonLevel { text-align: right; }
+
+  .col-lg-6 & {
+    .pokemonName { width: auto; }
+    .pokemonAttack { text-align: right; }
   }
 }
 

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -241,6 +241,9 @@ body:hover {
   // Fill the line when we're in small mode
   .pokemonName { width: 100%; }
 
+  // Hide the name header when we're in small mode
+  .col-lg-3 & thead .pokemonName { display: none; }
+
   // Name should grow faster than attack and level
   .pokemonName { flex-grow: 10; }
   .pokemonAttack, .pokemonLevel {

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -243,7 +243,10 @@ body:hover {
 
   // Name should grow faster than attack and level
   .pokemonName { flex-grow: 10; }
-  .pokemonAttack, .pokemonLevel { flex-grow: 1; }
+  .pokemonAttack, .pokemonLevel {
+    flex-grow: 1;
+    min-width: 60px;
+  }
 
   .pokemonAttack { text-align: left; }
   .pokemonLevel { text-align: right; }


### PR DESCRIPTION
Taking an alternative approach to #829 to avoid the challenge of dynamically sizing text. This will stack the pokemon's name above its attack and level in small columns, and keep it on a single line in the center column

| Left/Right column | Center column |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/90011/96385140-312c2f80-114f-11eb-992a-c2db186acfb1.png) | ![image](https://user-images.githubusercontent.com/90011/96385147-3f7a4b80-114f-11eb-8317-2a95c41ff468.png) |

It may be worth doing a bit more work so that the attack/level "column" line up consistently, but I want to see how we feel about this layout first