### PR TITLE
Resetting Aura Fix

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -13,6 +13,13 @@ class Farming implements Feature {
     mutationCounter = 0;
     wanderCounter = 0;
 
+    // You may be wondering why this is necessary.
+    // It turns out for some reason the plot age doesn't update in time in the same tick.
+    // This means that if we attempt to reset the auras in the same tick, the plant that changed stages
+    // will still act like it's in the previous stage, which means the wrong aura is applied.
+    // Queueing an aura reset in the next tick fixes this issue, and is barely noticable to the player.
+    queuedAuraReset = false;
+
     static readonly PLOT_WIDTH = 5;
     static readonly PLOT_HEIGHT = 5;
 
@@ -849,6 +856,12 @@ class Farming implements Feature {
 
         let change = false;
 
+        // Handle updating auras
+        if (this.queuedAuraReset) {
+            this.resetAuras();
+            this.queuedAuraReset = false;
+        }
+
         // Updating Berries
         this.plotList.forEach(plot => {
             if (plot.update(timeToReduce)) {
@@ -890,8 +903,9 @@ class Farming implements Feature {
 
         }
 
+        // Handle queueing aura reset
         if (change) {
-            this.resetAuras();
+            this.queuedAuraReset = true;
         }
 
         if (notifications.size) {


### PR DESCRIPTION
Comment in Farming.ts explains most of it.

For some reason, the stage of the plant wasn't being updated in the same tick, so `resetAura()` would see the plant that triggered the update in its previous stage. This affects aura plants because if there's only one plant, and the aura Berry goes from Sprout to Taller, the `resetAura()` call will think the Berry is still in Sprout stage, and won't apply the aura correctly.

To fix this, we queue up an aura reset instead, so that the auras will be reset in the next tick, where the plot stages are updated correctly. This leads to a minor visual delay, however overall the player will still have the same amount of ticks with the aura applied.

There might be a cleaner solution if there's a way of updating the Stage KnockoutComputed variable, if that's actually the issue here.