### PR TITLE
[BUG FIX] Added home: true to gen 5+ starting towns

### DIFF
--- a/src/components/AlolaSVG.html
+++ b/src/components/AlolaSVG.html
@@ -223,6 +223,7 @@
         { name: "Iki Town"
         , x: 36, y: 0
         , width: 4, height: 4
+        , home: true
         })
     %>
 

--- a/src/components/GalarSVG.html
+++ b/src/components/GalarSVG.html
@@ -59,7 +59,7 @@
         , noText: true
         })
     %>
-    
+
     <!--West Lake Axwell-->
     <%- include('templates/mapRoute',
         { route: 5, region: 7
@@ -343,6 +343,7 @@
         { name: "Postwick"
         , x: 40, y: 54.5
         , width: 5, height: 4.5
+        , home: true
         })
     %>
 

--- a/src/components/KalosSVG.html
+++ b/src/components/KalosSVG.html
@@ -238,7 +238,7 @@
         , x: 65, y: 17
         , noText: true
         })
-    %>    
+    %>
 
     <!--Route 16-->
     <%- include('templates/mapRoute',
@@ -389,6 +389,7 @@
         { name: "Vaniville Town"
         , x: 52, y: 51.5
         , width: 5, height: 4.5
+        , home: true
         })
     %>
 
@@ -578,7 +579,7 @@
         , width: 4, height: 3
         })
     %>
-    
+
     <%- include('templates/mapDungeon',
         { name: "Kalos Power Plant"
         , x: 37, y: 20

--- a/src/components/UnovaSVG.html
+++ b/src/components/UnovaSVG.html
@@ -503,6 +503,7 @@
         { name: "Aspertia City"
         , x: 6, y: 51.5
         , width: 5, height: 4.5
+        , home: true
         })
     %>
 


### PR DESCRIPTION
Unova: Aspertia
Kalos: Vaniville
Alola: Iki
Galar: Postwick
Apparently my editor removed some whitespace, but that shouldn't be a problem.

Fixes #1345 

I tested this and Aspertia immediately started flashing once I got the final Unova Pokémon.