### PR TITLE
Increased roamer chance for specific routes, changes every 6 hours

### DIFF
--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -76,10 +76,12 @@
        <div class="col-6"></div>
        <div class="col-3 no-gutters">
            <div class="list-group" data-bind="foreach: player.town().npcs">
+               <!-- ko if: $data.isVisible() -->
                 <button class="btn btn-info"
                         data-bind="text: $data.name, click: $data.openDialog">
                     NPC
                 </button>
+                <!-- /ko -->
            </div>
         </div>
 

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -79,9 +79,12 @@ class Game {
         this.farming.resetAuras();
         //Safari.load();
         Underground.energyTick(this.underground.getEnergyRegenTime());
-        DailyDeal.generateDeals(this.underground.getDailyDealsMax(), new Date());
-        BerryDeal.generateDeals(new Date());
-        Weather.generateWeather(new Date());
+
+        const now = new Date();
+        DailyDeal.generateDeals(this.underground.getDailyDealsMax(), now);
+        BerryDeal.generateDeals(now);
+        Weather.generateWeather(now);
+        RoamingPokemonList.generateIncreasedChanceRoutes(now);
 
         this.gameState = GameConstants.GameState.fighting;
     }
@@ -166,6 +169,7 @@ class Game {
             // Check if it's a new hour
             if (old.getHours() !== now.getHours()) {
                 Weather.generateWeather(now);
+                RoamingPokemonList.generateIncreasedChanceRoutes(now);
             }
 
             // Save the game

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -208,9 +208,9 @@ class PokemonFactory {
 
     private static roamingChance(maxRoute: number, minRoute: number, curRoute: RegionRoute, region: GameConstants.Region, max = GameConstants.ROAMING_MAX_CHANCE, min = GameConstants.ROAMING_MIN_CHANCE) {
         const routeNum = MapHelper.normalizeRoute(curRoute?.number, region);
-        // Check if we should have increased chances on this route
+        // Check if we should have increased chances on this route (3 x rate)
         const increasedChance = RoamingPokemonList.getIncreasedChanceRouteByRegion(player.region)()?.number == curRoute?.number;
-        const roamingChance = (max + ( (min - max) * (maxRoute - routeNum) / (maxRoute - minRoute))) / (increasedChance ? 2 : 1);
+        const roamingChance = (max + ( (min - max) * (maxRoute - routeNum) / (maxRoute - minRoute))) / (increasedChance ? 3 : 1);
         return Math.random() < 1 / roamingChance;
     }
 

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -173,13 +173,13 @@ class PokemonFactory {
         return possible[Math.floor(Math.random() * possible.length)].pokemon.name;
     }
 
-    private static roamingEncounter(route: number, region: GameConstants.Region): boolean {
+    private static roamingEncounter(routeNum: number, region: GameConstants.Region): boolean {
         // Map to the route numbers
-        const routeNum = MapHelper.normalizeRoute(route, region);
+        const route = Routes.getRoute(region, routeNum);
         const routes = Routes.getRoutesByRegion(region).map(r => MapHelper.normalizeRoute(r.number, region));
 
         // Check if the dice rolls in their favor
-        const encounter = PokemonFactory.roamingChance(GameConstants.ROAMING_MAX_CHANCE, GameConstants.ROAMING_MIN_CHANCE, Math.max(...routes), Math.min(...routes), routeNum);
+        const encounter = PokemonFactory.roamingChance(Math.max(...routes), Math.min(...routes), route, region);
         if (!encounter) {
             return false;
         }
@@ -194,8 +194,12 @@ class PokemonFactory {
         return true;
     }
 
-    private static roamingChance(max, min, maxRoute, minRoute, curRoute) {
-        return Math.random() < 1 / (max + ( (min - max) * (maxRoute - curRoute) / (maxRoute - minRoute)));
+    private static roamingChance(maxRoute: number, minRoute: number, curRoute: RegionRoute, region: GameConstants.Region, max = GameConstants.ROAMING_MAX_CHANCE, min = GameConstants.ROAMING_MIN_CHANCE) {
+        const routeNum = MapHelper.normalizeRoute(curRoute?.number, region);
+        // Check if we should have increased chances on this route
+        const increasedChance = RoamingPokemonList.getIncreasedChanceRouteByRegion(player.region)()?.number == curRoute?.number;
+        const roamingChance = (max + ( (min - max) * (maxRoute - routeNum) / (maxRoute - minRoute))) / (increasedChance ? 2 : 1);
+        return Math.random() < 1 / roamingChance;
     }
 
     private static catchRateHelper(baseCatchRate: number, noVariation = false): number {

--- a/src/scripts/pokemons/RoamingPokemonList.ts
+++ b/src/scripts/pokemons/RoamingPokemonList.ts
@@ -2,6 +2,7 @@
 
 class RoamingPokemonList {
     public static list: Partial<Record<GameConstants.Region, Array<RoamingPokemon>>> = {};
+    public static increasedChanceRoute: Array<KnockoutObservable<RegionRoute>> = new Array(GameHelper.enumLength(GameConstants.Region)).fill(0).map((route, region) => ko.observable(null));
 
     constructor() { }
 
@@ -21,6 +22,25 @@ class RoamingPokemonList {
 
     public static getRegionalRoamers(region: GameConstants.Region): Array<RoamingPokemon> {
         return RoamingPokemonList.list[region] ? RoamingPokemonList.list[region].filter(p => p.isRoaming()) : [];
+    }
+
+    public static getIncreasedChanceRouteByRegion(region: GameConstants.Region): KnockoutObservable<RegionRoute> {
+        return this.increasedChanceRoute[region];
+    }
+
+    // How many hours between when the roaming Pokemon change routes for increased chances
+    private static period = 6;
+
+    public static generateIncreasedChanceRoutes(date = new Date()) {
+        // Seed the random runmber generator
+        SeededRand.seedWithDateHour(date, this.period);
+
+        this.increasedChanceRoute.forEach((route, region) => {
+            const routes = Routes.getRoutesByRegion(region);
+            // Select a route
+            const selectedRoute = SeededRand.fromArray(routes);
+            route(selectedRoute);
+        });
     }
 }
 

--- a/src/scripts/pokemons/RoamingPokemonList.ts
+++ b/src/scripts/pokemons/RoamingPokemonList.ts
@@ -29,7 +29,7 @@ class RoamingPokemonList {
     }
 
     // How many hours between when the roaming Pokemon change routes for increased chances
-    private static period = 6;
+    private static period = 8;
 
     public static generateIncreasedChanceRoutes(date = new Date()) {
         // Seed the random runmber generator

--- a/src/scripts/towns/KantoBerryMasterNPC.ts
+++ b/src/scripts/towns/KantoBerryMasterNPC.ts
@@ -4,10 +4,9 @@ class KantoBerryMasterNPC extends NPC {
 
     constructor(
         public name: string,
-        public dialog: string[],
-        public image?: string
+        public dialog: string[]
     ) {
-        super(name,dialog,image);
+        super(name, dialog);
     }
 
     get dialogHTML(): string {

--- a/src/scripts/towns/NPC.ts
+++ b/src/scripts/towns/NPC.ts
@@ -14,8 +14,8 @@ class NPC {
         return this.dialog.map(line => `<p>${line}</p>`).join('\n');
     }
 
-    get visible() {
-        return this.options.requirement?.isCompleted();
+    public isVisible() {
+        return this.options.requirement?.isCompleted() ?? true;
     }
 
     public openDialog() {

--- a/src/scripts/towns/NPC.ts
+++ b/src/scripts/towns/NPC.ts
@@ -1,19 +1,28 @@
+type NPCOptionalArgument = {
+    requirement?: Requirement | MultiRequirement | OneFromManyRequirement,
+    image?: string,
+};
+
 class NPC {
     constructor(
         public name: string,
         public dialog: string[],
-        public image?: string
+        public options: NPCOptionalArgument = {}
     ) {}
 
     get dialogHTML(): string {
         return this.dialog.map(line => `<p>${line}</p>`).join('\n');
     }
 
+    get visible() {
+        return this.options.requirement?.isCompleted();
+    }
+
     public openDialog() {
         $('#npc-modal .npc-name').text(this.name);
         $('#npc-modal .npc-dialog').html(this.dialogHTML);
-        if (this.image) {
-            $('#npc-modal .npc-image').attr('src', this.image);
+        if (this.options.image) {
+            $('#npc-modal .npc-image').attr('src', this.options.image);
             $('#npc-modal .npc-image').show();
         } else {
             $('#npc-modal .npc-image').hide();

--- a/src/scripts/towns/ProfOakNPC.ts
+++ b/src/scripts/towns/ProfOakNPC.ts
@@ -4,7 +4,7 @@ class ProfOakNPC extends NPC {
         public name: string,
         public dialog: string[]
     ) {
-        super(name, dialog);
+        super(name, dialog, { image: 'assets/images/oak.png' });
     }
 
     get dialogHTML(): string {

--- a/src/scripts/towns/RoamerNPC.ts
+++ b/src/scripts/towns/RoamerNPC.ts
@@ -10,6 +10,13 @@ class RoamerNPC extends NPC {
 
     get dialogHTML(): string {
         const route = RoamingPokemonList.getIncreasedChanceRouteByRegion(this.region);
+        const roamers = RoamingPokemonList.getRegionalRoamers(this.region);
+
+        // If no roaming Pokemon yet
+        if (!roamers.length) {
+            return `There hasn't been any reports of roaming Pokémon around ${GameConstants.camelCaseToString(GameConstants.Region[this.region])} lately..`;
+        }
+
         return super.dialogHTML.replace(/{ROUTE_NAME}/g, route()?.routeName);
     }
 }

--- a/src/scripts/towns/RoamerNPC.ts
+++ b/src/scripts/towns/RoamerNPC.ts
@@ -1,0 +1,15 @@
+class RoamerNPC extends NPC {
+
+    constructor(
+        public name: string,
+        public dialog: string[],
+        public region: GameConstants.Region
+    ) {
+        super(name, dialog);
+    }
+
+    get dialogHTML(): string {
+        const route = RoamingPokemonList.getIncreasedChanceRouteByRegion(this.region);
+        return super.dialogHTML.replace(/{ROUTE_NAME}/g, route()?.routeName);
+    }
+}

--- a/src/scripts/towns/RoamerNPC.ts
+++ b/src/scripts/towns/RoamerNPC.ts
@@ -17,6 +17,8 @@ class RoamerNPC extends NPC {
             return `There hasn't been any reports of roaming Pokémon around ${GameConstants.camelCaseToString(GameConstants.Region[this.region])} lately..`;
         }
 
-        return super.dialogHTML.replace(/{ROUTE_NAME}/g, route()?.routeName);
+        const roamersHTML = roamers.map(r => `<img width="64px" src="assets/images/pokemon/${r.pokemon.id}.png" />`).join('');
+
+        return super.dialogHTML.replace(/{ROUTE_NAME}/g, route()?.routeName) + roamersHTML;
     }
 }

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -5,6 +5,7 @@
 ///<reference path="NPC.ts"/>
 ///<reference path="KantoBerryMasterNPC.ts"/>
 ///<reference path="ProfOakNPC.ts"/>
+///<reference path="RoamerNPC.ts"/>
 
 type TownOptionalArgument = {
     requirements?: (Requirement | OneFromManyRequirement)[],
@@ -158,6 +159,9 @@ const BattleItemRival2 = new NPC('Battle Item Master', [
     'Do I know you? Wait... Have you met my worthless rival? Ha! Let me guess, he gave you some unwanted advice?',
     'I bet he forget to tell you that although all Battle Items only last for 30 seconds they can stack and last for days! Now scram!',
 ]);
+const KantoRoamerNPC = new RoamerNPC('Youngster Wendy', [
+    'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
+], GameConstants.Region.kanto);
 
 
 
@@ -219,6 +223,7 @@ TownList['Fuchsia City'] = new Town(
             new RouteKillRequirement(10, GameConstants.Region.kanto, 15),
         ])],
         shop: FuchsiaCityShop,
+        npcs: [KantoRoamerNPC],
     }
 );
 TownList['Cinnabar Island'] = new Town(

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -371,7 +371,8 @@ const BlackthornCityShop = new Shop([
     ItemList['Dragon_scale'],
 ]);
 
-//Johto Berry Master
+// Johto NPCs
+
 const JohtoBerryMaster = new Shop([
     ItemList['Boost_Mulch'],
     ItemList['Rich_Mulch'],
@@ -380,8 +381,6 @@ const JohtoBerryMaster = new Shop([
     ItemList['Berry_Shovel'],
     ItemList['Squirtbottle'],
 ]);
-
-// Johto NPCs
 
 const CherrygroveMrPokemon = new NPC('Mr Pokémon', [
     'Welcome to Johto! This is where the first ever Pokémon egg was found long ago.',
@@ -398,6 +397,10 @@ const EcruteakKimonoGirl = new NPC('Kimono Girl', [
     'Legends say that Ho-Oh is searching for a trainer of pure heart.',
     'To prove yourself, you must tame the three legendary beasts of Johto, and bring them to the nearby Tin Tower.',
 ]);
+
+const JohtoRoamerNPC = new RoamerNPC('Pokéfan Trevor', [
+    'On the news they are getting more reports of roaming Pokémon appearing on {ROUTE_NAME}!',
+], GameConstants.Region.johto);
 
 
 //Johto Towns
@@ -485,6 +488,7 @@ TownList['Blackthorn City'] = new Town(
     {
         requirements: [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Ice Path'))],
         shop: BlackthornCityShop,
+        npcs: [JohtoRoamerNPC],
     }
 );
 
@@ -651,6 +655,9 @@ const Weatherman = new NPC('Weatherman', [
     'It changes forms when the weather is drastically different.',
     'If you want to collect them all, wait for the weather to change.',
 ]);
+const HoennRoamerNPC = new RoamerNPC('Youngster Alex', [
+    'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
+], GameConstants.Region.hoenn);
 
 //Hoenn Towns
 TownList['Littleroot Town'] = new Town(
@@ -700,6 +707,7 @@ TownList['Slateport City'] = new Town(
             new GymBadgeRequirement(BadgeEnums.Knuckle),
         ],
         shop: SlateportCityShop,
+        npcs: [HoennRoamerNPC],
     }
 );
 TownList['Mauville City'] = new Town(
@@ -993,6 +1001,9 @@ const HearthomeContestFan = new NPC('Contest Fan', [
     'Their prized Magneton had evolved into a Magnezone!',
     'I\'m so happy for them, all of that training in Mt. Coronet must have paid off!',
 ]);
+const SinnohRoamerNPC = new RoamerNPC('Youngster James', [
+    'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
+], GameConstants.Region.sinnoh);
 
 //Sinnoh Towns
 TownList['Twinleaf Town'] = new Town(
@@ -1093,6 +1104,7 @@ TownList['Pal Park'] = new Town(
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 221)],
         shop: PalParkShop,
+        npcs: [SinnohRoamerNPC],
     }
 );
 TownList['Canalave City'] = new Town(
@@ -1368,6 +1380,9 @@ const ExcitedChild = new NPC('Professor Birch\'s Aide', [
     'Then my programme got interrupted by an emergency broadcast. A report on the first confirmed sightings of Tornadus and Thundurus in over twenty-five years! I\'ve read so much about them, they are my favorites.',
     'Last time they were spotted they just roamed around, causing all kinds of mischief. According to my books anyway. I\'m sure that amazing trainer from the TV will want to catch these mighty forces of nature.',
 ]);
+const UnovaRoamerNPC = new RoamerNPC('Youngster Sarah', [
+    'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
+], GameConstants.Region.unova);
 
 //Unova Towns
 TownList['Aspertia City'] = new Town(
@@ -1478,6 +1493,7 @@ TownList['Pokemon League Unova'] = new Town(
     GameConstants.Region.unova,
     {
         requirements: [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Victory Road Unova'))],
+        npcs: [UnovaRoamerNPC],
     }
 );
 TownList['Icirrus City'] = new Town(

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -655,8 +655,8 @@ const Weatherman = new NPC('Weatherman', [
     'It changes forms when the weather is drastically different.',
     'If you want to collect them all, wait for the weather to change.',
 ]);
-const HoennRoamerNPC = new RoamerNPC('Youngster Alex', [
-    'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
+const HoennRoamerNPC = new RoamerNPC('Reporter Gabby', [
+    'Our sources indicate that roaming Pokémon are gathering on {ROUTE_NAME}!',
 ], GameConstants.Region.hoenn);
 
 //Hoenn Towns
@@ -1001,8 +1001,8 @@ const HearthomeContestFan = new NPC('Contest Fan', [
     'Their prized Magneton had evolved into a Magnezone!',
     'I\'m so happy for them, all of that training in Mt. Coronet must have paid off!',
 ]);
-const SinnohRoamerNPC = new RoamerNPC('Youngster James', [
-    'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
+const SinnohRoamerNPC = new RoamerNPC('Hiker Kevin', [
+    'I spotted a bunvh of roaming Pokémon on {ROUTE_NAME}!',
 ], GameConstants.Region.sinnoh);
 
 //Sinnoh Towns
@@ -1104,7 +1104,6 @@ TownList['Pal Park'] = new Town(
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 221)],
         shop: PalParkShop,
-        npcs: [SinnohRoamerNPC],
     }
 );
 TownList['Canalave City'] = new Town(
@@ -1151,6 +1150,7 @@ TownList['Survival Area'] = new Town(
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 225)],
         shop: SurvivalAreaShop,
+        npcs: [SinnohRoamerNPC],
     }
 );
 TownList['Resort Area'] = new Town(
@@ -1374,14 +1374,14 @@ const AnvilleTownShop = new Shop([
 ]);
 
 //Unova NPCs
-const ExcitedChild = new NPC('Professor Birch\'s Aide', [
+const ExcitedChild = new NPC('Excited Child', [
     'Did you hear? Did you see? It was on TV!',
     'I was just watching my favorite show, The National Gymquirer. It was a live segment! Some hot shot trainer from Kanto defeated Drayden! It was amazing! That trainer is so cool! Drayden is like unbeatable.',
     'Then my programme got interrupted by an emergency broadcast. A report on the first confirmed sightings of Tornadus and Thundurus in over twenty-five years! I\'ve read so much about them, they are my favorites.',
     'Last time they were spotted they just roamed around, causing all kinds of mischief. According to my books anyway. I\'m sure that amazing trainer from the TV will want to catch these mighty forces of nature.',
 ]);
 const UnovaRoamerNPC = new RoamerNPC('Youngster Sarah', [
-    'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
+    'My friends told me roaming Pokémon have been spotted on {ROUTE_NAME}!',
 ], GameConstants.Region.unova);
 
 //Unova Towns
@@ -1493,7 +1493,6 @@ TownList['Pokemon League Unova'] = new Town(
     GameConstants.Region.unova,
     {
         requirements: [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Victory Road Unova'))],
-        npcs: [UnovaRoamerNPC],
     }
 );
 TownList['Icirrus City'] = new Town(
@@ -1505,6 +1504,7 @@ TownList['Icirrus City'] = new Town(
             new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Twist Mountain')),
         ])],
         shop: IcirrusCityShop,
+        npcs: [UnovaRoamerNPC],
     }
 );
 TownList['Black and White Park'] = new Town(

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -1002,7 +1002,7 @@ const HearthomeContestFan = new NPC('Contest Fan', [
     'I\'m so happy for them, all of that training in Mt. Coronet must have paid off!',
 ]);
 const SinnohRoamerNPC = new RoamerNPC('Hiker Kevin', [
-    'I spotted a bunvh of roaming Pokémon on {ROUTE_NAME}!',
+    'I spotted a bunch of roaming Pokémon on {ROUTE_NAME}!',
 ], GameConstants.Region.sinnoh);
 
 //Sinnoh Towns


### PR DESCRIPTION
Increased chances of encountering a Roaming Pokémon on specific routes that changes every 8 hours _(triple chance)_.

Added an NPC to each region letting you know the route for that region.
![image](https://user-images.githubusercontent.com/7288322/108621677-fb9aa880-7498-11eb-8f9f-c3fcb0de3878.png)

~~The NPCs could probably use a little refining, not sure of names, towns, or dialog,
But the base is there.~~
Updated thanks to @Ultima1990 

Also modified the NPC class to accept requirements, for if we want to hide/show an NPC later on.
Added image for Prof Oak NPC.