### PR TITLE
Party List Refactor

### DIFF
--- a/src/components/breeding.html
+++ b/src/components/breeding.html
@@ -34,117 +34,14 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
 
             <div class="tab-content p-3">
                 <div class="tab-pane active" id="breeding-pokemon">
-                    <div class="text-left">
-                        <div class="form-row collapse" id="breeding-filter">
-                            <div class="form-group col-md-6 col-6">
-                                <label>Search</label>
-                                <input autocomplete="off" class="form-control" oninput="BreedingController.filter.search(new RegExp(`(${this.value})`, 'i'))" placeholder="search here"/>
-                            </div>
-                            <div class="form-group col-md-3 col-6">
-                                <label>Display Value</label>
-                                <select autocomplete="off" class="custom-select" onchange="BreedingController.displayValue(this.value)">
-                                    <option value="attack" selected>Attack</option>
-                                    <option value="attackBonus">Attack Bonus</option>
-                                    <option value="baseAttack">Base Attack</option>
-                                    <option value="eggSteps">Egg Steps</option>
-                                    <option value="timesHatched">Times Hatched</option>
-                                </select>
-                            </div>
-                            <div class="form-group col-md-3 col-6">
-                                <label>Category</label>
-                                <select autocomplete="off" class="custom-select" onchange="BreedingController.filter.category(this.value)">
-                                    <option value="-1">All</option>
-                                    <!-- ko foreach: PokemonCategories.categories -->
-                                    <option style="color: whitesmoke" data-bind="attr: { value: $index }, text: $data.name, style: { background: $data.color }">Category</option>
-                                    <!-- /ko -->
-                                </select>
-                            </div>
-                            <div class="form-group col-md-3 col-6">
-                                <label>Region</label>
-                                <select autocomplete="off" class="custom-select" onchange="BreedingController.filter.region(+this.value)">
-                                    <option value="-2">All</option>
-                                    <!-- ko foreach: GameHelper.enumStrings(GameConstants.Region).filter(r => r != 'none' && GameConstants.Region[r] <= player.highestRegion()) -->
-                                    <option data-bind="attr: { value: GameConstants.Region[$data] }, text: GameConstants.camelCaseToString($data)">Region</option>
-                                    <!-- /ko -->
-                                    <option value="-1">None</option>
-                                </select>
-                            </div>
-                            <div class="form-group col-md-3 col-6">
-                                <label>Shiny Status</label>
-                                <select autocomplete="off" class="custom-select" onchange="BreedingController.filter.shinyStatus(+this.value)">
-                                    <option value="-1">All</option>
-                                    <option value="0">Not Shiny</option>
-                                    <option value="1">Shiny</option>
-                                </select>
-                            </div>
-                            <div class="form-group col-md-3 col-6">
-                                <label>Type</label>
-                                <select autocomplete="off" class="custom-select" onchange="BreedingController.filter.type1(+this.value)">
-                                    <option value="-2">All</option>
-                                    <!-- ko foreach: GameHelper.enumStrings(PokemonType).filter(t => t != 'None') -->
-                                    <option data-bind="attr: { value: PokemonType[$data] }, text: $data">Type</option>
-                                    <!-- /ko -->
-                                    <option value="-1">None</option>
-                                </select>
-                            </div>
-                            <div class="form-group col-md-3 col-6">
-                                <label>Type</label>
-                                <select autocomplete="off" class="custom-select" onchange="BreedingController.filter.type2(+this.value)">
-                                    <option value="-2">All</option>
-                                    <!-- ko foreach: GameHelper.enumStrings(PokemonType).filter(t => t != 'None') -->
-                                    <option data-bind="attr: { value: PokemonType[$data] }, text: $data">Type</option>
-                                    <!-- /ko -->
-                                    <option value="-1">None</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-row collapse" id="breeding-sort">
-                            <div class="form-group col" data-bind="with: Settings.getSetting('partySort')">
-                                <label>Sort</label>
-                                <div class="input-group">
-                                    <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])"
-                                        data-bind="foreach: $data.options, attr: {name}, selectedOptions: [$data.observableValue()]">
-                                        <option data-bind="text: $data.text, value: $data.value"></option>
-                                    </select>
-                                    <div class="input-group-append bg-primary text-light">
-                                        <label for="hatcheryPartySortDirection" class="clickable m-0 pl-2 pr-2" style="font-size: 22px;" data-bind="text: Settings.getSetting('partySortDirection').observableValue() ? '⥄' : '⥂'">⥂</label>
-                                        <input id="hatcheryPartySortDirection" style="vertical-align: middle" class="hidden" type='checkbox'
-                                            data-bind="checked: Settings.getSetting('partySortDirection').observableValue()"
-                                            onchange="Settings.setSettingByName('partySortDirection', this.checked)"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <div data-bind="template: { name: 'partyListFilterTemplate', data: {'name': 'breeding'} }"></div>
                     <div>
                         <!-- Check if the player has any level 100 Pokémon or if they have any eggs -->
                         <p class="bg-danger my-0" data-bind="visible: !App.game.party.hasMaxLevelPokemon()">
                             Unfortunately, you don't have any pokémon of level 100 to breed.
                         </p>
                         <!-- ko if: App.game.party.hasMaxLevelPokemon() -->
