### PR TITLE
Fix Map Tooltip not appearing

### DIFF
--- a/src/components/AlolaSVG.html
+++ b/src/components/AlolaSVG.html
@@ -1,4 +1,4 @@
-<g data-bind='if: player.region == GameConstants.Region.alola'>
+<g data-bind='visible: player.region == GameConstants.Region.alola'>
     <image width="100%" xlink:href="assets/images/background.png"></image>
 
     <!-- ------ -->

--- a/src/components/HoennSVG.html
+++ b/src/components/HoennSVG.html
@@ -1,4 +1,4 @@
-<g data-bind='if: player.region == GameConstants.Region.hoenn'>
+<g data-bind='visible: player.region == GameConstants.Region.hoenn'>
     <image width="100%" xlink:href="assets/images/hoenn.png"></image>
 
     <!-- ------ -->

--- a/src/components/JohtoSVG.html
+++ b/src/components/JohtoSVG.html
@@ -1,4 +1,4 @@
-<g data-bind='if: player.region == GameConstants.Region.johto'>
+<g data-bind='visible: player.region == GameConstants.Region.johto'>
     <image width="100%" xlink:href="assets/images/johto.png"></image>
 
     <!-- ------ -->

--- a/src/components/KalosSVG.html
+++ b/src/components/KalosSVG.html
@@ -1,4 +1,4 @@
-<g data-bind='if: player.region == GameConstants.Region.kalos'>
+<g data-bind='visible: player.region == GameConstants.Region.kalos'>
     <image width="100%" xlink:href="assets/images/background.png"></image>
 
     <!-- ------ -->

--- a/src/components/KantoSVG.html
+++ b/src/components/KantoSVG.html
@@ -1,4 +1,4 @@
-<g data-bind='if: player.region == GameConstants.Region.kanto'>
+<g data-bind='visible: player.region == GameConstants.Region.kanto'>
     <image width="100%" xlink:href="assets/images/kanto.png"></image>
 
     <!-- ------ -->

--- a/src/components/SinnohSVG.html
+++ b/src/components/SinnohSVG.html
@@ -1,4 +1,4 @@
-<g data-bind='if: player.region == GameConstants.Region.sinnoh'>
+<g data-bind='visible: player.region == GameConstants.Region.sinnoh'>
     <image width="100%" xlink:href="assets/images/sinnoh.png"></image>
 
     <!-- ------ -->

--- a/src/components/UnovaSVG.html
+++ b/src/components/UnovaSVG.html
@@ -1,4 +1,4 @@
-<g data-bind='if: player.region == GameConstants.Region.unova'>
+<g data-bind='visible: player.region == GameConstants.Region.unova'>
     <image width="100%" xlink:href="assets/images/unova.png"></image>
 
     <!-- ------ -->
@@ -741,7 +741,7 @@
         , databind: "click:function(){MapHelper.openShipModal()}, attr: { class: MapHelper.calculateTownCssClass('Castelia City') }"
         })
      %>
-     
+
     <!--bridge-->
     <%- include('templates/mapPOI',
         { name: "Skyarrow Bridge"

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -27,7 +27,6 @@ class MapHelper {
                 Battle.generateNewEnemy();
             }
             App.game.gameState = GameConstants.GameState.fighting;
-            GameController.applyRouteBindings();
         } else {
             if (!MapHelper.routeExist(route, region)) {
                 return Notifier.notify({
@@ -155,7 +154,6 @@ class MapHelper {
             Battle.enemyPokemon(null);
             //this should happen last, so all the values all set beforehand
             App.game.gameState = GameConstants.GameState.town;
-            GameController.applyRouteBindings();
         } else {
             const town = TownList[townName];
             const reqsList = [];


### PR DESCRIPTION
Closes #995 

The Map Tooltip is setup in `applyRouteBindings::GameController.ts` to display when hovering over towns on the map. This method was called on initialization, as well as in `moveToRoute` and `moveToTown`.

However, when we switch regions, `applyRouteBindings` was being called before the new region map was loaded in the DOM. This means the bindings were applied on the old map, and then the new map was loaded, thus the tooltip doesn't appear initially. When moving to a route/town in the region though the method was called, which is why the issue fixes itself then.

There were two options of fixing this:
1. Call `applyRouteBindings` after the new region map has loaded
2. Don't remove the region maps on switching regions

I didn't implement option 1 as I didn't know how to call a method after Knockout updates the DOM.

For option 2, this was done by changing the Knockout binding for the region maps from `if` to `visible`. the `if` binding removed the DOM elements entirely from the document, which is why the bindings were lost on moving to a new region. If we use `visible` instead, all the maps are loaded on initialization, and all bindings are applied correctly. Thus switching to a new region will only hide the previous and display the current region (with the bindings already added).

This solution fixes the bug (and also slightly increases performance on navigating to new routes/towns/regions), however it means that all the maps are loaded in the DOM and are never removed. This might be slightly less performant.