### PR TITLE
Actually deduct shards when purchasing a shard upgrade

### DIFF
--- a/src/scripts/shards/Shards.ts
+++ b/src/scripts/shards/Shards.ts
@@ -39,8 +39,10 @@ class Shards implements Feature {
         if (typeNum == PokemonType.None) {
             return;
         }
+
+        GameHelper.incrementObservable(this.shardWallet[typeNum], amt);
+
         if (amt > 0) {
-            GameHelper.incrementObservable(this.shardWallet[typeNum], amt);
             GameHelper.incrementObservable(App.game.statistics.totalShardsGained, amt);
             GameHelper.incrementObservable(App.game.statistics.shardsGained[typeNum], amt);
         }
@@ -79,7 +81,7 @@ class Shards implements Feature {
             GameHelper.incrementObservable(this.shardUpgrades[typeNum * Shards.nEffects + effectNum]);
         }
     }
-    
+
     public isValidUpgrade(
         typeNum: PokemonType,
         effectNum: GameConstants.TypeEffectiveness


### PR DESCRIPTION
On the dev branch, I notied that shard purchases weren't actually deducting shards when buying shard upgrades. It looks like this started happening a few days ago with the ArrayOfObservable changes. We moved the shard count update in `gainShards` into an `if (amt > 0)` block, even though we remove shards by passing a negative amount  into `gainShards`.


