### PR TITLE
[CODES] Only allow obtaining a shiny from within your maximum region

### DIFF
--- a/src/scripts/codes/RedeemableCodes.ts
+++ b/src/scripts/codes/RedeemableCodes.ts
@@ -24,7 +24,7 @@ class RedeemableCodes implements Saveable {
             }),
             new RedeemableCode('shiny-charmer', -318017456, false, () => {
                 // Select a random Pokemon to give the player as a shiny
-                const pokemon = pokemonMap.random(GameConstants.TotalPokemonsPerRegion[player.highestRegion()]);
+                const pokemon = pokemonMap.randomRegion(player.highestRegion());
                 App.game.party.gainPokemonById(pokemon.id, true, true);
                 // Notify that the code was activated successfully
                 Notifier.notify({


### PR DESCRIPTION
Changed the free shiny code to only being able to obtain a shiny from within your maximum region, you can still obtain a unreleased Pokémon such as the alternate Arceus forms, or Unowns, but don't think it's too much of an issue.