### PR TITLE
Update Quest Generation Limitations

### DIFF
--- a/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
@@ -12,9 +12,16 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
 
     public static generateData(): any[] {
         // Allow up to highest region
-        const region = SeededRand.intBetween(0, player.highestRegion());
-        const dungeon = SeededRand.fromArray(GameConstants.RegionDungeons[region]);
         const amount = SeededRand.intBetween(5, 20);
+        let attempts = 0;
+        let region = GameConstants.Region.kanto;
+        let dungeon = GameConstants.RegionDungeons[region]['Viridian Forest'];
+        // Try to find unlocked dungeon, end after 10 attempts
+        do {
+            region = SeededRand.intBetween(0, player.highestRegion());
+            dungeon = SeededRand.fromArray(GameConstants.RegionDungeons[region]);
+            console.log(`dungeon ${dungeon} unlocked ${TownList[dungeon].isUnlocked()}`);
+        } while (!TownList[dungeon].isUnlocked() && ++attempts < 10);
         const reward = this.calcReward(amount, dungeon);
         return [amount, reward, dungeon];
     }

--- a/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
@@ -15,7 +15,7 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
         const amount = SeededRand.intBetween(5, 20);
         let attempts = 0;
         let region = GameConstants.Region.kanto;
-        let dungeon = GameConstants.RegionDungeons[region]['Viridian Forest'];
+        let dungeon = GameConstants.RegionDungeons[region][0];
         // Try to find unlocked dungeon, end after 10 attempts
         do {
             region = SeededRand.intBetween(0, player.highestRegion());

--- a/src/scripts/quests/questTypes/DefeatGymQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatGymQuest.ts
@@ -13,8 +13,8 @@ class DefeatGymQuest extends Quest implements QuestInterface {
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(5, 20);
         let attempts = 0;
-        let gymTown = GameConstants.RegionGyms['Pewter City'];
         let region = GameConstants.Region.kanto;
+        let gymTown = GameConstants.RegionGyms[region][0];
         // Try to find unlocked gym, end after 10 attempts
         do {
             region = SeededRand.intBetween(0, player.highestRegion());

--- a/src/scripts/quests/questTypes/DefeatGymQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatGymQuest.ts
@@ -11,9 +11,16 @@ class DefeatGymQuest extends Quest implements QuestInterface {
     }
 
     public static generateData(): any[] {
-        const region = SeededRand.intBetween(0, player.highestRegion());
-        const gymTown = SeededRand.fromArray(GameConstants.RegionGyms[region]);
         const amount = SeededRand.intBetween(5, 20);
+        let attempts = 0;
+        let gymTown = GameConstants.RegionGyms['Pewter City'];
+        let region = GameConstants.Region.kanto;
+        // Try to find unlocked gym, end after 10 attempts
+        do {
+            region = SeededRand.intBetween(0, player.highestRegion());
+            gymTown = SeededRand.fromArray(GameConstants.RegionGyms[region]);
+        } while (!Gym.isUnlocked(gymList[gymTown]) && ++attempts < 10);
+
         const reward = this.calcReward(amount, gymTown);
         return [amount, reward, gymTown];
     }

--- a/src/scripts/quests/questTypes/DefeatPokemonsQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatPokemonsQuest.ts
@@ -14,8 +14,14 @@ class DefeatPokemonsQuest extends Quest implements QuestInterface {
 
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(100, 500);
-        const region = SeededRand.intBetween(0, player.highestRegion());
-        const route = SeededRand.fromArray(Routes.getRoutesByRegion(region)).number;
+        let attempts = 0;
+        let region = GameConstants.Region.kanto;
+        let route = 1;
+        // Try to find unlocked route, end after 10 attempts
+        do {
+            region = SeededRand.intBetween(0, player.highestRegion());
+            route = SeededRand.fromArray(Routes.getRoutesByRegion(region)).number;
+        } while (!MapHelper.accessToRoute(route, region) && ++attempts < 10);
         const reward = this.calcReward(amount, route, region);
         return [amount, reward, route, region];
     }

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -33,7 +33,7 @@ class GainShardsQuest extends Quest implements QuestInterface {
     }
 
     public static generateData(): any[] {
-        const type = SeededRand.fromArray(GameHelper.createArray(1, GameHelper.enumLength(PokemonType) - 1, 1));
+        const type = SeededRand.fromArray(GameHelper.createArray(0, GameHelper.enumLength(PokemonType) - 2, 1));
         const amount = SeededRand.intBetween(200, 600);
         const reward = this.calcReward(type, amount);
         return [amount, reward, type];

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -10,25 +10,37 @@ class GainShardsQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.shardsGained[this.type];
     }
 
+    public static rewardWeight: Record<PokemonType, number> = {
+        [PokemonType.None]:     0,
+        [PokemonType.Normal]:   1,
+        [PokemonType.Fire]:     2,
+        [PokemonType.Water]:    1,
+        [PokemonType.Electric]: 2,
+        [PokemonType.Grass]:    2,
+        [PokemonType.Ice]:      4,
+        [PokemonType.Fighting]: 1,
+        [PokemonType.Poison]:   1,
+        [PokemonType.Ground]:   2,
+        [PokemonType.Flying]:   1,
+        [PokemonType.Psychic]:  4,
+        [PokemonType.Bug]:      3,
+        [PokemonType.Rock]:     2,
+        [PokemonType.Ghost]:    4,
+        [PokemonType.Dragon]:   5,
+        [PokemonType.Dark]:     3,
+        [PokemonType.Steel]:    3,
+        [PokemonType.Fairy]:    5,
+    }
+
     public static generateData(): any[] {
-        const possibleTypes = [
-            PokemonType.Normal,
-            PokemonType.Poison,
-            PokemonType.Water,
-            PokemonType.Grass,
-            PokemonType.Flying,
-            PokemonType.Fire,
-            PokemonType.Fighting,
-        ];
-        const type = SeededRand.fromArray(possibleTypes);
+        const type = SeededRand.fromArray(GameHelper.createArray(1, GameHelper.enumLength(PokemonType) - 1, 1));
         const amount = SeededRand.intBetween(200, 600);
         const reward = this.calcReward(type, amount);
         return [amount, reward, type];
     }
 
     private static calcReward(type: PokemonType, amount: number): number {
-        // Needs balancing between different types
-        const reward = amount * GameConstants.DEFEAT_POKEMONS_BASE_REWARD;
+        const reward = amount * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * this.rewardWeight[type];
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -33,7 +33,7 @@ class GainShardsQuest extends Quest implements QuestInterface {
     }
 
     public static generateData(): any[] {
-        const type = SeededRand.fromArray(GameHelper.createArray(0, GameHelper.enumLength(PokemonType) - 2, 1));
+        const type = SeededRand.fromEnum(PokemonType);
         const amount = SeededRand.intBetween(200, 600);
         const reward = this.calcReward(type, amount);
         return [amount, reward, type];


### PR DESCRIPTION
### Defeat Pokemon Quest
We now prioritize accessible routes
### Gain Shards Quest
We now allow for all shard types, and scale the reward based on shard type
### Defeat Gym Quest
We now prioritize accessible Gyms
### Defeat Dungeon Quest
We now prioritize accessible Dungeons
### Harvest Berries Quest
We now select from unlocked Berries (we also always include all Gen 1 Berries)
I've also updated the reward calculation to be more balanced.


## Testing

For testing, you can:
1. Remove all unnecessary quests from `QuestHelper.quests`
2. Set `uniqueQuestTypes` to false in `Quests.generateQuestList`

Then just reroll the quests in-game.