### PR TITLE
Fix oak item challenge

### DIFF
--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -127,7 +127,7 @@ class GameController {
     static addKeyListeners() {
         // Oak Items
         const $oakItemsModal = $('#oakItemsModal');
-        $oakItemsModal.data('allowToggle', true);
+        $oakItemsModal.data('allow-toggle', true);
         $oakItemsModal.on('hidden.bs.modal shown.bs.modal', _ => $oakItemsModal.data('allow-toggle', true));
         const oakItems = App.game.oakItems;
         // Pokeball Selector
@@ -150,7 +150,7 @@ class GameController {
                     // Open oak items with 'O'
                     if (oakItems.canAccess() && $oakItemsModal.data('allow-toggle')) {
                         $('.modal').modal('hide');
-                        $oakItemsModal.data('allow-toggle',false);
+                        $oakItemsModal.data('allow-toggle', false);
                         $oakItemsModal.modal('toggle');
                     }
                     break;

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -127,8 +127,7 @@ class GameController {
     static addKeyListeners() {
         // Oak Items
         const $oakItemsModal = $('#oakItemsModal');
-        $oakItemsModal.data('allow-toggle', true);
-        $oakItemsModal.on('hidden.bs.modal shown.bs.modal', _ => $oakItemsModal.data('allow-toggle', true));
+        $oakItemsModal.on('hidden.bs.modal shown.bs.modal', _ => $oakItemsModal.data('disable-toggle', false));
         const oakItems = App.game.oakItems;
         // Pokeball Selector
         const $pokeballSelector = $('#pokeballSelectorModal');
@@ -148,9 +147,9 @@ class GameController {
             switch (e.code) {
                 case 'KeyO':
                     // Open oak items with 'O'
-                    if (oakItems.canAccess() && $oakItemsModal.data('allow-toggle')) {
+                    if (oakItems.canAccess() && !$oakItemsModal.data('disable-toggle')) {
                         $('.modal').modal('hide');
-                        $oakItemsModal.data('allow-toggle', false);
+                        $oakItemsModal.data('disable-toggle', true);
                         $oakItemsModal.modal('toggle');
                     }
                     break;

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -127,6 +127,8 @@ class GameController {
     static addKeyListeners() {
         // Oak Items
         const $oakItemsModal = $('#oakItemsModal');
+        $oakItemsModal.data('allowToggle', true);
+        $oakItemsModal.on('hidden.bs.modal shown.bs.modal', _ => $oakItemsModal.data('allow-toggle', true));
         const oakItems = App.game.oakItems;
         // Pokeball Selector
         const $pokeballSelector = $('#pokeballSelectorModal');
@@ -146,8 +148,9 @@ class GameController {
             switch (e.code) {
                 case 'KeyO':
                     // Open oak items with 'O'
-                    if (oakItems.canAccess()) {
+                    if (oakItems.canAccess() && $oakItemsModal.data('allow-toggle')) {
                         $('.modal').modal('hide');
+                        $oakItemsModal.data('allow-toggle',false);
                         $oakItemsModal.modal('toggle');
                     }
                     break;

--- a/src/scripts/oakItems/OakItems.ts
+++ b/src/scripts/oakItems/OakItems.ts
@@ -144,6 +144,9 @@ class OakItems implements Feature {
     }
 
     activate(item: OakItems.OakItem) {
+        if (App.game.challenges.list.disableOakItems.active()) {
+            return;
+        }
         if (!this.isUnlocked(item)) {
             return;
         }


### PR DESCRIPTION
While playing with the "No Oak Item" challenge, you could still toggle them using the number keys. This should fix that issue.
Additionally, this should also fix the issue where holding down the `O` key would prevent any further inputs until the page is refreshed.