### PR TITLE
Berry Update: Life and Death

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -305,8 +305,8 @@ class Farming implements Feature {
             [0, 10, 20, 0, 0], BerryColor.Purple,
             [
                 'Considered to have a special power from the olden days, this Berry is sometimes dried and used as a good-luck charm.',
-                'Nearby Pokémon are wary of this Berry plant.',
-            ], new Aura(AuraType.Attract, [0.99, 0.98, 0.97]), ['Shedinja']);
+                'This Berry causes other Berries to wither away faster.',
+            ], undefined, ['Shedinja']);
         this.berryData[BerryType.Haban]     = new Berry(BerryType.Haban,    [10800, 21600, 43200, 86400, 172800],
             34, 0, 4000, 15,
             [0, 0, 10, 20, 0], BerryColor.Red,

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -821,6 +821,22 @@ class Farming implements Feature {
             unlockReq: () => App.game.farming.unlockedBerries[BerryType.Starf](),
         }));
 
+        // Empty Mutations for hints
+
+        // Kasib
+        this.mutations.push(new BlankMutation(0, BerryType.Kasib,
+            {
+                hint: 'I\'ve heard of a Berry that only appears after a Berry plant has withered, but is repelled by Colbur Plants.',
+                unlockReq: () => App.game.farming.highestUnlockedBerry() > BerryType.Occa,
+            }));
+
+        // Starf
+        this.mutations.push(new BlankMutation(0, BerryType.Starf,
+            {
+                hint: 'I\'ve heard of a Berry that only appears after a Shiny Pokémon wanders near open soil.',
+                unlockReq: () => App.game.farming.highestUnlockedBerry() > BerryType.Occa,
+            }));
+
         //#endregion
 
         //#endregion

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -386,7 +386,10 @@ class Farming implements Feature {
         this.berryData[BerryType.Petaya]    = new Berry(BerryType.Petaya,   [10800, 21600, 43200, 86400, 432000],
             0.5, 0, 15000, 20,
             [30, 0, 0, 30, 10], BerryColor.Pink,
-            ['This Berry is surrounded by mystery. It is rumored to be imbued with the power of all living things.'],
+            [
+                'This Berry is surrounded by mystery. It is rumored to be imbued with the power of all living things.',
+                'This power keeps other Berries alive for longer.',
+            ],
             undefined, ['Mew']);
         this.berryData[BerryType.Apicot]    = new Berry(BerryType.Apicot,   [10800, 21600, 43200, 86400, 432000],
             0.5, 0, 15000, 20,
@@ -1179,6 +1182,15 @@ class Farming implements Feature {
             });
             this.unlockedBerries[berry](true);
         }
