### PR TITLE
Make Sinnoh stones usable on Unova mons

### DIFF
--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -8434,7 +8434,7 @@ const pokemonList: PokemonListData[] =
             'levelType': LevelType.mediumfast,
             'exp': 58,
             'catchRate': 255,
-            'evolutions': [new StoneEvolution('Bonsly', 'Sudowoodo', GameConstants.StoneType.None)],
+            'evolutions': [new LevelEvolution('Bonsly', 'Sudowoodo', 17)],
             'baby': true,
             'base': {
                 'hitpoints': 50,
@@ -8453,7 +8453,7 @@ const pokemonList: PokemonListData[] =
             'levelType': LevelType.mediumfast,
             'exp': 62,
             'catchRate': 145,
-            'evolutions': [new StoneEvolution('Mime Jr.', 'Mr. Mime', GameConstants.StoneType.None)],
+            'evolutions': [new LevelEvolution('Mime Jr.', 'Mr. Mime', 18)],
             'baby': true,
             'base': {
                 'hitpoints': 20,
@@ -11200,7 +11200,7 @@ const pokemonList: PokemonListData[] =
             'levelType': 4,
             'exp': 60,
             'catchRate': 255,
-            'evolutions': [new StoneEvolution('Minccino', 'Cinccino', GameConstants.StoneType.None)],
+            'evolutions': [new StoneEvolution('Minccino', 'Cinccino', GameConstants.StoneType.Shiny_stone)],
             'base': {
                 'hitpoints': 55,
                 'attack': 50,
@@ -11937,7 +11937,7 @@ const pokemonList: PokemonListData[] =
             'levelType': LevelType.mediumslow,
             'exp': 130,
             'catchRate': 90,
-            'evolutions': [new StoneEvolution('Lampent', 'Chandelure', GameConstants.StoneType.None)],
+            'evolutions': [new StoneEvolution('Lampent', 'Chandelure', GameConstants.StoneType.Dusk_stone)],
             'base': {
                 'hitpoints': 60,
                 'attack': 40,
@@ -13137,7 +13137,7 @@ const pokemonList: PokemonListData[] =
             'levelType': LevelType.mediumfast,
             'exp': 130,
             'catchRate': 120,
-            'evolutions': [new StoneEvolution('Floette', 'Florges', GameConstants.StoneType.None)],
+            'evolutions': [new StoneEvolution('Floette', 'Florges', GameConstants.StoneType.Shiny_stone)],
             'base': {
                 'hitpoints': 54,
                 'attack': 45,
@@ -13312,7 +13312,7 @@ const pokemonList: PokemonListData[] =
             'levelType': LevelType.mediumfast,
             'exp': 157,
             'catchRate': 90,
-            'evolutions': [new StoneEvolution('Doublade', 'Aegislash', GameConstants.StoneType.None)],
+            'evolutions': [new StoneEvolution('Doublade', 'Aegislash', GameConstants.StoneType.Dusk_stone)],
             'base': {
                 'hitpoints': 59,
                 'attack': 110,
@@ -14743,7 +14743,7 @@ const pokemonList: PokemonListData[] =
             'levelType': LevelType.mediumslow,
             'exp': 102,
             'catchRate': 120,
-            'evolutions': [new StoneEvolution('Steenee', 'Tsareena', GameConstants.StoneType.None)],
+            'evolutions': [new LevelEvolution('Steenee', 'Tsareena', 28)],
             'base': {
                 'hitpoints': 52,
                 'attack': 40,


### PR DESCRIPTION
I searched for "StoneType.none" in PokemonList.ts
I've changed the stonetype for Lampent to Dusk stone, and Minccino to Shiny stone.
I've changed Bonsly and Mine Jr. to levelup evolutions. Because why not. Not that it changes anything in practice, oh well. They are both move based evolutions, both based on Mimic. Bonsly learns it at 17, Mime Jr. at 18.

I also changed some Kalos Pokémon, best to avoid potential future problems with that:
I've changed the stonetype for Floette to Shiny stone, and Doublade to Dusk stone.
There are still several StoneType.none situations in there. Happiny and Mantyke aren't very important. 

The rest is Alola stuff:
Charjabug and Crabrawler are Alola location based evolutions. I haven't touched those. I have changed Steenee, which is also a move based evolution. Stomp, at 28. Poidole is also move based. From Dragon Pulse. Which it learns at level 1. Honestly, I have no idea for this one. Level 1 is a bit early for a UB. Finally there is Meltan. Which. Uhm. Yeah. 400 Meltan Candy in PoGo. IDK.