### PR TITLE
Don't weigh multiform Pokémon more than normal mons in pokemonMap random functions

### DIFF
--- a/src/modules/utilities/Rand.ts
+++ b/src/modules/utilities/Rand.ts
@@ -1,0 +1,30 @@
+export default class Rand {
+    public static next(): number {
+        return Math.random();
+    }
+
+    // get a number between min and max (both inclusive)
+    public static intBetween(min: number, max: number): number {
+        return Math.floor((max - min + 1) * Rand.next() + min);
+    }
+
+    public static boolean(): boolean {
+        return !!this.intBetween(0, 1);
+    }
+
+    public static fromArray<T>(arr: Array<T>): T {
+        return arr[Rand.intBetween(0, arr.length - 1)];
+    }
+
+    public static fromWeightedArray<T>(arr: Array<T>, weights: Array<number>): T {
+        const max = weights.reduce((acc, weight) => acc + weight, 0);
+        let rand = this.intBetween(1, max);
+        return arr.find((_e, i) => (rand -= weights[i]) <= 0) || arr[0];
+    }
+
+    // Filters out any enum values that are less than 0 (for None)
+    public static fromEnum(_enum): number {
+        const arr = Object.keys(_enum).map(Number).filter((item) => item >= 0);
+        return this.fromArray(arr);
+    }
+}

--- a/src/scripts/codes/RedeemableCodes.ts
+++ b/src/scripts/codes/RedeemableCodes.ts
@@ -25,7 +25,8 @@ class RedeemableCodes implements Saveable {
             new RedeemableCode('shiny-charmer', -318017456, false, () => {
                 // Select a random Pokemon to give the player as a shiny
                 const pokemon = pokemonMap.randomRegion(player.highestRegion());
-                App.game.party.gainPokemonById(pokemon.id, true, true);
+                // Floor the ID, only give base/main Pokemon forms
+                App.game.party.gainPokemonById(Math.floor(pokemon.id), true, true);
                 // Notify that the code was activated successfully
                 Notifier.notify({
                     title:'Code activated!',

--- a/src/scripts/items/EggItem.ts
+++ b/src/scripts/items/EggItem.ts
@@ -16,7 +16,7 @@ class EggItem extends CaughtIndicatingItem {
 
         let success: boolean;
         if (this.type === GameConstants.EggItemType.Pokemon_egg) {
-            success = App.game.breeding.gainPokemonEgg(pokemonMap.random(GameConstants.TotalPokemonsPerRegion[player.highestRegion()]));
+            success = App.game.breeding.gainPokemonEgg(pokemonMap.randomRegion(player.highestRegion()));
         } else if (this.type === GameConstants.EggItemType.Mystery_egg) {
             success = App.game.breeding.gainRandomEgg();
         } else {

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -4,6 +4,7 @@
 /// <reference path="../../declarations/weather/WeatherType.d.ts" />
 /// <reference path="../../declarations/enums/PokemonType.d.ts" />
 /// <reference path="../../declarations/interfaces/BagItem.d.ts" />
+/// <reference path="../../declarations/utilities/Rand.d.ts" />
 /// <reference path="../farming/BerryType.ts" />
 
 const pokemonBabyPrevolutionMap: { [name: string]: PokemonNameType } = {};
@@ -21104,9 +21105,11 @@ const pokemonMap = new GenericProxy<
                     // minimum 0 (Kanto)
                     const min = Math.max(GameConstants.Region.kanto, Math.min(_min, _max));
                     const max = Math.max(GameConstants.Region.kanto, _min, _max);
-                    const filteredPokemon: PokemonListData[] = pokemon.filter(p => p.id > 0 && (p as PokemonListData).nativeRegion >= min && (p as PokemonListData).nativeRegion <= max);
-                    const random = Math.floor(Math.random() * filteredPokemon.length);
-                    const poke: PokemonListData = filteredPokemon[random];
+                    // Decide on a base ID first (so we aren't weighted towards pokemon with multiple forms such as Alcremie)
+                    const basePokemonIDs: number[] = [...new Set(pokemon.filter(p => p.id > 0 && (p as PokemonListData).nativeRegion >= min && (p as PokemonListData).nativeRegion <= max).map(p => Math.floor(p.id)))];
+                    const ID: number = Rand.fromArray(basePokemonIDs);
+                    // Choose a Pokemon with that base ID
+                    const poke: PokemonListData = Rand.fromArray(pokemon.filter(p => Math.floor(p.id) === ID && (p as PokemonListData).nativeRegion >= min && (p as PokemonListData).nativeRegion <= max));
                     // return a random Pokemon or MissingNo if none found
                     return poke || (pokemon.find(p => p.id == 0) as PokemonListData);
                 };

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -21097,8 +21097,12 @@ const pokemonMap = new GenericProxy<
                     const min = Math.max(0, Math.min(_min, _max));
                     // maximum is same as however many pokemon are available
                     const max = Math.min(pokemon.length, Math.max(_min, _max));
-                    const random = Math.floor(Math.random() * (max ? max : pokemon.length) + min);
-                    return pokemon[random];
+                    // Decide on a base ID first (so we aren't weighted towards pokemon with multiple forms such as Alcremie)
+                    const basePokemonIDs: number[] = [...new Set(pokemon.filter(p => p.id >= min && p.id <= max).map(p => Math.floor(p.id)))];
+                    const ID: number = Rand.fromArray(basePokemonIDs);
+                    // Choose a Pokemon with that base ID
+                    const poke: PokemonListData = Rand.fromArray(pokemon.filter(p => Math.floor(p.id) === ID && p.id >= min && p.id <= max));
+                    return poke || (pokemon.find(p => p.id == 0) as PokemonListData);
                 };
             case 'randomRegion':
                 return (_max = GameConstants.Region.kanto, _min = GameConstants.Region.kanto) => {


### PR DESCRIPTION
Multiform Pokémon such as Alcremie and Unown are weighted to appear more often due to more of them existing.
This PR changes that so each Pokémon ID has an equal chance of appearing.
Also updated shiny code to only give main forms as pretty much all of these are obtainable.