### PR TITLE
[FIX] Show item count for non-UG items

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -174,7 +174,7 @@
                                     </td>
                                     <td class='vertical-middle' data-bind='text: amount1 + " × " + item1.name'></td>
                                     <td class='vertical-middle'>→</td>
-                                    <td class='vertical-middle text-center' data-bind='text: player._itemList[Underground.getMineItemById(item2.id).valueType]?.() ?? player.getUndergroundItemAmount(item2.id)'></td>
+                                    <td class='vertical-middle text-center' data-bind='text: player.getUndergroundItemAmount(item2.id)'></td>
                                     <td class='vertical-middle'>
                                         <img class='mineInventoryItem' data-bind='attr: {src: item2.image }'>
                                     </td>

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -174,7 +174,7 @@
                                     </td>
                                     <td class='vertical-middle' data-bind='text: amount1 + " × " + item1.name'></td>
                                     <td class='vertical-middle'>→</td>
-                                    <td class='vertical-middle text-center' data-bind='text: player.getUndergroundItemAmount(item2.id)'></td>
+                                    <td class='vertical-middle text-center' data-bind='text: player._itemList[Underground.getMineItemById(item2.id).valueType]?.() ?? player.getUndergroundItemAmount(item2.id)'></td>
                                     <td class='vertical-middle'>
                                         <img class='mineInventoryItem' data-bind='attr: {src: item2.image }'>
                                     </td>

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -194,7 +194,12 @@ class Player {
 
     // TODO(@Isha) move to underground classes.
     public getUndergroundItemAmount(id: number) {
-        return player.mineInventory().find(i => i.id == id)?.amount() || 0;
+        const mineItem = player.mineInventory().find(i => i.id == id);
+        if (mineItem) {
+            return mineItem.amount();
+        }
+        const itemAmount = player.itemList[Underground.getMineItemById(id)?.valueType];
+        return itemAmount?.() || 0;
     }
 
     public toJSON() {


### PR DESCRIPTION
Tested with today's water stone trade:
![image](https://user-images.githubusercontent.com/21047644/127742470-0880db15-a2fa-4074-8e1e-9dbedc346dde.png)
Feel free to tell me if you'd rather want to modify `player.getUndergroundItemAmount()` or add a new function.