### PR TITLE
Fixed the Grammer for Let's Go Event Pokemon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11012,7 +11012,7 @@ aria-labelledby="hallOfFameModalLabel" aria-hidden="true">
                    When Pokémon are in a Region they're not native to, they will only retain <strong data-bind="text: App.game.party.getRegionAttackMultiplier(player.highestRegion() + 1).toLocaleString(undefined,{style: 'percent'})"></strong> of their total attack.<br/>
                    You will also have to progress to the Dock in <span data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() + 1])"></span> before you are able to travel between regions again.
                </p>
-               <button class="btn btn-success btn-block" onclick="MapHelper.travelToNextRegion()" data-dismiss="modal">Lets go!</button>
+               <button class="btn btn-success btn-block" onclick="MapHelper.travelToNextRegion()" data-dismiss="modal">Let's Go!</button>
            </div>
        </div>
     </div>

--- a/src/components/developmentBanner.html
+++ b/src/components/developmentBanner.html
@@ -15,7 +15,7 @@
                     or <a href="https://github.com/pokeclicker/pokeclicker/issues" target="_blank">GitHub</a>.</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary btn-block" data-dismiss="modal">Lets GO!</button>
+                <button type="button" class="btn btn-primary btn-block" data-dismiss="modal">Let's GO!</button>
             </div>
         </div>
     </div>

--- a/src/components/nextRegionModal.html
+++ b/src/components/nextRegionModal.html
@@ -17,7 +17,7 @@
                    When Pokémon are in a Region they're not native to, they will only retain <strong data-bind="text: App.game.party.getRegionAttackMultiplier(player.highestRegion() + 1).toLocaleString(undefined,{style: 'percent'})"></strong> of their total attack.<br/>
                    You will also have to progress to the Dock in <span data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() + 1])"></span> before you are able to travel between regions again.
                </p>
-               <button class="btn btn-success btn-block" onclick="MapHelper.travelToNextRegion()" data-dismiss="modal">Lets go!</button>
+               <button class="btn btn-success btn-block" onclick="MapHelper.travelToNextRegion()" data-dismiss="modal">Let's Go!</button>
            </div>
        </div>
     </div>

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -20243,7 +20243,7 @@ const pokemonList = createPokemonArray(
     },
     {
         'id': -8,
-        'name': 'Lets go Pikachu',
+        'name': 'Let\'s Go Pikachu',
         'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 50,
         'type': [PokemonType.Electric],
@@ -20261,7 +20261,7 @@ const pokemonList = createPokemonArray(
     },
     {
         'id': -9,
-        'name': 'Lets go Eevee',
+        'name': 'Let\'s Go Eevee',
         'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 50,
         'type': [PokemonType.Normal],

--- a/src/scripts/specialEvents/SpecialEvents.ts
+++ b/src/scripts/specialEvents/SpecialEvents.ts
@@ -99,8 +99,8 @@ SpecialEvents.newEvent('Halloween!', 'Encounter Spooky Pokémon for a limited ti
         Routes.getRoutesByRegion(GameConstants.Region.hoenn).forEach(route => route.pokemon.land = route.pokemon.land.filter(p => !['Pikachu (Gengar)', 'Shuppet', 'Duskull'].includes(p)));
     }
 );
-// Lets go P/E release date
-SpecialEvents.newEvent('Lets GO!', 'Encounter special Eevee and Pikachu roaming in the Kanto region.',
+// Let's Go P/E release date
+SpecialEvents.newEvent('Let\'s GO!', 'Encounter special Eevee and Pikachu roaming in the Kanto region.',
     // Start
     new Date(new Date().getFullYear(), 10, 16, 1), () => {
         RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon(pokemonMap['Let\'s Go Pikachu']));

--- a/src/scripts/specialEvents/SpecialEvents.ts
+++ b/src/scripts/specialEvents/SpecialEvents.ts
@@ -103,13 +103,13 @@ SpecialEvents.newEvent('Halloween!', 'Encounter Spooky Pokémon for a limited ti
 SpecialEvents.newEvent('Lets GO!', 'Encounter special Eevee and Pikachu roaming in the Kanto region.',
     // Start
     new Date(new Date().getFullYear(), 10, 16, 1), () => {
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon(pokemonMap['Lets go Pikachu']));
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon(pokemonMap['Lets go Eevee']));
+        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon(pokemonMap['Let\'s Go Pikachu']));
+        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon(pokemonMap['Let\'s Go Eevee']));
     },
     // End
     new Date(new Date().getFullYear(), 10, 23, 23), () => {
-        RoamingPokemonList.remove(GameConstants.Region.kanto, 'Lets go Pikachu');
-        RoamingPokemonList.remove(GameConstants.Region.kanto, 'Lets go Eevee');
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 'Let\'s Go Pikachu');
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 'Let\'s Go Eevee');
     }
 );
 // Christmas


### PR DESCRIPTION
Fixed the grammar for Let's Go event Pokemon. I thought it look odd that the capitalization and apostrophe was missing.