### PR TITLE
change(encounters): Use Pokémon Yellow version encounters

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -75,7 +75,7 @@ dungeonList['Digletts Cave'] = new Dungeon('Digletts Cave',
 );
 
 dungeonList['Mt. Moon'] = new Dungeon('Mt. Moon',
-    ['Sandshrew', 'Clefairy', 'Zubat', 'Paras', 'Geodude', 'Pidgeotto'],
+    ['Sandshrew', 'Clefairy', 'Zubat', 'Paras', 'Geodude'],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.Token_collector],
     834,
     [new DungeonBossPokemon('Kabuto', 4170, 12), new DungeonBossPokemon('Omanyte', 4170, 12)],
@@ -91,7 +91,7 @@ dungeonList['Rock Tunnel'] = new Dungeon('Rock Tunnel',
 );
 
 dungeonList['Power Plant'] = new Dungeon('Power Plant',
-    ['Pikachu', 'Raichu', 'Magnemite', 'Magneton', 'Grimer', 'Muk', 'Electrode'],
+    ['Pikachu', 'Raichu', 'Magnemite', 'Magneton', 'Grimer', 'Muk', 'Voltorb', 'Electrode'],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Lucky_incense],
     13507,
     [new DungeonBossPokemon('Electabuzz', 67535, 35), new DungeonBossPokemon('Zapdos', 101302, 50)],
@@ -107,7 +107,7 @@ dungeonList['Pokemon Tower'] = new Dungeon('Pokemon Tower',
 );
 
 dungeonList['Seafoam Islands'] = new Dungeon('Seafoam Islands',
-    ['Zubat', 'Golbat', 'Psyduck', 'Golduck', 'Slowpoke', 'Slowbro', 'Shellder', 'Krabby', 'Horsea', 'Staryu'],
+    ['Zubat', 'Golbat', 'Goldeen', 'Poliwag', 'Magikarp', 'Slowpoke', 'Slowbro', 'Tentacool', 'Krabby', 'Kingler', 'Staryu'],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Lucky_egg],
     17226,
     [new DungeonBossPokemon('Seel', 86130, 35), new DungeonBossPokemon('Articuno', 129195, 50)],
@@ -115,7 +115,7 @@ dungeonList['Seafoam Islands'] = new Dungeon('Seafoam Islands',
 );
 
 dungeonList['Pokemon Mansion'] = new Dungeon('Pokemon Mansion',
-    ['Growlithe', 'Vulpix', 'Grimer', 'Muk', 'Koffing', 'Weezing'],
+    ['Rattata', 'Raticate', 'Growlithe', 'Grimer', 'Muk', 'Koffing', 'Weezing', 'Ditto'],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Token_collector],
     17760,
     [new DungeonBossPokemon('Magmar', 88800, 40)],
