### PR TITLE
Add two more Oak slots.

### DIFF
--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -25,7 +25,7 @@ class App {
                 new Wallet(),
                 new KeyItems(),
                 new BadgeCase(),
-                new OakItems([20, 50, 100]),
+                new OakItems([20, 50, 100, 300, 450]),
                 new PokemonCategories(),
                 new Party(),
                 new Shards(),


### PR DESCRIPTION
With the addition of the two new Berry related oak items (to a total of 10), a max of 3 active feels too low.
This adds a fourth at 300 (mid-Hoenn) and a fifth at 450 (mid-Sinnoh)