-                        <ul class="row justify-content-center p-0" data-bind="foreach: App.game.party.caughtPokemon">
-                            <li class="eggSlot col-sm-4 col-md-3 col-lg-2 pokedexEntry text-nowrap" data-bind="visible: BreedingController.visible($data), style:{background: PokedexHelper.getBackgroundColors($data.name)}, class: App.game.breeding.hasFreeEggSlot() || App.game.breeding.hasFreeQueueSlot() ? '' : 'disabled'">
-                                <span style="top: 0; border-top-left-radius: 6px; border-top-right-radius: 6px;" data-bind="text: $data.name">name</span>
-                                <div data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)" style="position: absolute;right: 0px;top: 0px;">✨</div>
-                                <img src="" width="80px" data-bind="attr:{ src: PokedexHelper.getImage($data.id)}">
-                                <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: BreedingController.getDisplayValue($data)">value</span>
-                                <a class="overlay" href="#breed" data-bind="click: function() { App.game.breeding.addPokemonToHatchery($data); App.game.breeding.checkCloseModal();}"></a>
-                                <div class="pokemonCategory dropdown">
-                                    <button data-toggle="dropdown" data-bind="class: `category-${$data.category + 1}`"></button>
-                                    <div class="dropdown-menu p-0">
-                                        <!-- ko foreach: PokemonCategories.categories -->
-                                        <a class="dropdown-item category" href="#" data-bind="text: $data.name, click: () => { $parent.category = $index() }">Category</a>
-                                        <!-- /ko -->
-                                        <a class="dropdown-item bg-dark py-1" href="#categoryModal" data-toggle="modal"><i>Edit</i></a>
-                                    </div>
-                                </div>
-                                <div class="sidebar">
-                                    <a class="useProtein" href="#useProtein" data-bind="class: ItemHandler.hasItem('Protein') && $data.canUseProtein() ? '' : 'disabled', click: function() { $data.useProtein(); }">
-                                        <img class="p-0" src="assets/images/items/Protein.png" width="100%" height="100%"/>
-                                    </a>
-                                </div>
-                            </li>
-                        </ul>
+                        <div data-bind="template: { name: 'partyListTemplate', data: {'controller': BreedingController, 'showProtein': true } }"></div>
                         <!-- /ko -->
                     </div>
                 </div>

--- a/src/components/damageCalculatorModal.html
+++ b/src/components/damageCalculatorModal.html
@@ -28,8 +28,8 @@ aria-labelledby="damageCalculatorModalLabel" aria-hidden="true">
                 <div class="form-row m-0">
                     <div class="form-group col-md-3 col-6 align-self-center">
                         <div class="form-check">
-                            <input id="damage-calc-include-breeding" class="form-check-input" type="checkbox" autocomplete="off" data-bind="checked: DamageCalculator.includeBreeding"></input>
-                            <label for="damage-calc-include-breeding" class="form-check-label">Include Breeding</label>
+                            <input id="damage-calc-include-nonbattle" class="form-check-input" type="checkbox" autocomplete="off" data-bind="checked: DamageCalculator.includeNonBattle"></input>
+                            <label for="damage-calc-include-nonbattle" class="form-check-label">Include Non-Battle Pokémon</label>
                         </div>
                         <div class="form-check">
                             <input id="damage-calc-use-base" class="form-check-input" type="checkbox" autocomplete="off" data-bind="checked: DamageCalculator.baseAttackOnly"></input>

--- a/src/components/pokemonListContainer.html
+++ b/src/components/pokemonListContainer.html
@@ -53,7 +53,7 @@
                 </tr>
             </thead>
             <tbody data-bind="foreach: PartyController.getSortedList()">
-                <tr data-bind="hidden: $data.breeding">
+                <tr data-bind="hidden: $data.location === PartyPokemon.Battle">
                     <td>
                         <img
                             class="smallImage"

