### PR TITLE
Decrease Shop Price Multiplier

### DIFF
--- a/src/scripts/battleFrontier/BattleFrontierBattle.ts
+++ b/src/scripts/battleFrontier/BattleFrontierBattle.ts
@@ -56,6 +56,7 @@ class BattleFrontierBattle extends Battle {
         } else {
             this.enemyPokemon(null);
         }
+        player.lowerItemMultipliers(MultiplierDecreaser.Battle);
     }
 
     public static generateNewEnemy() {

--- a/src/scripts/battleFrontier/BattleFrontierBattle.ts
+++ b/src/scripts/battleFrontier/BattleFrontierBattle.ts
@@ -56,7 +56,6 @@ class BattleFrontierBattle extends Battle {
         } else {
             this.enemyPokemon(null);
         }
-        player.lowerItemMultipliers(MultiplierDecreaser.Battle);
     }
 
     public static generateNewEnemy() {

--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -88,7 +88,7 @@ class BattleFrontierRunner {
                     title: 'Battle Frontier',
                     message: `You made it to stage ${this.stage()}`,
                     type: NotificationConstants.NotificationOption.info,
-                    timeout: 5 * GameConstants.MINUTE,
+                    timeout: 1 * GameConstants.MINUTE,
                 });
 
                 this.end();

--- a/src/scripts/dungeons/DungeonBattle.ts
+++ b/src/scripts/dungeons/DungeonBattle.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../declarations/GameHelper.d.ts" />
+/// <reference path="../Battle.ts" />
 
 class DungeonBattle extends Battle {
 
@@ -25,7 +26,7 @@ class DungeonBattle extends Battle {
     public static defeatPokemon() {
         const enemyPokemon: BattlePokemon = this.enemyPokemon();
 
-        // Handle Rrainer Pokemon defeat
+        // Handle Trainer Pokemon defeat
         if (this.trainer()) {
             this.defeatTrainerPokemon();
             return;
@@ -38,6 +39,7 @@ class DungeonBattle extends Battle {
         }
         enemyPokemon.defeat();
         App.game.breeding.progressEggsBattle(DungeonRunner.dungeon.difficultyRoute, player.region);
+        player.lowerItemMultipliers(MultiplierDecreaser.Battle);
 
         // Clearing Dungeon tile
         DungeonRunner.map.currentTile().type(GameConstants.DungeonTile.empty);
@@ -70,6 +72,7 @@ class DungeonBattle extends Battle {
 
         GameHelper.incrementObservable(this.trainerPokemonIndex);
         App.game.breeding.progressEggsBattle(DungeonRunner.dungeon.difficultyRoute, player.region);
+        player.lowerItemMultipliers(MultiplierDecreaser.Battle);
 
         // No Pokemon left, trainer defeated
         if (this.trainerPokemonIndex() >= this.trainer().team.length) {

--- a/src/scripts/gym/GymBattle.ts
+++ b/src/scripts/gym/GymBattle.ts
@@ -19,6 +19,7 @@ class GymBattle extends Battle {
         } else {
             this.generateNewEnemy();
         }
+        player.lowerItemMultipliers(MultiplierDecreaser.Battle);
     }
 
     /**


### PR DESCRIPTION
Fixes the lack of a Multiplier Decrease in Gyms, Dungeons, and Battle Frontier. Also decreased the timer on the Battle Frontier notification box because 5 minutes is way too long. Fixes #1466 

Note: The Battle Frontier multiplier decrease might be a little too quick for repeat battles as it is with every Pokémon defeated