### PR TITLE
Make Underground a Feature

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2199,7 +2199,7 @@
     y="496"
     height="64"
     width="48"
-    data-bind="click:function(){Underground.openUndergroundModal()}, attr: { class: Underground.canAccess() ? &#39;city unlockedTown&#39; : &#39;city lockedTown&#39; }">
+    data-bind="click:function(){App.game.underground.openUndergroundModal()}, attr: { class: App.game.underground.canAccess() ? &#39;city unlockedTown&#39; : &#39;city lockedTown&#39; }">
 </rect>
 
     
@@ -6613,9 +6613,9 @@
     <div id="shortcutsBody" class="card-body show p-0">
       <table class="table table-sm m-0">
         <tbody>
-          <tr data-bind="visible: Underground.canAccess">
+          <tr data-bind="visible: App.game.underground.canAccess">
             <td class="p-0">
-              <button class="btn btn-block btn-primary m-0" onclick="Underground.openUndergroundModal()">
+              <button class="btn btn-block btn-primary m-0" onclick="App.game.underground.openUndergroundModal()">
                   Underground
               </button>
             </td>
@@ -7706,15 +7706,15 @@ style="cursor:default" tabindex="-1">
                         >
                             <span data-bind="text: '(' + player._itemList[$data]() + ')'">(?)</span>
                             <img class="restore-item" data-bind="attr: { src: 'assets/images/items/' + $data + '.png'}">
-                            <span data-bind="text: ' +' + Underground.calculateItemEffect(GameConstants.EnergyRestoreSize[$data])">&nbsp;+? energy</span>
+                            <span data-bind="text: ' +' + App.game.underground.calculateItemEffect(GameConstants.EnergyRestoreSize[$data])">&nbsp;+? energy</span>
                         </button>
                     </div>
                     <div class='row' style="text-align:center;">
                         <div class='progress'>
                             <div id='mineEnergyBar' class='progress-bar bg-warning' role='progressbar'
                                 aria-valuemin='0' aria-valuemax='100'
-                                data-bind="style: { width: Math.floor(Underground.energy/Underground.getMaxEnergy()*100) + '%' }">
-                                <span data-bind="text: 'Energy: ' + Math.floor(Underground.energy) + ' / ' + Underground.getMaxEnergy() + (Math.floor(Underground.energy) < Underground.getMaxEnergy() ? ' (' + Underground.energyTick() + 's)' : '')"></span>
+                                data-bind="style: { width: Math.floor(App.game.underground.energy/App.game.underground.getMaxEnergy()*100) + '%' }">
+                                <span data-bind="text: 'Energy: ' + Math.floor(App.game.underground.energy) + ' / ' + App.game.underground.getMaxEnergy() + (Math.floor(App.game.underground.energy) < App.game.underground.getMaxEnergy() ? ' (' + Underground.energyTick() + 's)' : '')"></span>
                             </div>
                         </div>
                     </div>
@@ -7767,17 +7767,17 @@ style="cursor:default" tabindex="-1">
                         </thead>
                         <tbody>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getMaxEnergy(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Energy_Max)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getMaxEnergy(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Max)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getMaxItems(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Items_Max)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getMaxItems(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Items_Max)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getEnergyGain(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Energy_Gain)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getEnergyGain(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Gain)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getEnergyRegenTime(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Energy_Regen_Time)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getEnergyRegenTime(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Regen_Time)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getDailyDealsMax(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Daily_Deals_Max)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getDailyDealsMax(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Daily_Deals_Max)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getBombEfficiency(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Bomb_Efficiency)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getBombEfficiency(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Bomb_Efficiency)}}"></tr>
                         </tbody>
                     </table>
                 </div>
@@ -7860,7 +7860,7 @@ style="cursor:default" tabindex="-1">
                 <button class='btn btn-success btn-block'
                         data-bind='css: { disabled: !upgrade.canBuy() },
                                 text: upgrade.isMaxLevel() ? "Max" : "Upgrade",
