### PR TITLE
Fix parasite mutations

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -630,8 +630,8 @@ class Farming implements Feature {
                 BerryType.Tamato,
                 BerryType.Spelon,
             ]));
-        // Occa Overgrow
-        this.mutations.push(new EvolveNearBerryMutation(.0004, BerryType.Occa, undefined, [BerryType.Occa], { showHint: false }));
+        // Occa Parasite
+        this.mutations.push(new ParasiteMutation(.0004, BerryType.Occa));
         // Passho
         this.mutations.push(new GrowNearBerryMutation(.0001, BerryType.Passho,
             [
@@ -659,8 +659,7 @@ class Farming implements Feature {
                 },
             }));
         // Rindo Overgrow
-        this.mutations.push(new GrowNearBerryMutation(.0004, BerryType.Rindo,
-            [BerryType.Rindo], {showHint: false }));
+        this.mutations.push(new GrowNearBerryMutation(.0004, BerryType.Rindo, [BerryType.Rindo], {showHint: false }));
         // Yache
         this.mutations.push(new EvolveNearBerryStrictMutation(.0001, BerryType.Yache, BerryType.Passho, {}, PlotStage.Seed, {
             hint: 'I\'ve heard that growing a Passho Berry alone will cause it to change!',
@@ -669,8 +668,8 @@ class Farming implements Feature {
         this.mutations.push(new OakMutation(.0001, BerryType.Chople, BerryType.Spelon, OakItems.OakItem.Blaze_Cassette));
         // Kebia
         this.mutations.push(new OakMutation(.0001, BerryType.Kebia, BerryType.Pamtre, OakItems.OakItem.Poison_Barb));
-        // Kebia Overgrow
-        this.mutations.push(new EvolveNearBerryMutation(.0004, BerryType.Kebia, undefined, [BerryType.Kebia], { showHint: false }));
+        // Kebia Parasite
+        this.mutations.push(new ParasiteMutation(.0004, BerryType.Kebia));
         // Shuca
         this.mutations.push(new OakMutation(.0001, BerryType.Shuca, BerryType.Watmel, OakItems.OakItem.Sprinklotad));
         // Coba
@@ -716,8 +715,8 @@ class Farming implements Feature {
                 BerryType.Kasib,
                 BerryType.Payapa,
             ]));
-        // Colbur Overgrow
-        this.mutations.push(new EvolveNearBerryMutation(.0004, BerryType.Colbur, undefined, [BerryType.Colbur], { showHint: false }));
+        // Colbur Parasite
+        this.mutations.push(new ParasiteMutation(.0004, BerryType.Colbur));
         // Babiri
         berryReqs = {};
         berryReqs[BerryType.Shuca] = 4;

--- a/src/scripts/farming/mutation/mutationTypes/ParasiteMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/ParasiteMutation.ts
@@ -1,0 +1,24 @@
+/// <reference path="./EvolveNearBerryMutation.ts" />
+
+/**
+ * Parasite Mutation
+ */
+class ParasiteMutation extends EvolveNearBerryMutation {
+
+    constructor(mutationChance: number, berry: BerryType) {
+        super(mutationChance, berry, undefined, [berry], { showHint: false });
+    }
+
+    /**
+     * Determines which plots can mutate. Excludes the parasite berry
+     * @return The plot indices that can mutate
+     */
+    getMutationPlots(): number[] {
+        const plots = super.getMutationPlots();
+
+        return plots.filter((idx) => {
+            return App.game.farming.plotList[idx].berry !== this.mutatedBerry;
+        });
+    }
+
+}


### PR DESCRIPTION
We were using EvolveNearBerryMutation with the originalBerry parameter undefined so all Berry plants nearby had the chance to mutate (and thus it becomes a parasite mutation). However, we didn't check if the nearby plants were the same Berry species, so the parasite mutation could occur on the same Berry type (e.g. Kebia Berries could mutate into Kebia Berries). This caused an infinite loop of mutations, as Evolve Mutations resets the Berry age.

To fix this, I created the ParasiteMutation subclass for EvolveNearBerryMutation, that overrides getMutationPlots to exclude the parasite mutation Berry itself from the mutation pool. This should stop the infinite mutations.