+    }
+
+    /**
+     * Checks whether a Berry plant exists on the farm
+     * @param berry The Berry type
+     * @param stage The stage of the Berry plant. Defaults to PlotStage.Berry
+     */
+    berryInFarm(berry: BerryType, stage = PlotStage.Berry) {
+        return this.plotList.some(plot => plot.berry == berry && plot.stage() >= stage);
     }
 
     toJSON(): Record<string, any> {

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -124,59 +124,65 @@ class Plot implements Saveable {
         this.tooltip = ko.pureComputed(() => {
             const tooltip = [];
 
+            // Time
             if (this.berry !== BerryType.None) {
 
                 tooltip.push(`<u>${BerryType[this.berry]}</u>`);
 
-                const timeType = Settings.getSetting('farmDisplay').observableValue();
-                if (timeType === 'nextStage') {
-                    const formattedTime = this.formattedStageTimeLeft();
-                    switch (this.stage()) {
-                        case PlotStage.Seed:
-                            tooltip.push(`${formattedTime} until sprout`);
-                            break;
-                        case PlotStage.Sprout:
-                            tooltip.push(`${formattedTime} until grown`);
-                            break;
-                        case PlotStage.Taller:
-                            tooltip.push(`${formattedTime} until bloom`);
-                            break;
-                        case PlotStage.Bloom:
-                            tooltip.push(`${formattedTime} until ripe`);
-                            break;
-                        case PlotStage.Berry:
-                            tooltip.push(`${formattedTime} until death`);
-                            break;
-                    }
+                // Petaya Effect
+                if (App.game.farming.berryInFarm(BerryType.Petaya) && this.berry !== BerryType.Petaya && this.stage() == PlotStage.Berry) {
+                    tooltip.push('∞ until death');
+                // Normal Time
                 } else {
-                    const formattedTime = this.formattedTimeLeft();
-                    switch (this.stage()) {
-                        case PlotStage.Seed:
-                        case PlotStage.Sprout:
-                        case PlotStage.Taller:
-                        case PlotStage.Bloom:
-                            tooltip.push(`${formattedTime} until ripe`);
-                            break;
-                        case PlotStage.Berry:
-                            tooltip.push(`${formattedTime} until death`);
-                            break;
+                    const timeType = Settings.getSetting('farmDisplay').observableValue();
+                    if (timeType === 'nextStage') {
+                        const formattedTime = this.formattedStageTimeLeft();
+                        switch (this.stage()) {
+                            case PlotStage.Seed:
+                                tooltip.push(`${formattedTime} until sprout`);
+                                break;
+                            case PlotStage.Sprout:
+                                tooltip.push(`${formattedTime} until grown`);
+                                break;
+                            case PlotStage.Taller:
+                                tooltip.push(`${formattedTime} until bloom`);
+                                break;
+                            case PlotStage.Bloom:
+                                tooltip.push(`${formattedTime} until ripe`);
+                                break;
+                            case PlotStage.Berry:
+                                tooltip.push(`${formattedTime} until death`);
+                                break;
+                        }
+                    } else {
+                        const formattedTime = this.formattedTimeLeft();
+                        switch (this.stage()) {
+                            case PlotStage.Seed:
+                            case PlotStage.Sprout:
+                            case PlotStage.Taller:
+                            case PlotStage.Bloom:
+                                tooltip.push(`${formattedTime} until ripe`);
+                                break;
+                            case PlotStage.Berry:
+                                tooltip.push(`${formattedTime} until death`);
+                                break;
+                        }
                     }
                 }
-
-
             }
 
+            // Aura
             if (this.stage() >= PlotStage.Taller && this.berryData.aura) {
                 tooltip.push('<u>Aura Emitted:</u>');
                 tooltip.push(`${this.berryData.aura.getLabel(this.stage())}`);
             }
-
             const auraStr = this.formattedAuras();
             if (auraStr) {
                 tooltip.push('<u>Aura Received:</u>');
                 tooltip.push(auraStr);
             }
 
+            // Mulch
             if (this.mulch !== MulchType.None) {
                 const mulchTime = this.formattedMulchTimeLeft();
                 tooltip.push('<u>Mulch</u>');
@@ -204,6 +210,13 @@ class Plot implements Saveable {
             const oldAge = this.age;
             this.age += growthTime;
 
+            // Checking for Kasib
+            // TODO: HLXII
+
+            // Checking for Petaya Berries
+            if (App.game.farming.berryInFarm(BerryType.Petaya) && this.berry !== BerryType.Petaya) {
+                this.age = Math.min(this.age, this.berryData.growthTime[3] + 1);
+            }
 
             const updatedStage = this.stageUpdated(oldAge, this.age);
 
@@ -287,11 +300,12 @@ class Plot implements Saveable {
 
             // Check for Kasib berry mutation/replant chance
             if (App.game.farming.highestUnlockedBerry() > BerryType.Occa) {
-                if (App.game.farming.plotList.every(plot => plot.berry !== BerryType.Colbur)) {
+                if (!App.game.farming.berryInFarm(BerryType.Colbur)) {
                     if (Math.random() < 0.05) {
                         this.notifications.push(FarmNotificationType.Mutated);
                         this.berry = BerryType.Kasib;
                         this.age = 0;
+                        App.game.farming.unlockBerry(BerryType.Kasib);
                         return;
                     }
                 }
@@ -322,6 +336,7 @@ class Plot implements Saveable {
                 const emptyPlots = App.game.farming.plotList.filter(plot => plot.isUnlocked && plot.isEmpty());
                 const chosenPlot = emptyPlots[Math.floor(Math.random() * emptyPlots.length)];
                 chosenPlot.plant(BerryType.Starf);
+                App.game.farming.unlockBerry(BerryType.Starf);
             }
 
             return {pokemon: wanderPokemon, shiny: shiny};

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -210,9 +210,6 @@ class Plot implements Saveable {
             const oldAge = this.age;
             this.age += growthTime;
 
-            // Checking for Kasib
-            // TODO: HLXII
-
             // Checking for Petaya Berries
             if (App.game.farming.berryInFarm(BerryType.Petaya) && this.berry !== BerryType.Petaya) {
                 this.age = Math.min(this.age, this.berryData.growthTime[3] + 1);
@@ -356,6 +353,11 @@ class Plot implements Saveable {
         }
 
         multiplier *= this._auras[AuraType.Growth]();
+
+        // Handle Kasib Effect
+        if (this.stage() == PlotStage.Berry && this.berry != BerryType.Kasib && App.game.farming.berryInFarm(BerryType.Kasib)) {
+            multiplier *= 5;
+        }
 
         return multiplier;
     }

--- a/src/scripts/farming/mutation/Mutation.ts
+++ b/src/scripts/farming/mutation/Mutation.ts
@@ -35,7 +35,7 @@ abstract class Mutation implements Saveable {
         };
     }
     fromJSON(json: Record<string, any>): void {
-        this.hintSeen = json['hintSeen'] ?? false;
+        this.hintSeen = json.hasOwnProperty('hintSeen') ? json['hintSeen'] : false;
     }
 
     /**

--- a/src/scripts/farming/mutation/mutationTypes/BlankMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/BlankMutation.ts
@@ -1,0 +1,14 @@
+/// <reference path="../Mutation.ts" />
+
+/**
+ * A Blank Mutation to be used to store hint data.
+ * This is mostly because the Mutation framework controls the hints, but some mutations are outside of the Mutation framework
+ */
+class BlankMutation extends Mutation {
+    getMutationPlots(): number[] {
+        return [];
+    }
+    handleMutation(index: number): void {
+        return;
+    }
+}


### PR DESCRIPTION
Kasib wasn't annoying enough. Petaya was extremely difficult to obtain with no payoff.

I've removed the Wandering Pokemon Attract Debuff from Kasib, and replaced it with faster growth rate for Berry plants in the Berry stage. This way Kasib Berries will be very annoying as players will have less time to manually harvest their plants.

The Petaya Berry will now keep Berry plants alive indefinitely. It does not however affect itself or any other Petaya plant, so once the Petaya plant withers, the rest of the plants will start aging again. This brings some interesting end-game strategies, as you can keep Auras around for much longer. This also helps mutations (as plants won't die anymore), but it won't help out that much since Petaya is already an end game plant to obtain (maybe for people who didn't want to try for Lum yet).

I've also added empty Mutations so that the Kasib/Starf mutations have hints that appear.