--- a/src/components/templates/partyListFilterTemplate.html
+++ b/src/components/templates/partyListFilterTemplate.html
@@ -1,0 +1,88 @@
+<!-- To be used in conjunction with the partyListTemplate -->
+<!-- Example usage -->
+<!-- <div data-bind="template: { name: 'partyListFilterTemplate', data: {'name': 'breeding'}}"></div> -->
+
+<script type="text/html" id="partyListFilterTemplate">
+    <div class="text-left">
+        <div class="form-row collapse" data-bind="attr: { id: $data.name + '-filter' }">
+            <div class="form-group col-md-6 col-6">
+                <label>Search</label>
+                <input autocomplete="off" class="form-control" oninput="PartyListController.filter.search(new RegExp(`(${this.value})`, 'i'))" placeholder="search here"/>
+            </div>
+            <div class="form-group col-md-3 col-6">
+                <label>Display Value</label>
+                <select autocomplete="off" class="custom-select" onchange="PartyListController.displayValue(this.value)">
+                    <option value="attack" selected>Attack</option>
+                    <option value="attackBonus">Attack Bonus</option>
+                    <option value="baseAttack">Base Attack</option>
+                    <option value="eggSteps">Egg Steps</option>
+                    <option value="timesHatched">Times Hatched</option>
+                </select>
+            </div>
+            <div class="form-group col-md-3 col-6">
+                <label>Category</label>
+                <select autocomplete="off" class="custom-select" onchange="PartyListController.filter.category(this.value)">
+                    <option value="-1">All</option>
+                    <!-- ko foreach: PokemonCategories.categories -->
+                    <option style="color: whitesmoke" data-bind="attr: { value: $index }, text: $data.name, style: { background: $data.color }">Category</option>
+                    <!-- /ko -->
+                </select>
+            </div>
+            <div class="form-group col-md-3 col-6">
+                <label>Region</label>
+                <select autocomplete="off" class="custom-select" onchange="PartyListController.filter.region(+this.value)">
+                    <option value="-2">All</option>
+                    <!-- ko foreach: GameHelper.enumStrings(GameConstants.Region).filter(r => r != 'none' && GameConstants.Region[r] <= player.highestRegion()) -->
+                    <option data-bind="attr: { value: GameConstants.Region[$data] }, text: GameConstants.camelCaseToString($data)">Region</option>
+                    <!-- /ko -->
+                    <option value="-1">None</option>
+                </select>
+            </div>
+            <div class="form-group col-md-3 col-6">
+                <label>Shiny Status</label>
+                <select autocomplete="off" class="custom-select" onchange="PartyListController.filter.shinyStatus(+this.value)">
+                    <option value="-1">All</option>
+                    <option value="0">Not Shiny</option>
+                    <option value="1">Shiny</option>
+                </select>
+            </div>
+            <div class="form-group col-md-3 col-6">
+                <label>Type</label>
+                <select autocomplete="off" class="custom-select" onchange="PartyListController.filter.type1(+this.value)">
+                    <option value="-2">All</option>
+                    <!-- ko foreach: GameHelper.enumStrings(PokemonType).filter(t => t != 'None') -->
+                    <option data-bind="attr: { value: PokemonType[$data] }, text: $data">Type</option>
+                    <!-- /ko -->
+                    <option value="-1">None</option>
+                </select>
+            </div>
+            <div class="form-group col-md-3 col-6">
+                <label>Type</label>
+                <select autocomplete="off" class="custom-select" onchange="PartyListController.filter.type2(+this.value)">
+                    <option value="-2">All</option>
+                    <!-- ko foreach: GameHelper.enumStrings(PokemonType).filter(t => t != 'None') -->
+                    <option data-bind="attr: { value: PokemonType[$data] }, text: $data">Type</option>
+                    <!-- /ko -->
+                    <option value="-1">None</option>
+                </select>
+            </div>
+        </div>
+        <div class="form-row collapse" data-bind="attr: { id: $data.name + '-sort' }">
+            <div class="form-group col" data-bind="with: Settings.getSetting('partySort')">
+                <label>Sort</label>
+                <div class="input-group">
+                    <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])"
+                        data-bind="foreach: $data.options, attr: {name}, selectedOptions: [$data.observableValue()]">
+                        <option data-bind="text: $data.text, value: $data.value"></option>
+                    </select>
+                    <div class="input-group-append bg-primary text-light">
+                        <label for="hatcheryPartySortDirection" class="clickable m-0 pl-2 pr-2" style="font-size: 22px;" data-bind="text: Settings.getSetting('partySortDirection').observableValue() ? '⥄' : '⥂'">⥂</label>
+                        <input id="hatcheryPartySortDirection" style="vertical-align: middle" class="hidden" type='checkbox'
+                            data-bind="checked: Settings.getSetting('partySortDirection').observableValue()"
+                            onchange="Settings.setSettingByName('partySortDirection', this.checked)"/>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</script>

