### PR TITLE
Fixup all Proteins being used when Battle Item multiplier set to all

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -4,9 +4,9 @@
     </div>
     <button type="button" class="btn btn-sm btn-primary" 
             style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px;" 
-            data-bind="text: ItemHandler.multipliers[ItemHandler.multIndex()]"
-            onclick="ItemHandler.incrementMultiplier()"
-            oncontextmenu="ItemHandler.decrementMultiplier(); return false"
+            data-bind="text: EffectEngineRunner.multipliers[EffectEngineRunner.multIndex()]"
+            onclick="EffectEngineRunner.incrementMultiplier()"
+            oncontextmenu="EffectEngineRunner.decrementMultiplier(); return false"
             title="Controls"
             data-toggle="popover"
             data-html="true"
@@ -30,7 +30,7 @@
                                 'bg-secondary': !EffectEngineRunner.isActive($data)()
                             },
                             event: {
-                                click: function(){ItemHandler.useItem($data)}
+                                click: function(){ItemHandler.useItem($data, EffectEngineRunner.amountToUse())}
                             },
                             tooltip: {
                               title: ItemList[$data].displayName + '<br/>' + ItemList[$data].description,

--- a/src/scripts/effectEngine/effectEngineRunner.ts
+++ b/src/scripts/effectEngine/effectEngineRunner.ts
@@ -1,5 +1,12 @@
 class EffectEngineRunner {
     public static counter = 0;
+    public static multipliers = ['×1', '×10', '×100', '×1000', 'All'];
+    public static multIndex = ko.observable(0);
+
+    public static amountToUse = ko.pureComputed(() => {
+        // Either the digits specified, or All (Infinity)
+        return Number(EffectEngineRunner.multipliers[EffectEngineRunner.multIndex()].replace(/\D/g, '')) || Infinity;
+    })
 
     public static tick() {
         this.counter = 0;
@@ -19,6 +26,14 @@ class EffectEngineRunner {
                 });
             }
         }
+    }
+
+    public static incrementMultiplier() {
+        this.multIndex((this.multIndex() + 1) % this.multipliers.length);
+    }
+
+    public static decrementMultiplier() {
+        this.multIndex((this.multIndex() + this.multipliers.length - 1) % this.multipliers.length);
     }
 
     public static getEffect(itemName: string) {

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -5,10 +5,8 @@ class ItemHandler {
     public static amountSelected: KnockoutObservable<number> = ko.observable(1);
     static amount: KnockoutObservable<number> = ko.observable(1);
     public static amountToUse = 1;
-    public static multipliers = ['×1', '×10', '×100', '×1000', 'All'];
-    public static multIndex = ko.observable(0);
 
-    public static useItem(name: string): boolean {
+    public static useItem(name: string, amount = 1): boolean {
         if (!player.itemList[name]()) {
             Notifier.notify({
                 message: `You don't have any ${ItemList[name].displayName}s left...`,
@@ -16,10 +14,8 @@ class ItemHandler {
             });
             return false;
         }
-        // Either the digits specified, or All (Infinity)
-        const amountSelected = Number(this.multipliers[this.multIndex()].replace(/\D/g, '')) || Infinity;
         // Only allow the player to use the amount they have maximum
-        this.amountToUse = Math.min(player.itemList[name](), amountSelected);
+        this.amountToUse = Math.min(player.itemList[name](), amount);
 
         player.itemList[name](player.itemList[name]() - this.amountToUse);
 
@@ -77,13 +73,4 @@ class ItemHandler {
             type: NotificationConstants.NotificationOption.success,
         });
     }
-
-    public static incrementMultiplier() {
-        this.multIndex((this.multIndex() + 1) % this.multipliers.length);
-    }
-
-    public static decrementMultiplier() {
-        this.multIndex((((this.multIndex() - 1) % this.multipliers.length) + this.multipliers.length) % this.multipliers.length);
-    }
-
 }

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -102,6 +102,10 @@ class PartyPokemon implements Saveable {
         }
         if (ItemHandler.useItem('Protein')) {
             GameHelper.incrementObservable(this.proteinsUsed);
+            Notifier.notify({
+                message: `Used 1 × Protein on ${this.name}<br/>Total used: ${this.proteinsUsed().toLocaleString('en-US')}`,
+                type: NotificationConstants.NotificationOption.info,
+            });
         }
     }
 


### PR DESCRIPTION
This PR fixes the Proteins being used being bound to the amount of battle items selected:
![image](https://user-images.githubusercontent.com/7288322/99034021-1da2a600-25e1-11eb-9346-ba6df40ae00d.png)
