### PR TITLE
Roamer delay

### DIFF
--- a/src/scripts/pokemons/RoamingPokemonList.ts
+++ b/src/scripts/pokemons/RoamingPokemonList.ts
@@ -44,6 +44,6 @@ RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon(pokemonMa
 RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon(pokemonMap.Cresselia, undefined, new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Fullmoon Island'))));
 
 // Unova
-RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon(pokemonMap.Tornadus));
-RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon(pokemonMap.Thundurus));
+RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon(pokemonMap.Tornadus, undefined, new GymBadgeRequirement(BadgeEnums.Legend)));
+RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon(pokemonMap.Thundurus, undefined, new GymBadgeRequirement(BadgeEnums.Legend)));
 RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon(pokemonMap['Meloetta (aria)'], undefined, new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)));

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -1348,6 +1348,14 @@ const AnvilleTownShop = new Shop([
     ItemList['Meloetta (pirouette)'],
 ]);
 
+//Unova NPCs
+const ExcitedChild = new NPC('Professor Birch\'s Aide', [
+    'Did you hear? Did you see? It was on TV!',
+    'I was just watching my favorite show, The National Gymquirer. It was a live segment! Some hot shot trainer from Kanto defeated Drayden! It was amazing! That trainer is so cool! Drayden is like unbeatable.',
+    'Then my programme got interrupted by an emergency broadcast. A report on the first confirmed sightings of Tornadus and Thundurus in over twenty-five years!',
+    'Last time they were spotted they just roamed around, causing all kinds of mischief. According to my books anyway. I\'m sure that amazing trainer from the TV will want to catch these mighty forces of nature.',
+]);
+
 //Unova Towns
 TownList['Aspertia City'] = new Town(
     'Aspertia City',
@@ -1449,6 +1457,7 @@ TownList['Humilau City'] = new Town(
     GameConstants.Region.unova,
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.unova, 21)],
+        npcs: [ExcitedChild],
     }
 );
 TownList['Pokemon League Unova'] = new Town(

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -1352,7 +1352,7 @@ const AnvilleTownShop = new Shop([
 const ExcitedChild = new NPC('Professor Birch\'s Aide', [
     'Did you hear? Did you see? It was on TV!',
     'I was just watching my favorite show, The National Gymquirer. It was a live segment! Some hot shot trainer from Kanto defeated Drayden! It was amazing! That trainer is so cool! Drayden is like unbeatable.',
-    'Then my programme got interrupted by an emergency broadcast. A report on the first confirmed sightings of Tornadus and Thundurus in over twenty-five years!',
+    'Then my programme got interrupted by an emergency broadcast. A report on the first confirmed sightings of Tornadus and Thundurus in over twenty-five years! I\'ve read so much about them, they are my favorites.',
     'Last time they were spotted they just roamed around, causing all kinds of mischief. According to my books anyway. I\'m sure that amazing trainer from the TV will want to catch these mighty forces of nature.',
 ]);
 


### PR DESCRIPTION
Delays the first appearance of Tornadus and Thundurus, locking them behind the Legend (7th) badge of the region. Also adds a hint to Humilau City.

The National Gymquirer is a real in-universe show you can catch on TV in the gen 5 games btw. Thought it'd be a nice reference. Though the in-universe show is about gym leaders, not gym challengers. Creative liberty.