--- a/src/components/templates/partyListTemplate.html
+++ b/src/components/templates/partyListTemplate.html
@@ -1,0 +1,34 @@
+<!-- To be used in conjunction with the partyListFilterTemplate -->
+<!-- Example usage -->
+<!-- <div data-bind="template: { name: 'partyListTemplate', data: {'name': 'breeding', 'controller': BreedingController, 'showProtein': true }}"></div> -->
+
+<script type="text/html" id="partyListTemplate">
+    <ul class="row justify-content-center p-0" data-bind="foreach: App.game.party.caughtPokemon">
+        <li class="eggSlot col-sm-4 col-md-3 col-lg-2 pokedexEntry text-nowrap"
+        data-bind="visible: $parent.controller.visible($data),
+        style:{background: PokedexHelper.getBackgroundColors($data.name)},
+        css: { disabled: $parent.controller.disabled($data) }">
+            <span style="top: 0; border-top-left-radius: 6px; border-top-right-radius: 6px;" data-bind="text: $data.name">name</span>
+            <div data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)" style="position: absolute;right: 0px;top: 0px;">✨</div>
+            <img src="" width="80px" data-bind="attr:{ src: PokedexHelper.getImage($data.id)}">
+            <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: PartyListController.getDisplayValue($data)">value</span>
+            <a class="overlay" data-bind="click: function() { $parent.controller.handleClick($data) }"></a>
+            <div class="pokemonCategory dropdown">
+                <button data-toggle="dropdown" data-bind="class: `category-${$data.category + 1}`"></button>
+                <div class="dropdown-menu p-0">
+                    <!-- ko foreach: PokemonCategories.categories -->
+                    <a class="dropdown-item category" href="#" data-bind="text: $data.name, click: () => { $parent.category = $index() }">Category</a>
+                    <!-- /ko -->
+                    <a class="dropdown-item bg-dark py-1" href="#categoryModal" data-toggle="modal"><i>Edit</i></a>
+                </div>
+            </div>
+            <!-- ko if: $parent.showProtein -->
+            <div class="sidebar">
+                <a class="useProtein" href="#useProtein" data-bind="class: ItemHandler.hasItem('Protein') && $data.canUseProtein() ? '' : 'disabled', click: function() { $data.useProtein(); }">
+                    <img class="p-0" src="assets/images/items/Protein.png" width="100%" height="100%"/>
+                </a>
+            </div>
+            <!-- /ko -->
+        </li>
+    </ul>
+</script>

--- a/src/index.html
+++ b/src/index.html
@@ -91,6 +91,8 @@
 @import "templates/caughtStatusTemplate.html"
 @import "templates/eggSVGTemplate.html"
 @import "templates/multiOptionTemplate.html"
