### PR TITLE
Fix Underground Quest Old Amber reward

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -125,7 +125,7 @@ class QuestLineHelper {
         // Mine 5 layers in the Unerground
         const OldAmberReward = () => {
             // Gain an Old Amber
-            Underground.gainMineItem(3);
+            Underground.gainMineItem(202);
             Notifier.notify({
                 title: undergroundQuestLine.name,
                 message: 'You have gained an Old Amber fossil!<br/><i>You can breed this in the hatchery.</i>',

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -125,7 +125,11 @@ class QuestLineHelper {
         // Mine 5 layers in the Unerground
         const OldAmberReward = () => {
             // Gain an Old Amber
-            Underground.gainMineItem(202);
+            const oldAmber = UndergroundItem.list.find(item => item.name == 'Old Amber');
+            if (!oldAmber) {
+                return console.error('Unable to find item Old Amber');
+            }
+            Underground.gainMineItem(oldAmber.id);
             Notifier.notify({
                 title: undergroundQuestLine.name,
                 message: 'You have gained an Old Amber fossil!<br/><i>You can breed this in the hatchery.</i>',


### PR DESCRIPTION
We updated the Underground Item IDs in 0.7.1, but didn't update the Quest to return the new item IDs.

We should really think about creating an enum or something similar to make sure this doesn't happen again...

For now, I replicated how we found `Mind Plates` for the Deoxys quest line to find the `Old Amber` item.