### PR TITLE
Added Capture Pokémon type, Gain Farm Points quests

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -187,7 +187,7 @@ const questBase = 1; // change this to scale all quest points
 
 // Currency → QP reward amounts
 export const GAIN_MONEY_BASE_REWARD = questBase * 0.0017;
-export const GAIN_TOKENS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 45;
+export const GAIN_TOKENS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 35;
 export const GAIN_FARM_POINTS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 90;
 
 export const HATCH_EGGS_BASE_REWARD = questBase * 33;

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -184,7 +184,12 @@ export const SAFARI_OUT_OF_BALLS = 'Game Over!<br>You have run out of safari bal
 // Numbers calculated by Dimava assumes ability to 1 shot on high routes and some use oak items,
 //   which are now nerfed slightly until upgraded, so those numbers may need further adjusting
 const questBase = 1; // change this to scale all quest points
+
+// Currency → QP reward amounts
 export const GAIN_MONEY_BASE_REWARD = questBase * 0.0017;
+export const GAIN_TOKENS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 45;
+export const GAIN_FARM_POINTS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 90;
+
 export const HATCH_EGGS_BASE_REWARD = questBase * 33;
 export const SHINY_BASE_REWARD = questBase * 3000;
 
@@ -192,9 +197,6 @@ export const DEFEAT_POKEMONS_BASE_REWARD = questBase * 1;
 
 // Defeat reward divided by chance to catch (guessed)
 export const CAPTURE_POKEMONS_BASE_REWARD = DEFEAT_POKEMONS_BASE_REWARD / 0.8;
-
-// <route number> tokens gained for every capture
-export const GAIN_TOKENS_BASE_REWARD = CAPTURE_POKEMONS_BASE_REWARD / 13;
 
 // Average of 1/4 squares revealed = 75 energy ~ 12 minutes ~ 720 pokemons
 export const MINE_LAYERS_BASE_REWARD = questBase * 720;

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -190,7 +190,7 @@ const questBase = 1; // change this to scale all quest points
 
 // Currency → QP reward amounts
 export const GAIN_MONEY_BASE_REWARD = questBase * 0.0017;
-export const GAIN_TOKENS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 35;
+export const GAIN_TOKENS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 55;
 export const GAIN_FARM_POINTS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 90;
 
 export const HATCH_EGGS_BASE_REWARD = questBase * 33;

--- a/src/modules/utilities/SeededRand.ts
+++ b/src/modules/utilities/SeededRand.ts
@@ -52,6 +52,7 @@ export default class SeededRand {
         return arr.find((_e, i) => (rand -= weights[i]) <= 0) || arr[0];
     }
 