-                                click: function(){upgrade.buy(); DailyDeal.generateDeals(Underground.getDailyDealsMax(), new Date());}'>
+                                click: function(){upgrade.buy(); DailyDeal.generateDeals(App.game.underground.getDailyDealsMax(), new Date());}'>
                 </button>
             </td>
     </script>

--- a/src/components/KantoSVG.html
+++ b/src/components/KantoSVG.html
@@ -525,7 +525,7 @@
         { name: "Underground Entrance"
         , x: 72, y: 31
         , width: 3, height: 4
-        , databind: "click:function(){Underground.openUndergroundModal()}, attr: { class: Underground.canAccess() ? 'city unlockedTown' : 'city lockedTown' }"
+        , databind: "click:function(){App.game.underground.openUndergroundModal()}, attr: { class: App.game.underground.canAccess() ? 'city unlockedTown' : 'city lockedTown' }"
         })
      %>
 

--- a/src/components/shortcutsContainer.html
+++ b/src/components/shortcutsContainer.html
@@ -5,9 +5,9 @@
     <div id="shortcutsBody" class="card-body show p-0">
       <table class="table table-sm m-0">
         <tbody>
-          <tr data-bind="visible: Underground.canAccess">
+          <tr data-bind="visible: App.game.underground.canAccess">
             <td class="p-0">
-              <button class="btn btn-block btn-primary m-0" onclick="Underground.openUndergroundModal()">
+              <button class="btn btn-block btn-primary m-0" onclick="App.game.underground.openUndergroundModal()">
                   Underground
               </button>
             </td>

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -28,15 +28,15 @@ style="cursor:default" tabindex="-1">
                         >
                             <span data-bind="text: '(' + player._itemList[$data]() + ')'">(?)</span>
                             <img class="restore-item" data-bind="attr: { src: 'assets/images/items/' + $data + '.png'}">
-                            <span data-bind="text: ' +' + Underground.calculateItemEffect(GameConstants.EnergyRestoreSize[$data])">&nbsp;+? energy</span>
+                            <span data-bind="text: ' +' + App.game.underground.calculateItemEffect(GameConstants.EnergyRestoreSize[$data])">&nbsp;+? energy</span>
                         </button>
                     </div>
                     <div class='row no-gutters' style="text-align:center;">
                         <div class='progress'>
                             <div id='mineEnergyBar' class='progress-bar bg-warning' role='progressbar'
                                 aria-valuemin='0' aria-valuemax='100'
-                                data-bind="style: { width: Math.floor(Underground.energy/Underground.getMaxEnergy()*100) + '%' }">
-                                <span data-bind="text: 'Energy: ' + Math.floor(Underground.energy) + ' / ' + Underground.getMaxEnergy() + (Math.floor(Underground.energy) < Underground.getMaxEnergy() ? ' (' + Underground.energyTick() + 's)' : '')"></span>
+                                data-bind="style: { width: Math.floor(App.game.underground.energy/App.game.underground.getMaxEnergy()*100) + '%' }">
+                                <span data-bind="text: 'Energy: ' + Math.floor(App.game.underground.energy) + ' / ' + App.game.underground.getMaxEnergy() + (Math.floor(App.game.underground.energy) < App.game.underground.getMaxEnergy() ? ' (' + Underground.energyTick() + 's)' : '')"></span>
                             </div>
                         </div>
                     </div>
@@ -99,17 +99,17 @@ style="cursor:default" tabindex="-1">
                         </thead>
                         <tbody>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getMaxEnergy(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Energy_Max)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getMaxEnergy(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Max)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getMaxItems(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Items_Max)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getMaxItems(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Items_Max)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getEnergyGain(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Energy_Gain)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getEnergyGain(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Gain)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getEnergyRegenTime(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Energy_Regen_Time)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getEnergyRegenTime(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Regen_Time)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getDailyDealsMax(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Daily_Deals_Max)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getDailyDealsMax(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Daily_Deals_Max)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': Underground.getBombEfficiency(), 'upgrade': Underground.getUpgrade(Underground.Upgrades.Bomb_Efficiency)}}"></tr>