@@ -123,7 +123,7 @@ dungeonList['Pokemon Mansion'] = new Dungeon('Pokemon Mansion',
 );
 
 dungeonList['Victory Road'] = new Dungeon('Victory Road',
-    ['Zubat', 'Golbat', 'Machop', 'Geodude', 'Graveler', 'Onix', 'Marowak', 'Venomoth'],
+    ['Zubat', 'Golbat', 'Geodude', 'Graveler', 'Onix'],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
     24595,
     [new DungeonBossPokemon('Machoke', 122975, 42), new DungeonBossPokemon('Moltres', 184462, 50)],
@@ -131,7 +131,7 @@ dungeonList['Victory Road'] = new Dungeon('Victory Road',
 );
 
 dungeonList['Cerulean Cave'] = new Dungeon('Cerulean Cave',
-    ['Arbok', 'Raichu', 'Sandslash', 'Golbat', 'Parasect', 'Venomoth', 'Kadabra', 'Magneton', 'Dodrio', 'Hypno', 'Ditto', 'Wigglytuff', 'Electrode', 'Marowak', 'Chansey'],
+    ['Arbok', 'Raichu', 'Sandslash', 'Golbat', 'Gloom', 'Parasect', 'Venomoth', 'Weepinbell', 'Graveler', 'Ditto', 'Chansey', 'Magikarp', 'Poliwag', 'Goldeen', 'Seaking'],
     [GameConstants.BattleItemType.xAttack, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Lucky_incense],
     28735,
     [new DungeonBossPokemon('Rhydon', 143675, 60), new DungeonBossPokemon('Mewtwo', 215512, 70)],

--- a/src/scripts/wildBattle/Routes.ts
+++ b/src/scripts/wildBattle/Routes.ts
@@ -57,14 +57,14 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 2', GameConstants.Region.kanto, 2,
     new RoutePokemon({
-        land: ['Caterpie', 'Weedle', 'Rattata', 'Nidoran(F)', 'Nidoran(M)'],
+        land: ['Pidgey', 'Rattata', 'Nidoran(F)', 'Nidoran(M)'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 1)]
 ));
 Routes.add(new RegionRoute(
     'Kanto Route 3', GameConstants.Region.kanto, 3,
     new RoutePokemon({
-        land: ['Pidgey', 'Rattata', 'Spearow', 'Sandshrew', 'Jigglypuff', 'Mankey'],
+        land: ['Rattata', 'Spearow', 'Sandshrew', 'Mankey'],
     }),
     [
         new RouteKillRequirement(10, GameConstants.Region.kanto, 2),
@@ -75,7 +75,7 @@ Routes.add(new RegionRoute(
     'Kanto Route 4', GameConstants.Region.kanto, 4,
     new RoutePokemon({
         land: ['Rattata', 'Spearow', 'Ekans', 'Sandshrew', 'Mankey'],
-        water: ['Poliwag', 'Goldeen', 'Psyduck', 'Krabby', 'Seaking'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Seaking'],
     }),
     [
         new RouteKillRequirement(10, GameConstants.Region.kanto, 3),
@@ -85,8 +85,8 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 24', GameConstants.Region.kanto, 24,
     new RoutePokemon({
-        land: ['Caterpie', 'Metapod', 'Weedle', 'Kakuna', 'Pidgey', 'Pidgey', 'Pidgeotto', 'Oddish', 'Venonat', 'Abra', 'Bellsprout'],
-        water: ['Poliwag', 'Goldeen', 'Psyduck', 'Krabby', 'Seaking'],
+        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Venonat', 'Bellsprout'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Seaking'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 4)],
     4.1
@@ -94,8 +94,8 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 25', GameConstants.Region.kanto, 25,
     new RoutePokemon({
-        land: ['Caterpie', 'Metapod', 'Weedle', 'Kakuna', 'Pidgey', 'Pidgeotto', 'Oddish', 'Venonat', 'Abra', 'Bellsprout'],
-        water: ['Poliwag', 'Goldeen', 'Psyduck', 'Krabby'],
+        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Venonat', 'Bellsprout'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Krabby', 'Kingler'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 24)],
     4.2
@@ -103,7 +103,7 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 5', GameConstants.Region.kanto, 5,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Jigglypuff', 'Oddish', 'Meowth', 'Mankey', 'Abra', 'Bellsprout'],
+        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Jigglypuff', 'Mewoth', 'Abra'],
     }),
     [
         // Need to reach bills house
@@ -113,16 +113,16 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 6', GameConstants.Region.kanto, 6,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Jigglypuff', 'Oddish', 'Meowth', 'Mankey', 'Abra', 'Bellsprout'],
-        water: ['Poliwag', 'Goldeen', 'Shellder', 'Krabby'],
+        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Jigglypuff', 'Meowth', 'Abra'],
+        water: ['Psyduck', 'Golduck', 'Magikarp', 'Poliwag', 'Goldeen'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 5)]
 ));
 Routes.add(new RegionRoute(
     'Kanto Route 11', GameConstants.Region.kanto, 11,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Raticate', 'Rattata', 'Spearow', 'Ekans', 'Sandshrew', 'Drowzee'],
-        water: ['Poliwag', 'Goldeen', 'Tentacool', 'Shellder', 'Krabby', 'Horsea'],
+        land: ['Pidgey', 'Pidgeotto', 'Raticate', 'Rattata', 'Drowzee'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Tentacool', 'Horsea'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 6)],
     6.1
@@ -130,7 +130,7 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 9', GameConstants.Region.kanto, 9,
     new RoutePokemon({
-        land: ['Rattata', 'Raticate', 'Spearow', 'Fearow', 'Ekans', 'Sandshrew', 'Nidoran(F)', 'Nidoran(M)', 'Nidorina', 'Nidorino'],
+        land: ['Rattata', 'Raticate', 'Spearow', 'Fearow', 'Nidoran(F)', 'Nidoran(M)', 'Nidorina', 'Nidorino'],
     }),
     [
         new RouteKillRequirement(10, GameConstants.Region.kanto, 6),
@@ -140,8 +140,8 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 10', GameConstants.Region.kanto, 10,
     new RoutePokemon({
-        land: ['Rattata', 'Raticate', 'Spearow', 'Ekans', 'Sandshrew', 'Nidoran(F)', 'Nidoran(M)', 'Machop', 'Magnemite', 'Voltorb'],
-        water: ['Poliwag', 'Goldeen', 'Poliwhirl', 'Slowpoke', 'Krabby', 'Kingler', 'Horsea'],
+        land: ['Rattata', 'Raticate', 'Nidoran(F)', 'Nidoran(M)', 'Machop', 'Magnemite'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Krabby', 'Kingler', 'Horsea'],
     }),
     [
         new RouteKillRequirement(10, GameConstants.Region.kanto, 9),
@@ -151,7 +151,7 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 7', GameConstants.Region.kanto, 7,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Vulpix', 'Jigglypuff', 'Oddish', 'Meowth', 'Mankey', 'Growlithe', 'Abra', 'Bellsprout'],
+        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Vulpix', 'Jigglypuff', 'Meowth', 'Abra', 'Kadabra'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 10)],
     10.1
@@ -159,7 +159,7 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 8', GameConstants.Region.kanto, 8,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Ekans', 'Sandshrew', 'Vulpix', 'Jigglypuff', 'Meowth', 'Mankey', 'Growlithe', 'Abra', 'Kadabra'],
+        land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Vulpix', 'Jigglypuff', 'Meowth', 'Abra'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 7)],
     10.2
@@ -167,16 +167,16 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 12', GameConstants.Region.kanto, 12,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Gloom', 'Venonat', 'Bellsprout', 'Weepinbell', 'Farfetch\'d', 'Snorlax'],
-        water: ['Slowbro', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacool', 'Krabby', 'Horsea', 'Seadra'],
+        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Gloom', 'Bellsprout', 'Weepinbell', 'Farfetch\'d', 'Snorlax'],
+        water: ['Slowpoke', 'Slowbro', 'Magikarp', 'Poliwag', 'Goldeen', 'Horsea', 'Seadra'],
     }),
     [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Pokemon Tower'))]
 ));
 Routes.add(new RegionRoute(
     'Kanto Route 13', GameConstants.Region.kanto, 13,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Gloom', 'Venonat', 'Bellsprout', 'Weepinbell', 'Farfetch\'d', 'Ditto'],
-        water: ['Slowbro', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacool', 'Krabby', 'Horsea', 'Seadra'],
+        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Gloom', 'Bellsprout', 'Weepinbell', 'Farfetch\'d'],
+        water: ['Slowpoke', 'Slowbro', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacool', 'Horsea', 'Seadra'],
     }),
     [
         new OneFromManyRequirement([
@@ -188,8 +188,8 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 14', GameConstants.Region.kanto, 14,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Gloom', 'Venonat', 'Venomoth', 'Bellsprout', 'Weepinbell', 'Ditto'],
-        water: ['Poliwag', 'Goldeen'],
+        land: ['Pidgeotto', 'Oddish', 'Gloom', 'Venonat', 'Venomoth', 'Bellsprout', 'Weepinbell'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen'],
     }),
     [
         new OneFromManyRequirement([
@@ -201,7 +201,7 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 15', GameConstants.Region.kanto, 15,
     new RoutePokemon({
-        land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Gloom', 'Venonat', 'Venomoth', 'Bellsprout', 'Weepinbell', 'Ditto'],
+        land: ['Pidgeotto', 'Oddish', 'Gloom', 'Venonat', 'Venomoth', 'Bellsprout', 'Weepinbell'],
     }),
     [
         new OneFromManyRequirement([
@@ -220,8 +220,8 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 17', GameConstants.Region.kanto, 17,
     new RoutePokemon({
-        land: ['Raticate', 'Spearow', 'Fearow', 'Ponyta', 'Doduo', 'Dodrio'],
-        water: ['Poliwag', 'Goldeen', 'Tentacool', 'Shellder', 'Krabby'],
+        land: ['Fearow', 'Ponyta', 'Doduo', 'Dodrio'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Tentacool', 'Shellder'],
     }),
     [
         new OneFromManyRequirement([
@@ -234,7 +234,7 @@ Routes.add(new RegionRoute(
     'Kanto Route 18', GameConstants.Region.kanto, 18,
     new RoutePokemon({
         land: ['Rattata', 'Raticate', 'Spearow', 'Fearow', 'Doduo'],
-        water: ['Poliwag', 'Goldeen', 'Tentacool', 'Shellder', 'Krabby'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Tentacool', 'Shellder'],
     }),
     [
         new OneFromManyRequirement([
@@ -246,14 +246,14 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Kanto Route 19', GameConstants.Region.kanto, 19,
     new RoutePokemon({
-        water: ['Tentacool', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacruel', 'Shellder', 'Horsea', 'Staryu'],
+        water: ['Tentacool', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacruel', 'Staryu'],
     }),
     [new GymBadgeRequirement(BadgeEnums.Soul)]
 ));
 Routes.add(new RegionRoute(
     'Kanto Route 20', GameConstants.Region.kanto, 20,
     new RoutePokemon({
-        water: ['Tentacool', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacruel', 'Shellder', 'Horsea', 'Staryu'],
+        water: ['Tentacool', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacruel', 'Staryu'],
     }),
     [
         new OneFromManyRequirement([
@@ -266,7 +266,7 @@ Routes.add(new RegionRoute(
     'Kanto Route 21', GameConstants.Region.kanto, 21,
     new RoutePokemon({
         land: ['Pidgey', 'Pidgeotto', 'Rattata', 'Raticate', 'Tangela'],
-        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Tentacruel', 'Shellder', 'Horsea', 'Staryu'],
+        water: ['Tentacool', 'Magikarp', 'Poliwag', 'Goldeen', 'Tentacruel', 'Staryu'],
     }),
     [new GymBadgeRequirement(BadgeEnums.Soul)]
 ));
@@ -274,15 +274,15 @@ Routes.add(new RegionRoute(
     'Kanto Route 22', GameConstants.Region.kanto, 22,
     new RoutePokemon({
         land: ['Rattata', 'Spearow', 'Nidoran(F)', 'Nidoran(M)', 'Mankey'],
-        water: ['Poliwag', 'Poliwhirl', 'Goldeen'],
+        water: ['Magikarp', 'Poliwag', 'Poliwhirl', 'Goldeen'],
     }),
     [new GymBadgeRequirement(BadgeEnums.Earth)]
 ));
 Routes.add(new RegionRoute(
     'Kanto Route 23', GameConstants.Region.kanto, 23,
     new RoutePokemon({
-        land: ['Spearow', 'Fearow', 'Ekans', 'Arbok', 'Sandshrew', 'Sandslash', 'Nidorina', 'Nidorino', 'Mankey', 'Primeape', 'Ditto'],
-        water: ['Poliwag', 'Goldeen', 'Poliwhirl', 'Slowbro', 'Kingler', 'Seadra', 'Seaking'],
+        land: ['Fearow', 'Nidorina', 'Nidorino', 'Mankey', 'Primeape'],
+        water: ['Magikarp', 'Poliwag', 'Goldeen', 'Poliwhirl'],
     }),
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 22)]
 ));


### PR DESCRIPTION
Changed many encounters in Kanto routes and dungeons to make them more accurate to Yellow.
You'll notice encounters for routes 8 and 7 do not match what you will find on Bulbapedia. That's because those routes are in the wrong place. They need to be swapped. With this change to Routes.ts the Pokémon are in the right place, the route numbers are not.
I kept Tangela on route 21 and Chansey in Cerulean Cave as a mercy. They aren't there in Yellow. If the new Safari change works out this might be something to come back to. (In that case the Venonat line should also be removed from Safari.)
There are wild Pikachu and Raichu where there shouldn't be, even after these changes. Yellow has 0 wild Pikachu. Can't have that of course, gotta keep the yellow mouse available. Could move it to an egg...
I've kept version exclusives in mind. Everything should still be obtainable though it's very possible I missed something so please look it over.