### PR TITLE
3 New Kanto NPCs

### DIFF
--- a/src/scripts/towns/ProfOakNPC.ts
+++ b/src/scripts/towns/ProfOakNPC.ts
@@ -8,22 +8,24 @@ class ProfOakNPC extends NPC {
     }
 
     get dialogHTML(): string {
-        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.sinnoh) >= 107) {
+        const UniquePokemonCaught = App.game.party.caughtPokemon.filter(p => p.id > 0).length;
+
+        if (UniquePokemonCaught >= 493) {
             return `<p>Congratulations, you're more than half-way completed on the national Pokédex!</p>
                     <p>Next stop is Unova! I've always wanted to visit Castelia City personally...</p>`;
         }
 
-        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.hoenn) >= 135) {
-            return `<p>Hello! Thanks for visiting again.</p>
+        if (UniquePokemonCaught >= 392) {
+            return `<p>That's another Pokédex completed! Fantastic.</p>
                     <p>I really appreciate being able to see your outstanding progress, thank you!</p>`;
         }
 
-        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.johto) >= 100) {
+        if (UniquePokemonCaught >= 254) {
             return `<p>Oh, another regional Pokédex completed so soon?</p>
                     <p>Amazing! Next stop is Hoenn, enjoy the sunshine while you're there!</p>`;
         }
 
-        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.kanto) >= 151) {
+        if (UniquePokemonCaught >= 151) {
             return `<p>Congratulations on completing your Kanto Pokédex!"</p>
                     <p>Your journey isn't over yet, a whole world awaits you! Onwards to Johto!</p>`;
         }

--- a/src/scripts/towns/ProfOakNPC.ts
+++ b/src/scripts/towns/ProfOakNPC.ts
@@ -1,0 +1,39 @@
+class ProfOakNPC extends NPC {
+
+    constructor(
+        public name: string,
+        public dialog: string[],
+    ) {
+        super(name, dialog);
+    }
+
+    get dialogHTML(): string {
+        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.sinnoh) >= 107) {
+            return `<p>Congratulations, you're more than half-way completed on the national Pokédex!</p>
+                    <p>Next stop is Unova! I've always wanted to visit Castelia City personally...</p>`;
+        }
+
+        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.hoenn) >= 135) {
+            return `<p>Hello! Thanks for visiting again.</p>
+                    <p>I really appreciate being able to see your outstanding progress, thank you!</p>`;
+        }
+
+        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.johto) >= 100) {
+            return `<p>Oh, another regional Pokédex completed so soon?</p>
+                    <p>Amazing! Next stop is Hoenn, enjoy the sunshine while you're there!</p>`;
+        }
+
+        if (PokemonHelper.calcUniquePokemonsByRegion(GameConstants.Region.kanto) >= 151) {
+            return `<p>Congratulations on completing your Kanto Pokédex!"</p>
+                    <p>Your journey isn't over yet, a whole world awaits you! Onwards to Johto!</p>`;
+        }
+
+        if (App.game.badgeCase.badgeCount() >= 12) {
+            return `<p>Hello, new Champion, you've come a long way!</p>
+                    <p>If you complete your Pokédex I can arrange for you to travel to Johto!</p>`;
+        }
+
+        //Else, it does the default message.
+        return super.dialogHTML;
+    }
+}