+@import "templates/partyListFilterTemplate.html"
+@import "templates/partyListTemplate.html"
 
 <div class="container">
     <div class="row justify-content-center">

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -235,7 +235,7 @@ class Update implements Saveable {
             if (maxBattleFrontierStage >= 386) {
                 Update.addPokemonToSaveData(saveData, 386.3); // Deoxys (speed)
             }
-          
+
             // Update the attack bonus percentages
             saveData.party.caughtPokemon = saveData.party.caughtPokemon.map(p => {
                 p.attackBonusPercent = p.attackBonus;
@@ -262,6 +262,16 @@ class Update implements Saveable {
 
             // Reset all plots
             delete saveData.farming.plotList;
+
+            // TODO: HLXII - Move this to the version it'll be released in
+            for (const pokemon of saveData.party.caughtPokemon) {
+                if (pokemon.breeding) {
+                    pokemon.location = PartyLocation.Hatchery;
+                } else {
+                    pokemon.location = PartyLocation.Battle;
+                }
+                delete pokemon.breeding;
+            }
         },
     };
 

--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -221,7 +221,7 @@ class Breeding implements Feature {
     public addToQueue(pokemon: PartyPokemon): boolean {
         const queueSize = this.queueList().length;
         if (queueSize < this.queueSlots()) {
-            pokemon.breeding = true;
+            pokemon.location = PartyLocation.Hatchery;
             this.queueList.push(pokemon.name);
             return true;
         }
@@ -233,7 +233,7 @@ class Breeding implements Feature {
         const queueSize = this.queueList().length;
         if (queueSize > index) {
             const pokemonName = this.queueList.splice(index, 1)[0];
-            App.game.party._caughtPokemon().find(p => p.name == pokemonName).breeding = false;
+            App.game.party._caughtPokemon().find(p => p.name == pokemonName).location = PartyLocation.Battle;
             return true;
         }
         return false;
@@ -248,7 +248,7 @@ class Breeding implements Feature {
             return false;
         }
         const egg = this.createEgg(pokemon.name);
-        pokemon.breeding = true;
+        pokemon.location = PartyLocation.Hatchery;
         return this.gainEgg(egg);
     }
 

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -146,7 +146,7 @@ class BreedingController {
     public static visible(partyPokemon: PartyPokemon) {
         return ko.pureComputed(() => {
             // Only breedable Pokemon
-            if (partyPokemon.breeding || partyPokemon.level < 100) {
+            if (partyPokemon.location !== PartyLocation.Battle || partyPokemon.level < 100) {
                 return false;
             }
 

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -1,6 +1,6 @@
-///<reference path="../party/CaughtStatus.ts"/>
+///<reference path="../party/PartyListController.ts"/>
 
-class BreedingController {
+class BreedingController extends PartyListController {
     public static spotTypes = [
         `<g class="egg-spot">
           <path d="M33.5 104.3c4.4 4.9 9.3 7.3 6.7 9.6-2.6 2.4-8.3.4-12.7-4.4-4.5-4.9-6-10.8-3.4-13.2 2.6-2.3 5 3.2 9.4 8zm59.7 0c-4.5 4.9-9.4 7.3-6.8 9.6 2.6 2.4 8.4.4 12.8-4.4 4.4-4.9 6-10.8 3.3-13.2-2.6-2.3-4.9 3.2-9.3 8zm-1.6-14.8c-6.2 13.5-19 21-28.6 16.6-9.5-4.4-5-12.4 1.2-26 6.3-13.5 12-27.6 21.5-23.2 9.5 4.4 12.2 19 6 32.6zM74.29 37.558C66.497 46.286 70.6 55.4 62.4 55.4c-8.2 0-14.6-6.6-14.6-14.7S54.3 26 62.4 26c5.593.02 15.797 6.422 11.89 11.558z"/>
@@ -133,16 +133,6 @@ class BreedingController {
         return SeededRand.fromArray(this.spotTypes);
     }
 
-    public static filter = {
-        search: ko.observable(new RegExp('', 'i')),
-        category: ko.observable(-1).extend({ numeric: 0 }),
-        shinyStatus: ko.observable(-1).extend({ numeric: 0 }),
-        // All = -2
-        type1: ko.observable(-2).extend({ numeric: 0 }),
-        type2: ko.observable(-2).extend({ numeric: 0 }),
-        region: ko.observable(-2).extend({ numeric: 0 }),
-    }
-
     public static visible(partyPokemon: PartyPokemon) {
         return ko.pureComputed(() => {
             // Only breedable Pokemon
@@ -150,65 +140,17 @@ class BreedingController {
                 return false;
             }
 
-            if (!BreedingController.filter.search().test(partyPokemon.name)) {
-                return false;
-            }
-
-            // Check based on category
-            if (BreedingController.filter.category() >= 0) {
-                if (partyPokemon.category !== BreedingController.filter.category()) {
-                    return false;
-                }
-            }
-
-            // Check based on shiny status
-            if (BreedingController.filter.shinyStatus() >= 0) {
-                if (+partyPokemon.shiny !== BreedingController.filter.shinyStatus()) {
-                    return false;
-                }
-            }
-
-            // Check based on native region
-            if (BreedingController.filter.region() > -2) {
-                if (PokemonHelper.calcNativeRegion(partyPokemon.name) !== BreedingController.filter.region()) {
-                    return false;
-                }
-            }
-
-            // Check if either of the types match
-            const type1: (PokemonType | null) = BreedingController.filter.type1() > -2 ? BreedingController.filter.type1() : null;
-            const type2: (PokemonType | null) = BreedingController.filter.type2() > -2 ? BreedingController.filter.type2() : null;
-            if (type1 !== null || type2 !== null) {
-                const { type: types } = pokemonMap[partyPokemon.name];
-                if ([type1, type2].includes(PokemonType.None)) {
-                    const type = (type1 == PokemonType.None) ? type2 : type1;
-                    if (!BreedingController.isPureType(partyPokemon, type)) {
-                        return false;
-                    }
-                } else if ((type1 !== null && !types.includes(type1)) || (type2 !== null && !types.includes(type2))) {
-                    return false;
-                }
-            }
-            return true;
+            return this.applyFilters(partyPokemon);
         });
     }
 
-    private static isPureType(pokemon: PartyPokemon, type: (PokemonType | null)): boolean {
-        const pokemonData = pokemonMap[pokemon.name];
-        return ((type == null || pokemonData.type[0] === type) && (pokemonData.type[1] == undefined || pokemonData.type[1] == PokemonType.None));
+    public static disabled(partyPokemon: PartyPokemon) {
+        return !App.game.breeding.hasFreeEggSlot() && !App.game.breeding.hasFreeQueueSlot();
     }
 
-    // Value displayed at bottom of image
-    public static displayValue = ko.observable('attack');
-
-    private static getDisplayValue(pokemon: PartyPokemon): string {
-        const pokemonData = pokemonMap[pokemon.name];
-        switch (this.displayValue()) {
-            case 'attack': return `Attack: ${pokemon.attack.toLocaleString('en-US')}`;
-            case 'attackBonus': return `Attack Bonus: ${Math.floor(pokemon.baseAttack * (GameConstants.BREEDING_ATTACK_BONUS / 100) + pokemon.proteinsUsed()).toLocaleString('en-US')}`;
-            case 'baseAttack': return `Base Attack: ${pokemon.baseAttack.toLocaleString('en-US')}`;
-            case 'eggSteps': return `Egg Steps: ${App.game.breeding.getSteps(pokemonData.eggCycles).toLocaleString('en-US')}`;
-            case 'timesHatched': return `Hatches: ${App.game.statistics.pokemonHatched[pokemonData.id]() || 0}`;
-        }
+    public static handleClick(partyPokemon: PartyPokemon) {
+        App.game.breeding.addPokemonToHatchery(partyPokemon);
+        App.game.breeding.checkCloseModal();
     }
+
 }

--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -107,13 +107,13 @@ class Egg implements Saveable {
             partyPokemon.attack = partyPokemon.calculateAttack();
 
             // If breeding (not store egg), reset level, reset evolution check
-            if (partyPokemon.breeding) {
+            if (partyPokemon.location === PartyLocation.Hatchery) {
                 if (partyPokemon.evolutions !== undefined) {
                     partyPokemon.evolutions.forEach(evo => evo instanceof LevelEvolution ? evo.triggered = false : undefined);
                 }
                 partyPokemon.exp = 0;
                 partyPokemon.level = 1;
-                partyPokemon.breeding = false;
+                partyPokemon.location = PartyLocation.Battle;
                 partyPokemon.level = partyPokemon.calculateLevelFromExp();
                 partyPokemon.checkForLevelEvolution();
             }

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -92,7 +92,7 @@ class Party implements Feature {
 
         const maxLevel = (App.game.badgeCase.badgeCount() + 2) * 10;
         for (const pokemon of this.caughtPokemon) {
-            if (pokemon.level < maxLevel) {
+            if (pokemon.level < maxLevel && pokemon.location === PartyLocation.Battle) {
                 pokemon.gainExp(expTotal);
             }
         }
@@ -104,10 +104,10 @@ class Party implements Feature {
      * @param type2 types of the enemy we're calculating damage against.
      * @returns {number} damage to be done.
      */
-    public calculatePokemonAttack(type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, ignoreRegionMultiplier = false, region: GameConstants.Region = player.region, includeBreeding = false, useBaseAttack = false): number {
+    public calculatePokemonAttack(type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, ignoreRegionMultiplier = false, region: GameConstants.Region = player.region, includeNonBattle = false, useBaseAttack = false): number {
         let attack = 0;
         for (const pokemon of this.caughtPokemon) {
-            attack += this.calculateOnePokemonAttack(pokemon, type1, type2, region, ignoreRegionMultiplier, includeBreeding, useBaseAttack);
+            attack += this.calculateOnePokemonAttack(pokemon, type1, type2, region, ignoreRegionMultiplier, includeNonBattle, useBaseAttack);
         }
 
         if (EffectEngineRunner.isActive(GameConstants.BattleItemType.xAttack)()) {
@@ -117,7 +117,7 @@ class Party implements Feature {
         return Math.round(attack);
     }
 
-    public calculateOnePokemonAttack(pokemon: PartyPokemon, type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, region: GameConstants.Region = player.region, ignoreRegionMultiplier = false, includeBreeding = false, useBaseAttack = false): number {
+    public calculateOnePokemonAttack(pokemon: PartyPokemon, type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, region: GameConstants.Region = player.region, ignoreRegionMultiplier = false, includeNonBattle = false, useBaseAttack = false): number {
         let multiplier = 1, attack = 0;
         const pAttack = useBaseAttack ? pokemon.baseAttack : pokemon.attack;
         const nativeRegion = PokemonHelper.calcNativeRegion(pokemon.name);
@@ -125,7 +125,7 @@ class Party implements Feature {
             // Pokemon only retain a % of their total damage in other regions based on highest region.
             multiplier = this.getRegionAttackMultiplier();
         }
-        if (includeBreeding || !pokemon.breeding) {
+        if (includeNonBattle || pokemon.location === PartyLocation.Battle) {
             if (type1 == PokemonType.None) {
                 attack = pAttack * multiplier;
             } else {

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -32,12 +32,6 @@ class PartyController {
         return status;
     }
 
-    public static getMaxLevelPokemonList(): Array<PartyPokemon> {
-        return App.game.party.caughtPokemon.filter((partyPokemon: PartyPokemon) => {
-            return !partyPokemon.breeding && partyPokemon.level >= 100;
-        });
-    }
-
     static getSortedList = ko.pureComputed(function() {
         return App.game.party._caughtPokemon.sort(PartyController.compareBy(Settings.getSetting('partySort').observableValue(), Settings.getSetting('partySortDirection').observableValue()));
     }).extend({ rateLimit: 500 });

--- a/src/scripts/party/PartyListController.ts
+++ b/src/scripts/party/PartyListController.ts
@@ -1,0 +1,93 @@
+
+///<reference path="../party/CaughtStatus.ts"/>
+
+class PartyListController {
+
+    public static initialize() {}
+
+    public static filter = {
+        search: ko.observable(new RegExp('', 'i')),
+        category: ko.observable(-1).extend({ numeric: 0 }),
+        shinyStatus: ko.observable(-1).extend({ numeric: 0 }),
+        // All = -2
+        type1: ko.observable(-2).extend({ numeric: 0 }),
+        type2: ko.observable(-2).extend({ numeric: 0 }),
+        region: ko.observable(-2).extend({ numeric: 0 }),
+    }
+
+    public static applyFilters(partyPokemon: PartyPokemon) {
+        if (!PartyListController.filter.search().test(partyPokemon.name)) {
+            return false;
+        }
+
+        // Check based on category
+        if (PartyListController.filter.category() >= 0) {
+            if (partyPokemon.category !== PartyListController.filter.category()) {
+                return false;
+            }
+        }
+
+        // Check based on shiny status
+        if (PartyListController.filter.shinyStatus() >= 0) {
+            if (+partyPokemon.shiny !== PartyListController.filter.shinyStatus()) {
+                return false;
+            }
+        }
+
+        // Check based on native region
+        if (PartyListController.filter.region() > -2) {
+            if (PokemonHelper.calcNativeRegion(partyPokemon.name) !== PartyListController.filter.region()) {
+                return false;
+            }
+        }
+
+        // Check if either of the types match
+        const type1: (PokemonType | null) = PartyListController.filter.type1() > -2 ? PartyListController.filter.type1() : null;
+        const type2: (PokemonType | null) = PartyListController.filter.type2() > -2 ? PartyListController.filter.type2() : null;
+        if (type1 !== null || type2 !== null) {
+            const { type: types } = pokemonMap[partyPokemon.name];
+            if ([type1, type2].includes(PokemonType.None)) {
+                const type = (type1 == PokemonType.None) ? type2 : type1;
+                if (!PartyListController.isPureType(partyPokemon, type)) {
+                    return false;
+                }
+            } else if ((type1 !== null && !types.includes(type1)) || (type2 !== null && !types.includes(type2))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static isPureType(pokemon: PartyPokemon, type: (PokemonType | null)): boolean {
+        const pokemonData = pokemonMap[pokemon.name];
+        return ((type == null || pokemonData.type[0] === type) && (pokemonData.type[1] == undefined || pokemonData.type[1] == PokemonType.None));
+    }
+
+    public static visible(partyPokemon: PartyPokemon) {
+        return ko.pureComputed(() => {
+            return this.applyFilters(partyPokemon);
+        });
+    }
+
+    public static disabled(partyPokemon: PartyPokemon) {
+        return false;
+    }
+
+    public static handleClick(partyPokemon: PartyPokemon) {
+        return;
+    }
+
+    // Value displayed at bottom of image
+    public static displayValue = ko.observable('attack');
+
+    private static getDisplayValue(pokemon: PartyPokemon): string {
+        const pokemonData = pokemonMap[pokemon.name];
+        switch (this.displayValue()) {
+            case 'attack': return `Attack: ${pokemon.attack.toLocaleString('en-US')}`;
+            case 'attackBonus': return `Attack Bonus: ${Math.floor(pokemon.baseAttack * (GameConstants.BREEDING_ATTACK_BONUS / 100) + pokemon.proteinsUsed()).toLocaleString('en-US')}`;
+            case 'baseAttack': return `Base Attack: ${pokemon.baseAttack.toLocaleString('en-US')}`;
+            case 'eggSteps': return `Egg Steps: ${App.game.breeding.getSteps(pokemonData.eggCycles).toLocaleString('en-US')}`;
+            case 'timesHatched': return `Hatches: ${App.game.statistics.pokemonHatched[pokemonData.id]() || 0}`;
+        }
+    }
+}

--- a/src/scripts/party/PartyLocation.ts
+++ b/src/scripts/party/PartyLocation.ts
@@ -1,0 +1,6 @@
+enum PartyLocation {
+    Battle = 0,
+    Hatchery,
+    // TODO: Add Research
+    // TODO: Add this when implementing Party Slots. //PartySlot,
+}

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -7,12 +7,12 @@ class PartyPokemon implements Saveable {
         attackBonusAmount: 0,
         proteinsUsed: 0,
         exp: 0,
-        breeding: false,
+        location: PartyLocation.Battle,
         shiny: false,
         category: 0,
     };
 
-    _breeding: KnockoutObservable<boolean>;
+    _location: KnockoutObservable<PartyLocation>;
     _shiny: KnockoutObservable<boolean>;
     _level: KnockoutObservable<number>;
     _attack: KnockoutObservable<number>;
@@ -28,12 +28,12 @@ class PartyPokemon implements Saveable {
         public attackBonusAmount: number = 0,
         proteinsUsed,
         public exp: number = 0,
-        breeding = false,
+        location = PartyLocation.Battle,
         shiny = false,
         category = 0
     ) {
         this.proteinsUsed = ko.observable(proteinsUsed);
-        this._breeding = ko.observable(breeding);
+        this._location = ko.observable(location);
         this._shiny = ko.observable(shiny);
         this._level = ko.observable(1);
         this._attack = ko.observable(this.calculateAttack());
@@ -68,7 +68,7 @@ class PartyPokemon implements Saveable {
     }
 
     public checkForLevelEvolution() {
-        if (this.breeding || this.evolutions == null || this.evolutions.length == 0) {
+        if (this.location !== PartyLocation.Battle || this.evolutions == null || this.evolutions.length == 0) {
             return;
         }
 
@@ -123,7 +123,7 @@ class PartyPokemon implements Saveable {
         this.attackBonusAmount = json['attackBonusAmount'] ?? this.defaults.attackBonusAmount;
         this.proteinsUsed = ko.observable(json['proteinsUsed'] ?? this.defaults.proteinsUsed);
         this.exp = json['exp'] ?? this.defaults.exp;
-        this.breeding = json['breeding'] ?? this.defaults.breeding;
+        this.location = json['location'] ?? this.defaults.location;
         this.shiny = json['shiny'] ?? this.defaults.shiny;
         this.category = json['category'] ?? this.defaults.category;
         this.level = this.calculateLevelFromExp();
@@ -154,7 +154,7 @@ class PartyPokemon implements Saveable {
             attackBonusAmount: this.attackBonusAmount,
             proteinsUsed: this.proteinsUsed(),
             exp: this.exp,
-            breeding: this.breeding,
+            location: this.location,
             shiny: this.shiny,
             levelEvolutionTriggered: levelEvolutionTriggered,
             category: this.category,
@@ -178,12 +178,12 @@ class PartyPokemon implements Saveable {
         this._attack(attack);
     }
 
-    get breeding(): boolean {
-        return this._breeding();
+    get location(): PartyLocation {
+        return this._location();
     }
 
-    set breeding(bool: boolean) {
-        this._breeding(bool);
+    set location(value: PartyLocation) {
+        this._location(value);
     }
 
     get shiny(): boolean {

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -92,7 +92,7 @@ class PokemonFactory {
 
     public static generatePartyPokemon(id: number, shiny = false): PartyPokemon {
         const dataPokemon = PokemonHelper.getPokemonById(id);
-        return new PartyPokemon(dataPokemon.id, dataPokemon.name, dataPokemon.evolutions, dataPokemon.attack, 0, 0, 0, 0, false, shiny);
+        return new PartyPokemon(dataPokemon.id, dataPokemon.name, dataPokemon.evolutions, dataPokemon.attack, 0, 0, 0, 0, PartyLocation.Battle, shiny);
     }
 
     /**

--- a/src/scripts/types/DamageCalculator.ts
+++ b/src/scripts/types/DamageCalculator.ts
@@ -4,7 +4,7 @@ class DamageCalculator {
     static type1 = ko.observable(PokemonType.None);
     static type2 = ko.observable(PokemonType.None);
     static region = ko.observable(GameConstants.Region.none);
-    static includeBreeding = ko.observable(false);
+    static includeNonBattle = ko.observable(false);
     static baseAttackOnly = ko.observable(false);
     static detailType = ko.observable(PokemonType.None);
 
@@ -20,7 +20,7 @@ class DamageCalculator {
             DamageCalculator.type2(),
             ignoreRegionMultiplier,
             DamageCalculator.region(),
-            DamageCalculator.includeBreeding(),
+            DamageCalculator.includeNonBattle(),
             DamageCalculator.baseAttackOnly()
         );
     }
@@ -35,8 +35,8 @@ class DamageCalculator {
                 continue;
             }
 
-            const attack = App.game.party.calculateOnePokemonAttack(pokemon, this.type1(), this.type2(), this.region(), ignoreRegionMultiplier, this.includeBreeding(), this.baseAttackOnly());
-            
+            const attack = App.game.party.calculateOnePokemonAttack(pokemon, this.type1(), this.type2(), this.region(), ignoreRegionMultiplier, this.includeNonBattle(), this.baseAttackOnly());
+
             typedamage[dataPokemon.type1] += attack / 2;
             const otherType = dataPokemon.type2 !== PokemonType.None ? dataPokemon.type2 : dataPokemon.type1;
             typedamage[otherType] += attack / 2;
@@ -69,7 +69,7 @@ class DamageCalculator {
                 DamageCalculator.type2(),
                 DamageCalculator.region(),
                 ignoreRegionMultiplier,
-                DamageCalculator.includeBreeding(),
+                DamageCalculator.includeNonBattle(),
                 DamageCalculator.baseAttackOnly()
             ),
         };


### PR DESCRIPTION
This refactor is mostly setting up for using the Party List for Party Slots (#1039) and the PokeLab (#1048).

It refactors the current Breeding Modal elements into two templates: the PartyListFilterTemplate and the PartyListTemplate. This is so the sorting/Pokemon display elements can be shared between multiple modals (e.g. the Party Slot assignment modal and the Research assignment modal).

This also refactors the breeding property of PartyPokemon into a location property, to expand the different locations the pokemon can be in (e.g. the Party Slots or Researching).