### PR TITLE
Fix player being able to start a dungeon within a town by pressing spacebar

### DIFF
--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -197,7 +197,11 @@ class GameController {
                     if (player.town().gym) {
                         GymRunner.startGym(player.town().gym);
                     } else if (player.town().dungeon) {
-                        DungeonRunner.initializeDungeon(player.town().dungeon);
+                        if (player.town() instanceof DungeonTown) {
+                            DungeonRunner.initializeDungeon(player.town().dungeon);
+                        } else {
+                            MapHelper.moveToTown(player.town().dungeon.name);
+                        }
                     }
                     e.preventDefault();
                 } else if ('gymList' in player.town()) {


### PR DESCRIPTION
Players are able to enter dungeons without having access to the Dungeon yet if they are located within a town by pressing `spacebar` (although they aren't able to complete the dungeon).

This PR should fix that, it attempts to move the player to the dungeon town rather than just starting the dungeon.