### PR TITLE
Update League Item shop to exclude Rare Candy

### DIFF
--- a/src/scripts/towns/PokemonLeague.ts
+++ b/src/scripts/towns/PokemonLeague.ts
@@ -26,7 +26,7 @@ const indigoPlateauShop = new Shop([
     new PokeballItem(GameConstants.Pokeball.Masterball, 3000    , GameConstants.Currency.questPoint  , { multiplier: 1.35, multiplierDecrease: false, saveName: `${GameConstants.Pokeball[GameConstants.Pokeball.Masterball]}|${GameConstants.Currency[GameConstants.Currency.questPoint]}` }),
     new PokeballItem(GameConstants.Pokeball.Masterball, 3000    , GameConstants.Currency.farmPoint   , { multiplier: 1.35, multiplierDecrease: false, saveName: `${GameConstants.Pokeball[GameConstants.Pokeball.Masterball]}|${GameConstants.Currency[GameConstants.Currency.farmPoint]}` }),
     new PokeballItem(GameConstants.Pokeball.Masterball, 50      , GameConstants.Currency.diamond     , { multiplier: 1.35, multiplierDecrease: false, saveName: `${GameConstants.Pokeball[GameConstants.Pokeball.Masterball]}|${GameConstants.Currency[GameConstants.Currency.diamond]}` }),
-//    ItemList['RareCandy'],    // No current use, commented out until implemented
+    //ItemList['RareCandy'],
     ItemList['Protein'],
 ]);
 

--- a/src/scripts/towns/PokemonLeague.ts
+++ b/src/scripts/towns/PokemonLeague.ts
@@ -26,7 +26,7 @@ const indigoPlateauShop = new Shop([
     new PokeballItem(GameConstants.Pokeball.Masterball, 3000    , GameConstants.Currency.questPoint  , { multiplier: 1.35, multiplierDecrease: false, saveName: `${GameConstants.Pokeball[GameConstants.Pokeball.Masterball]}|${GameConstants.Currency[GameConstants.Currency.questPoint]}` }),
     new PokeballItem(GameConstants.Pokeball.Masterball, 3000    , GameConstants.Currency.farmPoint   , { multiplier: 1.35, multiplierDecrease: false, saveName: `${GameConstants.Pokeball[GameConstants.Pokeball.Masterball]}|${GameConstants.Currency[GameConstants.Currency.farmPoint]}` }),
     new PokeballItem(GameConstants.Pokeball.Masterball, 50      , GameConstants.Currency.diamond     , { multiplier: 1.35, multiplierDecrease: false, saveName: `${GameConstants.Pokeball[GameConstants.Pokeball.Masterball]}|${GameConstants.Currency[GameConstants.Currency.diamond]}` }),
-    ItemList['RareCandy'],
+//    ItemList['RareCandy'],    // No current use, commented out until implemented
     ItemList['Protein'],
 ]);
 


### PR DESCRIPTION
Closes #1468
Commented out Rare Candy item until such time as Rare Candies are implemented in game.