### PR TITLE
Berry fixes round 5

### DIFF
--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -233,6 +233,9 @@
 
                     <h4><u>Trades</u></h4>
                     <p>Berries can be traded with Berry Masters in later regions for other useful items</p>
+
+                    <h4><u>Wandering Pokémon</u></h4>
+                    <p>Ripe Berry plants may attract wild Pokémon that will join your party. Some Pokémon can only be found using certain Berry species.</p>
                 </div>
             </div>
 

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -195,13 +195,13 @@
                     <br/>Once fully grown, the Berry plant can be clicked to manually harvest the Berries and gain some Farm Points.</p>
 
                     <p>Otherwise after some time being fully grown, the Berry plant will wither away,
-                    dropping only a fraction of the Berries but may also be re-planted automatically.
+                    dropping half of the expected Berries but may also be re-planted automatically.
                     <br/><i>(Farm Points are only gained by manually harvesting Berries)</i><p>
 
                     <p>Additional plots can be unlocked by spending Berries.</p>
 
                     <h4><u>Mutations</u></h4>
-                    <p>Berries have the chance to mutate into other Berries based on certain conditions.
+                    <p>Berries have the chance to cause mutations and create new Berry species based on certain conditions.
                     <br/><i>(the Berry Master in Kanto will give you daily hints to what these conditions may be)</i></p>
 
                     <h4><u>Mulches</u></h4>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -201,7 +201,7 @@
                     <p>Additional plots can be unlocked by spending Berries.</p>
 
                     <h4><u>Mutations</u></h4>
-                    <p>Berries have the chance to cause mutations and create new Berry species based on certain conditions.
+                    <p>Berries have the chance to cause mutations and create new Berry species in empty plots based on certain conditions.
                     <br/><i>(the Berry Master in Kanto will give you daily hints to what these conditions may be)</i></p>
 
                     <h4><u>Mulches</u></h4>

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -47,7 +47,7 @@ export const SHINY_CHANCE_SHOP = 2048;
 export const SHINY_CHANCE_STONE = 2048;
 export const SHINY_CHANCE_SAFARI = 2048;
 export const SHINY_CHANCE_BREEDING = 1024;
-export const SHINY_CHANCE_FARM = 2048;
+export const SHINY_CHANCE_FARM = 1024;
 
 export const ITEM_PRICE_MULTIPLIER = 1.00045;
 export const ITEM_PRICE_DEDUCT = 1.0005;

