### PR TITLE
Fix checking all regions for current environment

### DIFF
--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -58,9 +58,7 @@ class MapHelper {
         const area = player.route() || player.town()?.name || undefined;
 
         const [env] = Object.entries(GameConstants.Environments).find(
-            ([, regions]) => Object.values(regions).find(
-                region => region.has(area)
-            )
+            ([, regions]) => regions[player.region]?.has(area)
         ) || [];
 
         return (env as GameConstants.Environment);


### PR DESCRIPTION
Just checks the current region environment info, so Kanto 23 doesn't pick up Galar 23, or any other routes that may be affected.