+                                'data': {'totalBonus': App.game.underground.getBombEfficiency(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Bomb_Efficiency)}}"></tr>
                         </tbody>
                     </table>
                 </div>
@@ -192,7 +192,7 @@ style="cursor:default" tabindex="-1">
                 <button class='btn btn-success btn-block'
                         data-bind='css: { disabled: !upgrade.canBuy() },
                                 text: upgrade.isMaxLevel() ? "Max" : "Upgrade",
-                                click: function(){upgrade.buy(); DailyDeal.generateDeals(Underground.getDailyDealsMax(), new Date());}'>
+                                click: function(){upgrade.buy(); DailyDeal.generateDeals(App.game.underground.getDailyDealsMax(), new Date());}'>
                 </button>
             </td>
     </script>

--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -29,6 +29,7 @@ class App {
                 new OakItems([20, 50, 100]),
                 new Party(),
                 new Shards(),
+                new Underground(),
                 new Farming(),
                 new LogBook(),
                 new RedeemableCodes(),

--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -17,7 +17,6 @@ class App {
             // Needs to be loaded first so save data can be updated (specifically "player" data)
             const update = new Update();
 
-            UndergroundItem.initialize();
             player = Save.load();
             App.game = new Game(
                 update,

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -25,6 +25,7 @@ class Game {
         public oakItems: OakItems,
         public party: Party,
         public shards: Shards,
+        public underground: Underground,
         public farming: Farming,
         public logbook: LogBook,
         public redeemableCodes: RedeemableCodes,
@@ -60,6 +61,7 @@ class Game {
         this.pokeballs.initialize();
         this.keyItems.initialize();
         this.oakItems.initialize();
+        this.underground.initialize();
         this.farming.initialize();
         this.specialEvents.initialize();
         this.load();
@@ -67,8 +69,8 @@ class Game {
         // TODO refactor to proper initialization methods
         Battle.generateNewEnemy();
         //Safari.load();
-        Underground.energyTick(Underground.getEnergyRegenTime());
-        DailyDeal.generateDeals(Underground.getDailyDealsMax(), new Date());
+        Underground.energyTick(this.underground.getEnergyRegenTime());
+        DailyDeal.generateDeals(this.underground.getDailyDealsMax(), new Date());
 
         this.gameState = GameConstants.GameState.fighting;
     }
@@ -136,7 +138,7 @@ class Game {
             if (new Date(player._lastSeen).toLocaleDateString() !== now.toLocaleDateString()) {
                 this.quests.resetRefreshes();
                 this.quests.generateQuestList();
-                DailyDeal.generateDeals(Underground.getDailyDealsMax(), now);
+                DailyDeal.generateDeals(this.underground.getDailyDealsMax(), now);
                 Notifier.notify({
                     message: 'It\'s a new day! Your quests and underground deals have been updated.',
                     type: NotificationConstants.NotificationOption.info,
@@ -152,8 +154,8 @@ class Game {
         if (Underground.counter >= GameConstants.UNDERGROUND_TICK) {
             Underground.energyTick(Math.max(0, Underground.energyTick() - 1));
             if (Underground.energyTick() == 0) {
-                Underground.gainEnergy();
-                Underground.energyTick(Underground.getEnergyRegenTime());
+                this.underground.gainEnergy();
+                Underground.energyTick(this.underground.getEnergyRegenTime());
             }
             Underground.counter = 0;
         }

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -15,9 +15,6 @@ class Save {
     public static getSaveObject() {
         const saveObject = {};
 
-        // TODO: Make the Underground a game Feature
-        saveObject[Underground.saveKey] = Underground.save();
-
         Object.keys(App.game).filter(key => App.game[key].saveKey).forEach(key => {
             saveObject[App.game[key].saveKey] = App.game[key].toJSON();
         });
@@ -30,13 +27,6 @@ class Save {
 
         const settings = localStorage.getItem('settings');
         Settings.load(JSON.parse(settings));
-
-
-        const saveJSON = localStorage.getItem('save');
-        if (saveJSON !== null) {
-            const saveObject = JSON.parse(saveJSON);
-            Underground.load(saveObject[Underground.saveKey]);
-        }
 
         if (saved !== 'null') {
             return new Player(JSON.parse(saved));

--- a/src/scripts/items/EnergyRestore.ts
+++ b/src/scripts/items/EnergyRestore.ts
@@ -12,14 +12,14 @@ class EnergyRestore extends Item {
         if (player.itemList[this.name()]() <= 0) {
             return;
         }
-        if (Underground.energy === Underground.getMaxEnergy()) {
+        if (App.game.underground.energy === App.game.underground.getMaxEnergy()) {
             Notifier.notify({
                 message: 'Your mining energy is already full!',
                 type: NotificationConstants.NotificationOption.danger,
             });
             return;
         }
-        Underground.gainEnergyThroughItem(this.type);
+        App.game.underground.gainEnergyThroughItem(this.type);
         player.loseItem(this.name(), 1);
     }
 }

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -35,7 +35,7 @@ class Mine {
         Mine.grid = tmpGrid;
         Mine.rewardGrid = tmpRewardGrid;
 
-        for (let i = 0; i < Underground.getMaxItems(); i++) {
+        for (let i = 0; i < App.game.underground.getMaxItems(); i++) {
             const item = UndergroundItem.getRandomItem();
             const x = Mine.getRandomCoord(this.sizeX, item.space[0].length);
             const y = Mine.getRandomCoord(this.sizeY, item.space.length);
@@ -110,11 +110,11 @@ class Mine {
             return;
         }
 
-        if (Underground.energy < Underground.PROSPECT_ENERGY) {
+        if (App.game.underground.energy < Underground.PROSPECT_ENERGY) {
             return;
         }
 
-        Underground.energy -= Underground.PROSPECT_ENERGY;
+        App.game.underground.energy -= Underground.PROSPECT_ENERGY;
 
         const rewards = Mine.rewardSummary();
         Mine.updateProspectResult(rewards);
@@ -173,7 +173,7 @@ class Mine {
     }
 
     private static hammer(x: number, y: number) {
-        if (Underground.energy >= Underground.HAMMER_ENERGY) {
+        if (App.game.underground.energy >= Underground.HAMMER_ENERGY) {
             if (x < 0 || y < 0) {
                 return;
             }
@@ -187,30 +187,30 @@ class Mine {
                 }
             }
             if (hasMined) {
-                Underground.energy -= Underground.HAMMER_ENERGY;
+                App.game.underground.energy -= Underground.HAMMER_ENERGY;
             }
         }
     }
 
     private static chisel(x: number, y: number) {
         if (Mine.grid[x][y]() > 0) {
-            if (Underground.energy >= Underground.CHISEL_ENERGY) {
+            if (App.game.underground.energy >= Underground.CHISEL_ENERGY) {
                 this.breakTile(x, y, 2);
-                Underground.energy -= Underground.CHISEL_ENERGY;
+                App.game.underground.energy -= Underground.CHISEL_ENERGY;
             }
         }
     }
 
     private static bomb() {
-        const tiles = Underground.getBombEfficiency();
-        if (Underground.energy >= Underground.BOMB_ENERGY) {
+        const tiles = App.game.underground.getBombEfficiency();
+        if (App.game.underground.energy >= Underground.BOMB_ENERGY) {
             for (let i = 1; i < tiles; i++) {
                 const x = GameConstants.randomIntBetween(1, this.sizeY - 2);
                 const y = GameConstants.randomIntBetween(1, this.sizeX - 2);
                 this.breakTile(x, y, 2);
             }
 
-            Underground.energy -= Underground.BOMB_ENERGY;
+            App.game.underground.energy -= Underground.BOMB_ENERGY;
         }
     }
 

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -46,7 +46,7 @@ class Mine {
         }
         Mine.loadingNewLayer = false;
         Mine.itemsFound(0);
-        
+
         Underground.showMine();
     }
 

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -321,10 +321,7 @@ class Mine {
 
     public static save(): Record<string, any> {
         if (this.grid == null) {
-            // This part should only get called when game saves for the first time after catching starter
-            ko.cleanNode(document.getElementById('mineBody'));
             Mine.loadMine();
-            ko.applyBindings(null, document.getElementById('mineBody'));
         }
         const mineSave = {
             grid: this.grid.map(row => row.map(val => val())),

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -6,7 +6,7 @@ class Underground implements Feature {
 
     upgradeList: Array<Upgrade>;
     defaults: Record<string, any>;
-    private _energy: KnockoutObservable<number>;
+    private _energy: KnockoutObservable<number> = ko.observable(0);
 
     public static itemSelected;
     public static energyTick: KnockoutObservable<number> = ko.observable(60);
@@ -17,7 +17,6 @@ class Underground implements Feature {
     
     constructor() {
         this.upgradeList = [];
-        this.energy = 0;
     }
 
     initialize() {

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -13,7 +13,7 @@ class Underground implements Feature {
     public static counter = 0;
 
     public static sortDirection = -1;
-    public static lastPropSort = 'none';    
+    public static lastPropSort = 'none';
     
     constructor() {
         this.upgradeList = [];
@@ -57,7 +57,7 @@ class Underground implements Feature {
                 AmountFactory.createArray(
                     GameHelper.createArray(50, 250, 50), GameConstants.Currency.diamond),
                 GameHelper.createArray(0, 10, 2)
-            )
+            ),
         ];
     }
 

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -1,42 +1,95 @@
-class Underground {
-    public static saveKey = 'underground';
+/// <reference path="../../declarations/GameHelper.d.ts" />
+///<reference path="../underground/UndergroundUpgrade.ts"/>
+class Underground implements Feature {
+    name = 'Underground';
+    saveKey = 'underground';
+
+    upgradeList: Array<Upgrade>;
+    defaults: Record<string, any>;
+    private _energy: KnockoutObservable<number>;
 
     public static itemSelected;
     public static energyTick: KnockoutObservable<number> = ko.observable(60);
     public static counter = 0;
 
     public static sortDirection = -1;
-    public static lastPropSort = 'none';
-
-    private static _energy: KnockoutObservable<number> = ko.observable(0);
-    public static upgradeList: Array<Upgrade> = [];
-
-    public static getMaxEnergy() {
-        return Underground.BASE_ENERGY_MAX + this.getUpgrade(Underground.Upgrades.Energy_Max).calculateBonus();
+    public static lastPropSort = 'none';    
+    
+    constructor() {
+        this.upgradeList = [];
+        this.energy = 0;
     }
 
-    public static getMaxItems() {
-        return Underground.BASE_ITEMS_MAX + this.getUpgrade(Underground.Upgrades.Items_Max).calculateBonus();
+    initialize() {
+        this.upgradeList = [
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Energy_Max, 'Max Energy', 10,
+                AmountFactory.createArray(
+                    GameHelper.createArray(50, 500, 50), GameConstants.Currency.diamond),
+                GameHelper.createArray(0, 100, 10)
+            ),
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Items_Max, 'Max items', 4,
+                AmountFactory.createArray(
+                    GameHelper.createArray(200, 800, 200), GameConstants.Currency.diamond),
+                GameHelper.createArray(0, 4, 1)
+            ),
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Energy_Gain, 'Energy restored', 17,
+                AmountFactory.createArray(
+                    GameHelper.createArray(100, 1700, 100), GameConstants.Currency.diamond),
+                GameHelper.createArray(0, 17, 1)
+            ),
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Energy_Regen_Time, 'Energy regen time', 20,
+                AmountFactory.createArray(
+                    GameHelper.createArray(20, 400, 20), GameConstants.Currency.diamond),
+                GameHelper.createArray(0, 20, 1),
+                false
+            ),
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Daily_Deals_Max, 'Daily deals', 2,
+                AmountFactory.createArray(
+                    GameHelper.createArray(150, 300, 150), GameConstants.Currency.diamond),
+                GameHelper.createArray(0, 2, 1)
+            ),
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Bomb_Efficiency, 'Bomb Efficiency', 5,
+                AmountFactory.createArray(
+                    GameHelper.createArray(50, 250, 50), GameConstants.Currency.diamond),
+                GameHelper.createArray(0, 10, 2)
+            )
+        ];
     }
 
-    public static getEnergyGain() {
-        return Underground.BASE_ENERGY_GAIN + this.getUpgrade(Underground.Upgrades.Energy_Gain).calculateBonus();
+    update(delta: number) {
     }
 
-    public static getEnergyRegenTime() {
-        return Underground.BASE_ENERGY_REGEN_TIME - this.getUpgrade(Underground.Upgrades.Energy_Regen_Time).calculateBonus();
+    getMaxEnergy() {
+        return Underground.BASE_ENERGY_MAX + this.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Max).calculateBonus();
     }
 
-    public static getDailyDealsMax() {
-        return Underground.BASE_DAILY_DEALS_MAX + this.getUpgrade(Underground.Upgrades.Daily_Deals_Max).calculateBonus();
+    getMaxItems() {
+        return Underground.BASE_ITEMS_MAX + this.getUpgrade(UndergroundUpgrade.Upgrades.Items_Max).calculateBonus();
     }
 
-    public static getBombEfficiency() {
-        return Underground.BASE_BOMB_EFFICIENCY + this.getUpgrade(Underground.Upgrades.Bomb_Efficiency).calculateBonus();
+    getEnergyGain() {
+        return Underground.BASE_ENERGY_GAIN + this.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Gain).calculateBonus();
     }
 
+    getEnergyRegenTime() {
+        return Underground.BASE_ENERGY_REGEN_TIME - this.getUpgrade(UndergroundUpgrade.Upgrades.Energy_Regen_Time).calculateBonus();
+    }
 
-    static getUpgrade(upgrade: Underground.Upgrades) {
+    getDailyDealsMax() {
+        return Underground.BASE_DAILY_DEALS_MAX + this.getUpgrade(UndergroundUpgrade.Upgrades.Daily_Deals_Max).calculateBonus();
+    }
+
+    getBombEfficiency() {
+        return Underground.BASE_BOMB_EFFICIENCY + this.getUpgrade(UndergroundUpgrade.Upgrades.Bomb_Efficiency).calculateBonus();
+    }
+
+    getUpgrade(upgrade: UndergroundUpgrade.Upgrades) {
         for (let i = 0; i < this.upgradeList.length; i++) {
             if (this.upgradeList[i].name == upgrade) {
                 return this.upgradeList[i];
@@ -108,7 +161,7 @@ class Underground {
         }
     }
 
-    public static gainEnergy() {
+    gainEnergy() {
         if (this.energy < this.getMaxEnergy()) {
             const oakMultiplier = App.game.oakItems.calculateBonus(OakItems.OakItem.Cell_Battery);
             this.energy = Math.min(this.getMaxEnergy(), this.energy + (oakMultiplier * this.getEnergyGain()));
@@ -124,7 +177,7 @@ class Underground {
         }
     }
 
-    public static gainEnergyThroughItem(item: GameConstants.EnergyRestoreSize) {
+    gainEnergyThroughItem(item: GameConstants.EnergyRestoreSize) {
         // Restore a percentage of maximum energy
         const effect: number = GameConstants.EnergyRestoreEffect[GameConstants.EnergyRestoreSize[item]];
         const gain = Math.min(this.getMaxEnergy() - this.energy, effect * this.getMaxEnergy());
@@ -209,7 +262,7 @@ class Underground {
         return success;
     }
 
-    public static openUndergroundModal() {
+    openUndergroundModal() {
         if (this.canAccess()) {
             $('#mineModal').modal('show');
         } else {
@@ -220,30 +273,30 @@ class Underground {
         }
     }
 
-    private static canAccess() {
+    canAccess() {
         return MapHelper.accessToRoute(11, 0) && App.game.keyItems.hasKeyItem(KeyItems.KeyItem.Explorer_kit);
     }
 
-    public static calculateItemEffect(item: GameConstants.EnergyRestoreSize) {
+    calculateItemEffect(item: GameConstants.EnergyRestoreSize) {
         const effect: number = GameConstants.EnergyRestoreEffect[GameConstants.EnergyRestoreSize[item]];
         return effect * this.getMaxEnergy();
     }
 
-    public static load(saveObject: Record<string, any>): void {
-        if (!saveObject) {
+    fromJSON(json: Record<string, any>): void {
+        if (!json) {
             console.warn('Underground not loaded.');
             return;
         }
 
-        const upgrades = saveObject['upgrades'];
-        for (const item in Underground.Upgrades) {
+        const upgrades = json['upgrades'];
+        for (const item in UndergroundUpgrade.Upgrades) {
             if (isNaN(Number(item))) {
-                Underground.getUpgrade((<any>Underground.Upgrades)[item]).level = upgrades[item] || 0;
+                this.getUpgrade((<any>UndergroundUpgrade.Upgrades)[item]).level = upgrades[item] || 0;
             }
         }
-        this.energy = saveObject['energy'] || 0;
+        this.energy = json['energy'] || 0;
 
-        const mine = saveObject['mine'];
+        const mine = json['mine'];
         if (mine) {
             Mine.loadSavedMine(mine);
         } else {
@@ -251,12 +304,12 @@ class Underground {
         }
     }
 
-    public static save(): Record<string, any> {
+    toJSON(): Record<string, any> {
         const undergroundSave = {};
         const upgradesSave = {};
-        for (const item in Underground.Upgrades) {
+        for (const item in UndergroundUpgrade.Upgrades) {
             if (isNaN(Number(item))) {
-                upgradesSave[item] = Underground.getUpgrade((<any>Underground.Upgrades)[item]).level;
+                upgradesSave[item] = this.getUpgrade((<any>UndergroundUpgrade.Upgrades)[item]).level;
             }
         }
         undergroundSave['upgrades'] = upgradesSave;
@@ -266,11 +319,11 @@ class Underground {
     }
 
     // Knockout getters/setters
-    static get energy(): number {
+    get energy(): number {
         return this._energy();
     }
 
-    static set energy(value) {
+    set energy(value) {
         this._energy(value);
     }
 
@@ -283,15 +336,6 @@ $(document).ready(function () {
 });
 
 namespace Underground {
-    export enum Upgrades {
-        'Energy_Max',
-        'Items_Max',
-        'Energy_Gain',
-        'Energy_Regen_Time',
-        'Daily_Deals_Max',
-        'Bomb_Efficiency',
-    }
-
     export const BASE_ENERGY_MAX = 50;
     export const BASE_ITEMS_MAX = 3;
     export const BASE_ENERGY_GAIN = 3;

--- a/src/scripts/underground/UndergroundItem.ts
+++ b/src/scripts/underground/UndergroundItem.ts
@@ -19,9 +19,6 @@ class UndergroundItem {
         UndergroundItem.list.push(new UndergroundItem(name, id, space, ...rest));
     }
 
-    public static initialize() {
-    }
-
     public static getRandomItem(): UndergroundItem {
         const i = Math.floor(Math.random() * (UndergroundItem.list.length));
         return UndergroundItem.list[i] || UndergroundItem.list[0];

--- a/src/scripts/underground/UndergroundUpgrade.ts
+++ b/src/scripts/underground/UndergroundUpgrade.ts
@@ -3,7 +3,7 @@
 class UndergroundUpgrade extends Upgrade {
 
     constructor(
-        name: UndergroundUpgrade.Upgrades, displayName: string, maxLevel: number, 
+        name: UndergroundUpgrade.Upgrades, displayName: string, maxLevel: number,
         costList: Amount[], bonusList: number[], increasing = true
     ) {
         super(name, displayName, maxLevel, costList, bonusList, increasing);
@@ -25,4 +25,4 @@ namespace UndergroundUpgrade {
         'Daily_Deals_Max',
         'Bomb_Efficiency',
     }
-};
+}

--- a/src/scripts/underground/UndergroundUpgrade.ts
+++ b/src/scripts/underground/UndergroundUpgrade.ts
@@ -1,10 +1,11 @@
-/// <reference path="../../declarations/GameHelper.d.ts" />
-/// <reference path="../wallet/AmountFactory.ts" />
-/// <reference path="../underground/Underground.ts" />
 
+///<reference path="../wallet/AmountFactory.ts"/>
 class UndergroundUpgrade extends Upgrade {
 
-    constructor(name: Underground.Upgrades, displayName: string, maxLevel: number, costList: Amount[], bonusList: number[], increasing = true) {
+    constructor(
+        name: UndergroundUpgrade.Upgrades, displayName: string, maxLevel: number, 
+        costList: Amount[], bonusList: number[], increasing = true
+    ) {
         super(name, displayName, maxLevel, costList, bonusList, increasing);
     }
 
@@ -15,50 +16,13 @@ class UndergroundUpgrade extends Upgrade {
 }
 
 
-Underground.upgradeList.push(
-    new UndergroundUpgrade(
-        Underground.Upgrades.Energy_Max,
-        'Max Energy',
-        10,
-        AmountFactory.createArray(
-            GameHelper.createArray(50, 500, 50), GameConstants.Currency.diamond
-        ),
-        GameHelper.createArray(0, 100, 10)
-    )
-);
-
-Underground.upgradeList.push(
-    new UndergroundUpgrade(Underground.Upgrades.Items_Max, 'Max items', 4,
-        AmountFactory.createArray(GameHelper.createArray(200, 800, 200), GameConstants.Currency.diamond),
-        GameHelper.createArray(0, 4, 1)
-    )
-);
-
-Underground.upgradeList.push(
-    new UndergroundUpgrade(Underground.Upgrades.Energy_Gain, 'Energy restored', 17,
-        AmountFactory.createArray(GameHelper.createArray(100, 1700, 100), GameConstants.Currency.diamond),
-        GameHelper.createArray(0, 17, 1)
-    )
-);
-
-Underground.upgradeList.push(
-    new UndergroundUpgrade(Underground.Upgrades.Energy_Regen_Time, 'Energy regen time', 20,
-        AmountFactory.createArray(GameHelper.createArray(20, 400, 20), GameConstants.Currency.diamond),
-        GameHelper.createArray(0, 20, 1),
-        false
-    )
-);
-
-Underground.upgradeList.push(
-    new UndergroundUpgrade(Underground.Upgrades.Daily_Deals_Max, 'Daily deals', 2,
-        AmountFactory.createArray(GameHelper.createArray(150, 300, 150), GameConstants.Currency.diamond),
-        GameHelper.createArray(0, 2, 1)
-    )
-);
-
-Underground.upgradeList.push(
-    new UndergroundUpgrade(Underground.Upgrades.Bomb_Efficiency, 'Bomb Efficiency', 5,
-        AmountFactory.createArray(GameHelper.createArray(50, 250, 50), GameConstants.Currency.diamond),
-        GameHelper.createArray(0, 10, 2)
-    )
-);
+namespace UndergroundUpgrade {
+    export enum Upgrades {
+        'Energy_Max',
+        'Items_Max',
+        'Energy_Gain',
+        'Energy_Regen_Time',
+        'Daily_Deals_Max',
+        'Bomb_Efficiency',
+    }
+};


### PR DESCRIPTION
Move `Underground` into a part of `Game`, so energy, upgrades and mine state can be saved in the same way `Feature` does. With this change, `Mine` and `mineInventory` remain static objects.