### PR TITLE
Fix battle frontier images

### DIFF
--- a/src/scripts/battleFrontier/BattleFrontierMilestonePokemon.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestonePokemon.ts
@@ -1,7 +1,7 @@
 class BattleFrontierMilestonePokemon extends BattleFrontierMilestone {
     pokemonName: string;
 
-    constructor (stage: number, pokemonName: string, image: string) {
+    constructor (stage: number, pokemonName: string, image = 'assets/images/items/pokeball/Premierball.png') {
         super(stage, () => {
             App.game.party.gainPokemonById(pokemonMap[pokemonName].id);
         }, image);

--- a/src/scripts/battleFrontier/BattleFrontierMilestones.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestones.ts
@@ -62,13 +62,13 @@ BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(30, 'Ultra
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(35, 'xClick', 100));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(40, 'xAttack', 100));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(50, 'SmallRestore', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(100, 'Deoxys', 'assets/images/items/Premierball.png'));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(100, 'Deoxys'));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(110, 'Water_stone', 10));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(120, 'Leaf_stone', 10));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(130, 'Thunder_stone', 10));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(140, 'Fire_stone', 10));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(150, 'MediumRestore', 200));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(151, 'Deoxys (attack)', 'assets/images/items/Premierball.png'));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(151, 'Deoxys (attack)'));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(160, 'Lucky_egg', 100));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(170, 'Lucky_incense', 100));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(180, 'Item_magnet', 100));
@@ -79,6 +79,6 @@ BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(220, 'Leaf
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(230, 'Thunder_stone', 40));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(240, 'Moon_stone', 40));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(250, 'Ultraball', 6400));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(251, 'Deoxys (defense)', 'assets/images/items/Premierball.png'));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(251, 'Deoxys (defense)'));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(300, 'Trade_stone', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(386, 'Deoxys (speed)', 'assets/images/items/Premierball.png'));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(386, 'Deoxys (speed)'));


### PR DESCRIPTION
closes #1307 

Fixes the Battle frontier images for Pokémon rewards.
Defaults to the premier ball unless specified.