--- a/src/scripts/farming/Berry.ts
+++ b/src/scripts/farming/Berry.ts
@@ -10,9 +10,9 @@ class Berry {
     public wander: PokemonNameType[];
 
     private static baseWander: PokemonNameType[] = [
-        'Butterfree', 'Weedle', 'Tangela', 'Scyther',
-        'Ledyba', 'Pineco', 'Heracross',
-        'Wurmple', 'Volbeat', 'Illumise',
+        'Tangela', 'Scyther',
+        'Pineco', 'Heracross',
+        'Volbeat', 'Illumise',
         'Burmy (plant)', 'Combee', 'Cherubi', 'Munchlax',
     ];
 

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -453,7 +453,7 @@ class Farming implements Feature {
 
         // Figy
         this.mutations.push(new GrowNearFlavorMutation(.009, BerryType.Figy,
-            [[25, 50], [0, 5], [0, 5], [0, 5], [0, 5]], {
+            [[25, 80], [0, 5], [0, 5], [0, 5], [0, 5]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings get too spicy!',
                 unlockReq: function(): boolean {
                     return App.game.farming.unlockedBerries[BerryType.Cheri]();
@@ -462,7 +462,7 @@ class Farming implements Feature {
         ));
         // Wiki
         this.mutations.push(new GrowNearFlavorMutation(.008, BerryType.Wiki,
-            [[0, 5], [25, 50], [0, 5], [0, 5], [0, 5]], {
+            [[0, 5], [25, 80], [0, 5], [0, 5], [0, 5]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings get too dry!',
                 unlockReq: function(): boolean {
                     return App.game.farming.unlockedBerries[BerryType.Chesto]();
@@ -471,7 +471,7 @@ class Farming implements Feature {
         ));
         // Mago
         this.mutations.push(new GrowNearFlavorMutation(.007, BerryType.Mago,
-            [[0, 5], [0, 5], [25, 50], [0, 5], [0, 5]], {
+            [[0, 5], [0, 5], [25, 80], [0, 5], [0, 5]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings get too sweet!',
                 unlockReq: function(): boolean {
                     return App.game.farming.unlockedBerries[BerryType.Pecha]();
@@ -480,7 +480,7 @@ class Farming implements Feature {
         ));
         // Aguav
         this.mutations.push(new GrowNearFlavorMutation(.006, BerryType.Aguav,
-            [[0, 5], [0, 5], [0, 5], [25, 50], [0, 5]], {
+            [[0, 5], [0, 5], [0, 5], [25, 80], [0, 5]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings get too bitter!',
                 unlockReq: function(): boolean {
                     return App.game.farming.unlockedBerries[BerryType.Rawst]();
@@ -489,7 +489,7 @@ class Farming implements Feature {
         ));
         // Iapapa
         this.mutations.push(new GrowNearFlavorMutation(.005, BerryType.Iapapa,
-            [[0, 5], [0, 5], [0, 5], [0, 5], [25, 50]], {
+            [[0, 5], [0, 5], [0, 5], [0, 5], [25, 80]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings get too sour!',
                 unlockReq: function(): boolean {
                     return App.game.farming.unlockedBerries[BerryType.Aspear]();
@@ -555,7 +555,7 @@ class Farming implements Feature {
                 BerryType.Figy,
             ]));
         // Tamato
-        this.mutations.push(new EvolveNearBerryMutation(.0005, BerryType.Tamato, BerryType.Sitrus, [BerryType.Lum]));
+        this.mutations.push(new EvolveNearBerryMutation(.0005, BerryType.Tamato, BerryType.Razz, [BerryType.Pomeg]));
         // Cornn
         this.mutations.push(new GrowNearBerryMutation(.0003, BerryType.Cornn,
             [
@@ -611,7 +611,7 @@ class Farming implements Feature {
         // Occa
         this.mutations.push(new GrowNearBerryMutation(.0001, BerryType.Occa,
             [
-                BerryType.Cheri,
+                BerryType.Razz,
                 BerryType.Figy,
                 BerryType.Tamato,
                 BerryType.Spelon,
@@ -635,6 +635,7 @@ class Farming implements Feature {
                 BerryType.Nomel,
             ]));
         // Rindo
+        // TODO: HLXII - Change mutation to grow spontaneously when Grass pokemon in party
         this.mutations.push(new GrowNearFlavorMutation(.0001, BerryType.Rindo,
             [[10, 15], [0, 0], [0, 0], [15, 20], [0, 0]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings match its flavor profile! If I recall, it tasted a little spicy and fairly bitter at the same time.',
@@ -659,6 +660,7 @@ class Farming implements Feature {
         // Shuca
         this.mutations.push(new OakMutation(.0001, BerryType.Shuca, BerryType.Watmel, OakItems.OakItem.Sprinklotad));
         // Coba
+        // TODO: HLXII - Change mutation to grow spontaneously when Flying pokemon in party
         this.mutations.push(new GrowNearFlavorMutation(.0001, BerryType.Coba,
             [[0, 0], [10, 15], [0, 0], [15, 20], [0, 0]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings match its flavor profile! If I recall, it tasted a little dry and fairly bitter at the same time.',
@@ -773,7 +775,7 @@ class Farming implements Feature {
         // Apicot
 
         // Lansat
-
+        // TODO: HLXII - Add Mutation to evolve Payapa when Milotic, Gardevoir, Blissey, and Togekiss in party.
         // Starf
         // No mutation, obtained by wandering shiny pokemon
         // Enigma

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -829,7 +829,7 @@ class Farming implements Feature {
     getMutationMultiplier(): number {
         let multiplier = 1;
         multiplier *= App.game.oakItems.calculateBonus(OakItems.OakItem.Squirtbottle);
-        return multiplier * 100;
+        return multiplier;
     }
 
     update(delta: number): void {

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -540,8 +540,8 @@ class Farming implements Feature {
             }));
         // Hondew
         this.mutations.push(new GrowNearFlavorMutation(.0004, BerryType.Hondew,
-            [[10, 15], [10, 15], [0, 0], [10, 15], [0, 0]], {
-                hint: 'I\'ve heard that a special Berry can appear if its surroundings match its flavor profile! If I recall, it tasted like a little bit of everything except sweet.',
+            [[15, 15], [15, 15], [0, 0], [15, 15], [0, 0]], {
+                hint: 'I\'ve heard that a special Berry can appear if its surroundings match its flavor profile! If I recall, it tasted fairly spicy, dry, and bitter at the same time.',
                 unlockReq: function(): boolean {
                     return App.game.farming.unlockedBerries[BerryType.Cheri]() &&
                     App.game.farming.unlockedBerries[BerryType.Chesto]() &&
@@ -680,7 +680,7 @@ class Farming implements Feature {
         let berryReqs = {};
         berryReqs[BerryType.Rindo] = 8;
         this.mutations.push(new GrowNearBerryStrictMutation(.0001, BerryType.Tanga, berryReqs, {
-            hint: 'I\'ve heard that a special Berry can appear after being surrounded by Ringo Berries!',
+            hint: 'I\'ve heard that a special Berry can appear after being surrounded by Rindo Berries!',
         }));
         // Charti
         this.mutations.push(new OakMutation(.0001, BerryType.Charti, BerryType.Cornn, OakItems.OakItem.Cell_Battery));
@@ -830,7 +830,7 @@ class Farming implements Feature {
     getMutationMultiplier(): number {
         let multiplier = 1;
         multiplier *= App.game.oakItems.calculateBonus(OakItems.OakItem.Squirtbottle);
-        return multiplier;
+        return multiplier * 100;
     }
 
     update(delta: number): void {

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -543,10 +543,9 @@ class Farming implements Feature {
             [[15, 15], [15, 15], [0, 0], [15, 15], [0, 0]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings match its flavor profile! If I recall, it tasted fairly spicy, dry, and bitter at the same time.',
                 unlockReq: function(): boolean {
-                    return App.game.farming.unlockedBerries[BerryType.Cheri]() &&
-                    App.game.farming.unlockedBerries[BerryType.Chesto]() &&
-                    App.game.farming.unlockedBerries[BerryType.Rawst]() &&
-                    App.game.farming.unlockedBerries[BerryType.Aspear]();
+                    return App.game.farming.unlockedBerries[BerryType.Figy]() &&
+                    App.game.farming.unlockedBerries[BerryType.Wiki]() &&
+                    App.game.farming.unlockedBerries[BerryType.Aguav]();
                 },
             }));
         // Grepa

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -230,14 +230,14 @@ class Farming implements Feature {
             [
                 'This Berry\'s flesh is dotted with countless tiny bubbles of air that keep it afloat in water.',
                 'This Berry promotes the fruiting of nearby Berry plants.',
-            ], new Aura(AuraType.Harvest, [1.2, 1.4, 1.6]), ['Squirtle', 'Totodile', 'Mudkip', 'Piplup']);
+            ], new Aura(AuraType.Harvest, [1.1, 1.2, 1.3]), ['Squirtle', 'Totodile', 'Mudkip', 'Piplup']);
         this.berryData[BerryType.Wacan]     = new Berry(BerryType.Wacan,    [10, 180, 900, 1800, 3600],
             2, 0.05, 250, 1,
             [0, 0, 15, 0, 10], BerryColor.Yellow,
             [
                 'Energy from lightning strikes is drawn into the plant, making the Berries grow big and rich.',
                 'The same energy promotes the growth of nearby Berries.',
-            ], new Aura(AuraType.Growth, [1.2, 1.4, 1.6]), ['Pikachu']);
+            ], new Aura(AuraType.Growth, [1.1, 1.2, 1.3]), ['Pikachu']);
         this.berryData[BerryType.Rindo]     = new Berry(BerryType.Rindo,    [3600, 7200, 16200, 28800, 57600],
             24, 0.05, 1400, 15,
             [10, 0, 0, 15, 0], BerryColor.Green,
@@ -258,7 +258,7 @@ class Farming implements Feature {
             [
                 'This Berry contains a substance that generates heat. It can even heat up a chilly heart.',
                 'Growing these Berries will promote Egg growth.',
-            ], new Aura(AuraType.Egg, [1.1, 1.2, 1.3]), ['Riolu']);
+            ], new Aura(AuraType.Egg, [1.01, 1.02, 1.03]), ['Riolu']);
         this.berryData[BerryType.Kebia]     = new Berry(BerryType.Kebia,    [100, 200, 400, 600, 86400],
             1, 1, 50, 1,
             [0, 15, 0, 0, 10], BerryColor.Green,
@@ -273,7 +273,7 @@ class Farming implements Feature {
             [
                 'The sweetness-laden pulp has just the hint of a hard-edged and fragrant bite to it.',
                 'Growing these Berries will soften the ground around it, increasing the chances of replanting.',
-            ], new Aura(AuraType.Replant, [1.2, 1.4, 1.6]), ['Larvitar']);
+            ], new Aura(AuraType.Replant, [1.1, 1.2, 1.3]), ['Larvitar']);
         this.berryData[BerryType.Coba]      = new Berry(BerryType.Coba,     [9000, 12600, 16200, 19800, 39600],
             29, 0.05, 1800, 15,
             [0, 10, 0, 15, 0], BerryColor.Blue,
@@ -338,7 +338,7 @@ class Farming implements Feature {
             [
                 'This Berry is sweet with a hint of bitterness and has a lingering sweet scent. It is often dried and used to make tea.',
                 'The scent of this Berry plant attracts wild Pokémon.',
-            ], new Aura(AuraType.Attract, [1.2, 1.4, 1.6]), ['Togepi']);
+            ], new Aura(AuraType.Attract, [1.1, 1.2, 1.3]), ['Togepi']);
         //#endregion
 
         //#region Fifth Generation

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -78,7 +78,7 @@ class Farming implements Feature {
             5, 0.5, 8, 4,
             [0, 0, 0, 10, 0], BerryColor.Green,
             ['If the leaves grow longer and curlier than average, this Berry will have a somewhat-bitter taste.']);
-        this.berryData[BerryType.Aspear]    = new Berry(BerryType.Aspear,   [10, 40, 50, 110, 220],
+        this.berryData[BerryType.Aspear]    = new Berry(BerryType.Aspear,   [10, 40, 60, 120, 220],
             6, 0.5, 9, 5,
             [0, 0, 0, 0, 10], BerryColor.Yellow,
             ['This Berry\'s peel is hard, but the flesh inside is very juicy. It is distinguished by its bracing sourness.']);
@@ -97,7 +97,7 @@ class Farming implements Feature {
         //#endregion
 
         //#region Second Generation
-        this.berryData[BerryType.Persim]    = new Berry(BerryType.Persim,   [20, 40, 60, 90, 180],
+        this.berryData[BerryType.Persim]    = new Berry(BerryType.Persim,   [20, 40, 50, 90, 180],
             5, 0.4, 10, 2,
             [10, 10, 10, 0, 10], BerryColor.Pink,
             ['The more this Berry absorbs energy from sunlight, the more vivdly colorful it grows.']);

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -78,7 +78,7 @@ class Farming implements Feature {
             5, 0.5, 8, 4,
             [0, 0, 0, 10, 0], BerryColor.Green,
             ['If the leaves grow longer and curlier than average, this Berry will have a somewhat-bitter taste.']);
-        this.berryData[BerryType.Aspear]    = new Berry(BerryType.Aspear,   [10, 40, 60, 120, 220],
+        this.berryData[BerryType.Aspear]    = new Berry(BerryType.Aspear,   [10, 40, 60, 120, 240],
             6, 0.5, 9, 5,
             [0, 0, 0, 0, 10], BerryColor.Yellow,
             ['This Berry\'s peel is hard, but the flesh inside is very juicy. It is distinguished by its bracing sourness.']);

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -540,7 +540,7 @@ class Farming implements Feature {
             }));
         // Hondew
         this.mutations.push(new GrowNearFlavorMutation(.0004, BerryType.Hondew,
-            [[10, 15], [10, 15], [0, 0], [10, 15], [10, 15]], {
+            [[10, 15], [10, 15], [0, 0], [10, 15], [0, 0]], {
                 hint: 'I\'ve heard that a special Berry can appear if its surroundings match its flavor profile! If I recall, it tasted like a little bit of everything except sweet.',
                 unlockReq: function(): boolean {
                     return App.game.farming.unlockedBerries[BerryType.Cheri]() &&

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -285,7 +285,7 @@ class Plot implements Saveable {
             App.game.party.gainPokemonById(PokemonHelper.getPokemonByName(wanderPokemon).id, shiny, true);
 
             // Check for Starf berry generation
-            if (shiny && App.game.farming.highestUnlockedBerry() > BerryType.Salac) {
+            if (shiny) {
                 const emptyPlots = App.game.farming.plotList.filter(plot => plot.isUnlocked && plot.isEmpty());
                 const chosenPlot = emptyPlots[Math.floor(Math.random() * emptyPlots.length)];
                 chosenPlot.plant(BerryType.Starf);

--- a/src/scripts/farming/mutation/Mutation.ts
+++ b/src/scripts/farming/mutation/Mutation.ts
@@ -11,7 +11,7 @@ abstract class Mutation implements Saveable {
 
     defaults: Record<string, any>;
 
-    mutationChance: number;
+    _mutationChance: number;
     mutatedBerry: BerryType;
     _hint?: string;
     showHint: boolean;
@@ -20,7 +20,7 @@ abstract class Mutation implements Saveable {
     _hintSeen: KnockoutObservable<boolean>;
 
     constructor(mutationChance: number, mutatedBerry: BerryType, options?: MutationOptions) {
-        this.mutationChance = mutationChance;
+        this._mutationChance = mutationChance;
         this.mutatedBerry = mutatedBerry;
         this._hint = options?.hint;
         this._unlockReq = options?.unlockReq;
@@ -74,6 +74,14 @@ abstract class Mutation implements Saveable {
     }
 
     /**
+     * Handles getting the mutation chance
+     * @param idx The plot index
+     */
+    mutationChance(idx: number): number {
+        return this._mutationChance;
+    }
+
+    /**
      * Update tag for mutations. Returns true if this mutation will occur
      */
     mutate(): boolean {
@@ -89,7 +97,7 @@ abstract class Mutation implements Saveable {
         let mutated = false;
 
         plots.forEach((idx) => {
-            const willMutate =  Math.random() < this.mutationChance * App.game.farming.getMutationMultiplier() * App.game.farming.plotList[idx].getMutationMultiplier();
+            const willMutate =  Math.random() < this.mutationChance(idx) * App.game.farming.getMutationMultiplier() * App.game.farming.plotList[idx].getMutationMultiplier();
             if (!willMutate) {
                 return;
             }

--- a/src/scripts/farming/mutation/mutationTypes/EnigmaMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/EnigmaMutation.ts
@@ -58,7 +58,7 @@ class EnigmaMutation extends GrowMutation {
      */
     static getReqs(): BerryType[] {
         SeededRand.seed(+App.game.discord.ID());
-        const berryTypes = Array.from({length: GameHelper.enumLength(BerryType) - 1}, (_, i) => i + 1);
+        const berryTypes = Farming.getGeneration(2).concat(Farming.getGeneration(3));
         return [...new Array(4)].map((_) => SeededRand.fromArray(berryTypes));
     }
 

--- a/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
@@ -57,7 +57,7 @@ class GrowNearFlavorMutation extends GrowNearMutation {
         const sameBerries = Plot.findNearPlots(idx).filter(plotIndex => {
             return App.game.farming.plotList[plotIndex].berry === this.mutatedBerry;
         }).length;
-        return super.mutationChance(idx) * Math.pow(10, -sameBerries);
+        return super.mutationChance(idx) * Math.pow(4, -sameBerries);
     }
 
 }

--- a/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
@@ -48,4 +48,30 @@ class GrowNearFlavorMutation extends GrowNearMutation {
         return this.flavorReqs.every((value, idx) => value[0] <= nearFlavors[idx] && nearFlavors[idx] <= value[1]);
     }
 
+    /**
+     * Handles getting the mutation chance.
+     * Will decrease the mutation chance if the mutatedBerry already exists around this one.
+     * @param idx The plot index
+     */
+    mutationChance(idx: number): number {
+        const plots = Plot.findNearPlots(idx);
+        if (!plots.length) {
+            return 0;
+        }
+        let sameBerries = 0;
+        plots.forEach(idx => {
+            const plot = App.game.farming.plotList[idx];
+            if (!plot.isUnlocked) {
+                return;
+            }
+            if (plot.isEmpty()) {
+                return;
+            }
+            if (plot.berry === this.mutatedBerry) {
+                sameBerries += 1;
+            }
+        });
+        return super.mutationChance(idx) * Math.pow(10, -sameBerries);
+    }
+
 }

--- a/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
@@ -56,7 +56,7 @@ class GrowNearFlavorMutation extends GrowNearMutation {
     mutationChance(idx: number): number {
         const plots = Plot.findNearPlots(idx);
         if (!plots.length) {
-            return 0;
+            return super.mutationChance(idx);
         }
         let sameBerries = 0;
         plots.forEach(idx => {

--- a/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/GrowNearFlavorMutation.ts
@@ -54,23 +54,9 @@ class GrowNearFlavorMutation extends GrowNearMutation {
      * @param idx The plot index
      */
     mutationChance(idx: number): number {
-        const plots = Plot.findNearPlots(idx);
-        if (!plots.length) {
-            return super.mutationChance(idx);
-        }
-        let sameBerries = 0;
-        plots.forEach(idx => {
-            const plot = App.game.farming.plotList[idx];
-            if (!plot.isUnlocked) {
-                return;
-            }
-            if (plot.isEmpty()) {
-                return;
-            }
-            if (plot.berry === this.mutatedBerry) {
-                sameBerries += 1;
-            }
-        });
+        const sameBerries = Plot.findNearPlots(idx).filter(plotIndex => {
+            return App.game.farming.plotList[plotIndex].berry === this.mutatedBerry;
+        }).length;
         return super.mutationChance(idx) * Math.pow(10, -sameBerries);
     }
 

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -911,6 +911,9 @@ const CanalaveCityShop = new Shop ([
 const PalParkShop = new Shop([
     ItemList['Razor_claw'],
     ItemList['Razor_fang'],
+    ItemList['Combee'],
+    ItemList['Burmy (plant)'],
+    ItemList['Cherubi'],
 ]);
 const SunyshoreCityShop = new Shop([
     ItemList['Electric_egg'],

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -911,9 +911,6 @@ const CanalaveCityShop = new Shop ([
 const PalParkShop = new Shop([
     ItemList['Razor_claw'],
     ItemList['Razor_fang'],
-    ItemList['Combee'],
-    ItemList['Burmy (plant)'],
-    ItemList['Cherubi'],
 ]);
 const SunyshoreCityShop = new Shop([
     ItemList['Electric_egg'],


### PR DESCRIPTION
 - Fix Hondew mutation to match actual Berry flavor and be harder.
 - Update Enigma mutation algorithm to use 2nd and 3rd gen berries. So nobody can get Cheri and Starf as two requirements (which would suck lol). The berry timers should be closer with 2nd and 3rd gens. This also closes #1078 
 - Fix typo from "Ringo" to "Rindo"
 - Change some wording in the Farm Help menu to be more clear
 - Mutation balance changes
 - Nerf Auras quite a bit
 - Boost wandering pokemon shiny chance.