### PR TITLE
Fix purchasing multiple shop Pokémon not rolling shiny chance multiple times

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -47,9 +47,9 @@ export const ROAMING_MAX_CHANCE = 4096;
 // Shinies
 export const SHINY_CHANCE_BATTLE = 8192;
 export const SHINY_CHANCE_DUNGEON = 4096;
-export const SHINY_CHANCE_SHOP = 2048;
 export const SHINY_CHANCE_STONE = 2048;
 export const SHINY_CHANCE_SAFARI = 2048;
+export const SHINY_CHANCE_SHOP = 1024;
 export const SHINY_CHANCE_BREEDING = 1024;
 export const SHINY_CHANCE_FARM = 1024;
 

--- a/src/scripts/items/PokemonItem.ts
+++ b/src/scripts/items/PokemonItem.ts
@@ -9,8 +9,11 @@ class PokemonItem extends CaughtIndicatingItem {
         this.type = pokemon;
     }
 
-    gain() {
-        const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_SHOP);
+    gain(amt: number) {
+        let shiny = false;
+        for (let i = 0; i < amt; i++) {
+            shiny = shiny || PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_SHOP);
+        }
         const pokemonName = this.name as PokemonNameType;
         if (shiny) {
             Notifier.notify({


### PR DESCRIPTION
When buying multiple shop Pokémon the shiny chance will be rolled for as many Pokémon as you purchased.

Also increased shiny rate for shop Pokémon from `2048` → `1024`.