### PR TITLE
Fix calculation of native pokemon region

### DIFF
--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -96,7 +96,7 @@ class PokemonHelper {
             return pokemon.nativeRegion;
         }
         const id = pokemon.id;
-        const region = GameConstants.TotalPokemonsPerRegion.findIndex(maxRegionID => maxRegionID >= id);
+        const region = GameConstants.TotalPokemonsPerRegion.findIndex(maxRegionID => maxRegionID >= Math.floor(id));
         return region >= 0 ? region : GameConstants.Region.none;
     }
 
@@ -234,7 +234,7 @@ class PokemonHelper {
         const evolutionPokemon = pokemonList.find((p: PokemonListData) => p.evolutions?.find(e => e.type.includes(EvolutionType.Stone) && e.getEvolvedPokemon() == pokemonName));
         return (evolutionPokemon as PokemonListData)?.evolutions?.find(e => e.getEvolvedPokemon() == pokemonName);
     }
-    
+
     public static getPokemonLocations = (pokemonName: PokemonNameType) => {
         const encounterTypes = {};
         // Routes

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -17820,7 +17820,7 @@ pokemonList.forEach(p => {
     if ((p as PokemonListData).baby) {
         (p as PokemonListData).evolutions?.forEach(evo => pokemonDevolutionMap[evo.getEvolvedPokemon()] = evo.basePokemon as PokemonNameType);
     }
-    (p as PokemonListData).nativeRegion = (p as PokemonListData).nativeRegion || GameConstants.TotalPokemonsPerRegion.findIndex(maxRegionID => maxRegionID >= p.id);
+    (p as PokemonListData).nativeRegion = (p as PokemonListData).nativeRegion || GameConstants.TotalPokemonsPerRegion.findIndex(maxRegionID => maxRegionID >= Math.floor(p.id));
     pokemonNameIndex[p.name.toLowerCase()] = p;
 });
 


### PR DESCRIPTION
Some pokemons (especially Deoxys) have the forms passing the region calculation, so `Math.floor` makes it work now

![image](https://user-images.githubusercontent.com/27972070/99033562-ee952180-2559-11eb-8be6-f12dbc1c4836.png)
