### PR TITLE
[FIX] Achievement percentage and achievement tracker

### DIFF
--- a/src/scripts/achievements/Achievement.ts
+++ b/src/scripts/achievements/Achievement.ts
@@ -38,7 +38,7 @@ class Achievement {
     }
 
     public isCompleted: KnockoutComputed<boolean> = ko.pureComputed(() => {
-        return this.unlocked || this.property.isCompleted();
+        return this.achievable() && (this.unlocked || this.property.isCompleted());
     })
 
     public getBonus() {

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -103,7 +103,7 @@ class AchievementHandler {
     }
 
     public static findByName(name: string): Achievement {
-        return AchievementHandler.achievementList.find((achievement) => achievement.name === name);
+        return AchievementHandler.achievementList.find((achievement) => achievement.name === name && achievement.achievable());
     }
 
     public static initialize(multiplier: Multiplier, challenges: Challenges) {


### PR DESCRIPTION
Fixes #1480 

This PR should also fix the 11 oak item achievement counting towards the achievement percentage.
Before:
![image](https://user-images.githubusercontent.com/21047644/128364146-42d85d9e-8084-40cc-8bd7-56eacabf818c.png)

After:
![image](https://user-images.githubusercontent.com/21047644/128363964-2f40999c-1893-45eb-afe7-0274074e4572.png)