+    // Filters out any enum values that are less than 0 (for None)
     public static fromEnum(_enum): number {
         const arr = Object.keys(_enum).map(Number).filter((item) => item >= 0);
         return this.fromArray(arr);

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -115,6 +115,7 @@ namespace GameConstants {
     declare const DEFEAT_POKEMONS_BASE_REWARD: number;
     declare const CAPTURE_POKEMONS_BASE_REWARD: number;
     declare const GAIN_TOKENS_BASE_REWARD: number;
+    declare const GAIN_FARM_POINTS_BASE_REWARD: number;
     declare const MINE_LAYERS_BASE_REWARD: number;
     declare const MINE_ITEMS_BASE_REWARD: number;
     declare const USE_OAK_ITEM_BASE_REWARD: number;

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -172,7 +172,7 @@ abstract class Quest {
         return {
             index: this.index || 0,
             customDescription: this.customDescription,
-            data: <any[]>[this.amount ,this.pointsReward],
+            data: <any[]>[this.amount, this.pointsReward],
             initial: this.initial(),
             claimed: this.claimed(),
             notified: this.notified,

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -1,6 +1,7 @@
 /// <reference path="./questTypes/DefeatPokemonsQuest.ts" />
 /// <reference path="./questTypes/CapturePokemonsQuest.ts" />
 /// <reference path="./questTypes/CapturePokemonTypesQuest.ts" />
+/// <reference path="./questTypes/GainFarmPointsQuest.ts" />
 /// <reference path="./questTypes/GainMoneyQuest.ts" />
 /// <reference path="./questTypes/GainTokensQuest.ts" />
 /// <reference path="./questTypes/GainShardsQuest.ts" />
@@ -20,6 +21,7 @@ class QuestHelper {
         DefeatPokemonsQuest,
         CapturePokemonsQuest,
         CapturePokemonTypesQuest,
+        GainFarmPointsQuest,
         GainMoneyQuest,
         GainTokensQuest,
         GainShardsQuest,

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -1,5 +1,6 @@
 /// <reference path="./questTypes/DefeatPokemonsQuest.ts" />
 /// <reference path="./questTypes/CapturePokemonsQuest.ts" />
+/// <reference path="./questTypes/CapturePokemonTypesQuest.ts" />
 /// <reference path="./questTypes/GainMoneyQuest.ts" />
 /// <reference path="./questTypes/GainTokensQuest.ts" />
 /// <reference path="./questTypes/GainShardsQuest.ts" />
@@ -18,6 +19,7 @@ class QuestHelper {
     public static quests = {
         DefeatPokemonsQuest,
         CapturePokemonsQuest,
+        CapturePokemonTypesQuest,
         GainMoneyQuest,
         GainTokensQuest,
         GainShardsQuest,

--- a/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
+++ b/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
@@ -1,0 +1,32 @@
+/// <reference path="../Quest.ts" />
+
+class CapturePokemonTypesQuest extends Quest implements QuestInterface {
+
+    constructor(capturesNeeded: number, reward: number, public type: PokemonType) {
+        super(capturesNeeded, reward);
+        this.focus = ko.pureComputed(() => pokemonMap.filter(p => p.type.includes(this.type)).map(p => App.game.statistics.pokemonCaptured[p.id]()).reduce((a,b) => a + b, 0));
+    }
+
+    public static generateData(): any[] {
+        const amount = SeededRand.intBetween(100, 500);
+        const reward = this.calcReward(amount);
+        const type = SeededRand.fromEnum(PokemonType);
+        return [amount, reward, type];
+    }
+
+    private static calcReward(amount: number): number {
+        const reward = amount * GameConstants.CAPTURE_POKEMONS_BASE_REWARD * 1.2;
+        return super.randomizeReward(reward);
+    }
+
+    get description(): string {
+        return `Capture ${this.amount.toLocaleString('en-US')} ${PokemonType[this.type]} type Pokémon.`;
+    }
+
+    toJSON() {
+        const json = super.toJSON();
+        json['name'] = this.constructor.name;
+        json['data'].push(this.type);
+        return json;
+    }
+}

--- a/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
@@ -36,7 +36,7 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
         const completeDungeonsReward = attacksToCompleteDungeon * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * GameConstants.ACTIVE_QUEST_MULTIPLIER * amount;
 
         let region: GameConstants.Region, route: number;
-        for (region = player.highestRegion; region >= 0; region--) {
+        for (region = player.highestRegion(); region >= 0; region--) {
             route = QuestHelper.highestOneShotRoute(region); // returns 0 if no routes in this region can be one shot
             if (route) {
                 break;

--- a/src/scripts/quests/questTypes/GainFarmPointsQuest.ts
+++ b/src/scripts/quests/questTypes/GainFarmPointsQuest.ts
@@ -1,0 +1,30 @@
+/// <reference path="../Quest.ts" />
+
+class GainFarmPointsQuest extends Quest implements QuestInterface {
+
+    constructor(amount: number, reward: number) {
+        super(amount, reward);
+        this.focus = App.game.statistics.totalFarmPoints;
+    }
+
+    public static generateData(): any[] {
+        const amount = SeededRand.intBetween(500, 5000);
+        const reward = this.calcReward(amount);
+        return [amount, reward];
+    }
+
+    private static calcReward(amount: number): number {
+        const reward = Math.ceil(amount * GameConstants.GAIN_FARM_POINTS_BASE_REWARD);
+        return super.randomizeReward(reward);
+    }
+
+    get description(): string {
+        return `Gain ${this.amount.toLocaleString('en-US')} Farm Points.`;
+    }
+
+    toJSON() {
+        const json = super.toJSON();
+        json['name'] = this.constructor.name;
+        return json;
+    }
+}

--- a/src/scripts/quests/questTypes/GainTokensQuest.ts
+++ b/src/scripts/quests/questTypes/GainTokensQuest.ts
@@ -8,14 +8,13 @@ class GainTokensQuest extends Quest implements QuestInterface {
     }
 
     public static generateData(): any[] {
-        const multiplier = Math.pow(player.highestRegion() + 1, 3);
-        const amount = SeededRand.intBetween(1000 * multiplier, 8000 * multiplier);
+        const amount = SeededRand.intBetween(1000, 8000);
         const reward = this.calcReward(amount);
         return [amount, reward];
     }
 
     private static calcReward(amount: number): number {
-        const reward =  Math.ceil((amount * GameConstants.GAIN_TOKENS_BASE_REWARD) / Math.pow(player.highestRegion() + 1, 2.6));
+        const reward =  Math.ceil(amount * GameConstants.GAIN_TOKENS_BASE_REWARD);
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/GainTokensQuest.ts
+++ b/src/scripts/quests/questTypes/GainTokensQuest.ts
@@ -8,14 +8,14 @@ class GainTokensQuest extends Quest implements QuestInterface {
     }
 
     public static generateData(): any[] {
-        const multiplier = Math.pow(player.highestRegion() + 1, 2);
+        const multiplier = Math.pow(player.highestRegion() + 1, 3);
         const amount = SeededRand.intBetween(1000 * multiplier, 8000 * multiplier);
         const reward = this.calcReward(amount);
         return [amount, reward];
     }
 
     private static calcReward(amount: number): number {
-        const reward =  Math.ceil(amount * GameConstants.GAIN_TOKENS_BASE_REWARD * Math.pow(Math.max(1, player.highestRegion()), -1.2));
+        const reward =  Math.ceil((amount * GameConstants.GAIN_TOKENS_BASE_REWARD) / Math.pow(player.highestRegion() + 1, 2.6));
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/GainTokensQuest.ts
+++ b/src/scripts/quests/questTypes/GainTokensQuest.ts
@@ -8,13 +8,14 @@ class GainTokensQuest extends Quest implements QuestInterface {
     }
 
     public static generateData(): any[] {
-        const amount = SeededRand.intBetween(1000, 8000);
+        const multiplier = Math.pow(player.highestRegion() + 1, 2);
+        const amount = SeededRand.intBetween(1000 * multiplier, 8000 * multiplier);
         const reward = this.calcReward(amount);
         return [amount, reward];
     }
 
     private static calcReward(amount: number): number {
-        const reward =  Math.ceil(amount * GameConstants.GAIN_TOKENS_BASE_REWARD);
+        const reward =  Math.ceil(amount * GameConstants.GAIN_TOKENS_BASE_REWARD * Math.pow(Math.max(1, player.highestRegion()), -0.7));
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/GainTokensQuest.ts
+++ b/src/scripts/quests/questTypes/GainTokensQuest.ts
@@ -15,7 +15,7 @@ class GainTokensQuest extends Quest implements QuestInterface {
     }
 
     private static calcReward(amount: number): number {
-        const reward =  Math.ceil(amount * GameConstants.GAIN_TOKENS_BASE_REWARD * Math.pow(Math.max(1, player.highestRegion()), -0.7));
+        const reward =  Math.ceil(amount * GameConstants.GAIN_TOKENS_BASE_REWARD * Math.pow(Math.max(1, player.highestRegion()), -1.2));
         return super.randomizeReward(reward);
     }
 


### PR DESCRIPTION
Capture Type quests gives 1.2 x the normal capture quest
Gain Farm Tokens quest gives about 10% of Farm Tokens as Quest Points
Fixed up the Defeat Dungeon Quest not using `player.highestRegion()`
Changed DT quest to allow for more required, lower rewards (based on highest region).
_Might need some balancing_