--- a/src/scripts/towns/ProfOakNPC.ts
+++ b/src/scripts/towns/ProfOakNPC.ts
@@ -2,7 +2,7 @@ class ProfOakNPC extends NPC {
 
     constructor(
         public name: string,
-        public dialog: string[],
+        public dialog: string[]
     ) {
         super(name, dialog);
     }

--- a/src/scripts/towns/ProfOakNPC.ts
+++ b/src/scripts/towns/ProfOakNPC.ts
@@ -10,27 +10,27 @@ class ProfOakNPC extends NPC {
     get dialogHTML(): string {
         const uniquePokemonCaught = new Set(App.game.party.caughtPokemon.filter(p => p.id > 0).map(p => Math.floor(p.id))).size;
 
-        if (uniquePokemonCaught >= 649) {
+        if (uniquePokemonCaught >= GameConstants.TotalPokemonsPerRegion[GameConstants.Region.unova]) {
             return `<p>Let me see your progress...Ah, fantastic, as usual!</p>
                     <p>Allow me some time to arrange tickets for your next destination.</p>`;
         }
 
-        if (uniquePokemonCaught >= 493) {
+        if (uniquePokemonCaught >= GameConstants.TotalPokemonsPerRegion[GameConstants.Region.sinnoh]) {
             return `<p>Congratulations, you're more than half-way completed on the national Pokédex!</p>
                     <p>Next stop is Unova! I've always wanted to visit Castelia City personally...</p>`;
         }
 
-        if (uniquePokemonCaught >= 386) {
+        if (uniquePokemonCaught >= GameConstants.TotalPokemonsPerRegion[GameConstants.Region.hoenn]) {
             return `<p>That's another regional Pokédex completed! Fantastic.</p>
                     <p>I really appreciate being able to see your outstanding progress, thank you!</p>`;
         }
 
-        if (uniquePokemonCaught >= 251) {
+        if (uniquePokemonCaught >= GameConstants.TotalPokemonsPerRegion[GameConstants.Region.johto]) {
             return `<p>Oh, another regional Pokédex completed so soon?</p>
                     <p>Amazing! Next stop is Hoenn, enjoy the sunshine while you're there!</p>`;
         }
 
-        if (uniquePokemonCaught >= 151) {
+        if (uniquePokemonCaught >= GameConstants.TotalPokemonsPerRegion[GameConstants.Region.kanto]) {
             return `<p>Congratulations on completing your Kanto Pokédex!</p>
                     <p>Your journey isn't over yet, a whole world awaits you! Onwards to Johto!</p>`;
         }

--- a/src/scripts/towns/ProfOakNPC.ts
+++ b/src/scripts/towns/ProfOakNPC.ts
@@ -35,7 +35,7 @@ class ProfOakNPC extends NPC {
                     <p>Your journey isn't over yet, a whole world awaits you! Onwards to Johto!</p>`;
         }
 
-        if (App.game.badgeCase.badgeCount() >= 12) {
+        if (App.game.badgeCase.badgeCount() >= 13) {
             return `<p>Hello, new Champion, you've come a long way!</p>
                     <p>If you complete your Pokédex I can arrange for you to travel to Johto!</p>`;
         }

--- a/src/scripts/towns/ProfOakNPC.ts
+++ b/src/scripts/towns/ProfOakNPC.ts
@@ -8,25 +8,30 @@ class ProfOakNPC extends NPC {
     }
 
     get dialogHTML(): string {
-        const UniquePokemonCaught = App.game.party.caughtPokemon.filter(p => p.id > 0).length;
+        const uniquePokemonCaught = new Set(App.game.party.caughtPokemon.filter(p => p.id > 0).map(p => Math.floor(p.id))).size;
 
-        if (UniquePokemonCaught >= 493) {
+        if (uniquePokemonCaught >= 649) {
+            return `<p>Let me see your progress...Ah, fantastic, as usual!</p>
+                    <p>Allow me some time to arrange tickets for your next destination.</p>`;
+        }
+
+        if (uniquePokemonCaught >= 493) {
             return `<p>Congratulations, you're more than half-way completed on the national Pokédex!</p>
                     <p>Next stop is Unova! I've always wanted to visit Castelia City personally...</p>`;
         }
 
-        if (UniquePokemonCaught >= 392) {
-            return `<p>That's another Pokédex completed! Fantastic.</p>
+        if (uniquePokemonCaught >= 386) {
+            return `<p>That's another regional Pokédex completed! Fantastic.</p>
                     <p>I really appreciate being able to see your outstanding progress, thank you!</p>`;
         }
 
-        if (UniquePokemonCaught >= 254) {
+        if (uniquePokemonCaught >= 251) {
             return `<p>Oh, another regional Pokédex completed so soon?</p>
                     <p>Amazing! Next stop is Hoenn, enjoy the sunshine while you're there!</p>`;
         }
 
-        if (UniquePokemonCaught >= 151) {
-            return `<p>Congratulations on completing your Kanto Pokédex!"</p>
+        if (uniquePokemonCaught >= 151) {
+            return `<p>Congratulations on completing your Kanto Pokédex!</p>
                     <p>Your journey isn't over yet, a whole world awaits you! Onwards to Johto!</p>`;
         }
 

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -4,6 +4,7 @@
 ///<reference path="../../declarations/enums/Badges.d.ts"/>
 ///<reference path="NPC.ts"/>
 ///<reference path="KantoBerryMasterNPC.ts"/>
+///<reference path="ProfOakNPC.ts"/>
 
 type TownOptionalArgument = {
     requirements?: (Requirement | OneFromManyRequirement)[],
@@ -143,6 +144,18 @@ const KantoBerryMaster = new KantoBerryMasterNPC('Berry Master', [
     'Bah! You younglings have no appreciation of the art of Berry farming!',
     'Come back when you are ready to learn!',
 ]);
+const ProfOak = new ProfOakNPC('Prof. Oak', [
+    'Good luck on your journey!',
+    'Come visit me when you complete your Pokédex!',
+]);
+const BattleItemRival = new NPC('Battle Item Master', [
+    'Hey kid, you look new! Let me offer some advice, Battle Items like x-attack can be acquired along Routes, inside Dungeons and in Shops!',
+    'Use them to help you out whenever you feel like time is against you!',
+]);
+const BattleItemRival2 = new NPC('Battle Item Master', [
+    'Do I know you? Wait... Have you met my worthless rival? Ha! Let me guess, he gave you some unwanted advice?',
+    'I bet he forget to tell you that although all Battle Items only last for 30 seconds they can stack and last for days! Now scram!',
+]);
 
 
 
@@ -156,6 +169,7 @@ TownList['Pewter City'] = new Town(
             new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Viridian Forest')),
         ],
         shop: PewterCityShop,
+        npcs: [BattleItemRival],
     }
 );
 TownList['Cerulean City'] = new Town(
@@ -191,6 +205,7 @@ TownList['Saffron City'] = new Town(
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Rainbow)],
         shop: SaffronCityShop,
+        npcs: [BattleItemRival2],
     }
 );
 TownList['Fuchsia City'] = new Town(
@@ -226,7 +241,13 @@ TownList['Viridian City'] = new Town(
         npcs: [ViridianCityOldMan],
     }
 );
-TownList['Pallet Town'] = new Town('Pallet Town', GameConstants.Region.kanto);
+TownList['Pallet Town'] = new Town(
+    'Pallet Town',
+    GameConstants.Region.kanto,
+    {
+        npcs: [ProfOak],
+    }
+);
 TownList['Lavender Town'] = new Town(
     'Lavender Town',
     GameConstants.Region.kanto,

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -149,7 +149,7 @@ const ProfOak = new ProfOakNPC('Prof. Oak', [
     'Come visit me when you complete your Pokédex!',
 ]);
 const BattleItemRival = new NPC('Battle Item Master', [
-    'Hey kid, you look new! Let me offer some advice, Battle Items like x-attack can be acquired along Routes, inside Dungeons and in Shops!',
+    'Hey kid, you look new! Let me offer some advice, Battle Items like xAttack can be acquired along Routes, inside Dungeons and in Shops!',
     'Use them to help you out whenever you feel like time is against you!',
 ]);
 const BattleItemRival2 = new NPC('Battle Item Master', [


### PR DESCRIPTION
### **Three New Beginner NPCs for Kanto:**

This PR is to help address some concerns with new players being unsure or not being overly passionate about Pokedex completion and also to help convey some information about the importance of Battle Items and how they can be used.

Some new players complain that it's not clear there's content after Kanto Elite 4 or are unaware they need to complete their Pokedex. For them, the most involved NPC i've added is **Prof. Oak!** in Pallet Town. At all stages of the game, he will change his comments to reflect and praise players that have the immersion to be able to remember the dialogues that seem like their might be a follow-up if they were to return to them! 

For instance, for a player like me in Hoenn but who hasn't completed their Regional Pokedex yet there Oak will say this:

<img src="https://user-images.githubusercontent.com/58609098/99736952-34ed0200-2abf-11eb-88bb-0ab75efa0c72.png" alt="Screenshot_8" width="500" height="800">

Pallet Town in my opinion has been neglected for a while. It's the very first town new players spawn in and yet despite being the perfect hub for communicating to new players we don't utilise it. Even if the way i've implemented it only serves to say:

> Good luck on your journey!
> Come visit me when you complete your Pokédex!

It plants those seeds of interaction and of things to do; it gives them an early idea of their objective. Even before they complete their Pokédex this text changes to congratulate them once they're the new Kanto champion. Additionally, this is perfect because upon completion of their Pokédex , we have to visit that same city to travel to Johto anyway! 

### **The battle item rivals**

Based on previous feedback where we don't want to outright display the duration of the battle items in the tooltip. Purpose of this is to inform new players if they weren't already clear that the Battle Items are aquired steadily over time and are useful for a boost in gyms and dungeons. They also stack and last for 30 seconds each. All whilst doing it in a manner that's a subtle reference to the older generation Pokemon games where NPCs share models and sometimes make meta jokes about how they all look alike. 

I think with multiple bits of advice to drop off, the multiple NPCs are needed as it would not otherwise fit very well. It also allows us to create this dynamic of two rivals with different personalities, but both ultimately helping the player with advice. 

Both NPCs are named "Battle Item Master".
One of them is first encountered after two dungeons, in Pewter City. 

> Hey kid, you look new! Let me offer some advice, Battle Items like x-attack can be acquired along routes, inside Dungeons and Shops!
> Don't be stingy and use them to help you out whenever you feel like time is against you!

The second Master is encountered in Saffron City. 

> Huh, you looking at me? Wait... Have you met my worthless rival? Ha! Let me guess, he gave you some unwanted advice?
> I bet he forget to tell you that although all Battle Items only last for 30 seconds they can stack and last for days! Now scram!

<img src="https://user-images.githubusercontent.com/58609098/99738580-bb571300-2ac2-11eb-9b86-2fc02420fe17.png" alt="Screenshot_8" width="400" height="700"><img src="https://user-images.githubusercontent.com/58609098/99738579-ba25e600-2ac2-11eb-9c5b-113795714e22.png" alt="Screenshot_8" width="400" height="700">