### PR TITLE
fix(statistics): Fix bug with length property

### DIFF
--- a/src/modules/DataStore/StatisticStore/index.ts
+++ b/src/modules/DataStore/StatisticStore/index.ts
@@ -133,7 +133,7 @@ export default class Statistics implements Saveable {
             // We use a proxy to generate new array observables on the fly.
             this[array] = new Proxy([], {
                 get: (statistics, prop: string) => {
-                    if (statistics[prop]) {
+                    if (typeof statistics[prop] !== 'undefined') {
                         return statistics[prop];
                     }
 
@@ -174,7 +174,7 @@ export default class Statistics implements Saveable {
         this.objectObservables.forEach((object) => {
             this[object] = new Proxy({}, {
                 get: (statistics, prop: string) => {
-                    if (statistics[prop]) {
+                    if (typeof statistics[prop] !== 'undefined') {
                         return statistics[prop];
                     }
 


### PR DESCRIPTION
This is a small fix that should prevent the warning about `length` being an invalid property on new saves (because `0` is a falsey value). This will return whatever value is set, as long as it isn't undefined, so both `0` and an observable will be properly returned

closes #947 