### PR TITLE
Pledge Grove Fix

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1639,6 +1639,18 @@ dungeonList['Stark Mountain'] = new Dungeon('Stark Mountain',
 // Unova
 // TODO: Balancing of dungeon Pokemon HP & rewards.
 
+dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
+    ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant'],
+    [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
+    2403000,
+    [
+        new DungeonBossPokemon('Sawsbuck (Autumn)', 13000000, 100),
+        new DungeonBossPokemon('Sawsbuck (Winter)', 13000000, 100),
+        new DungeonBossPokemon('Keldeo (Resolute)', 52000000, 100, {requirement: new
+        ObtainedPokemonRequirement(pokemonMap.Keldeo)}),
+    ],
+    106500, 20, 100);
+
 dungeonList['Floccesy Ranch'] = new Dungeon('Floccesy Ranch',
     [
         {pokemon: 'Psyduck', options: { weight: 2 }},
@@ -2726,13 +2738,6 @@ dungeonList['Moor of Icirrus'] = new Dungeon('Moor of Icirrus',
         new DungeonBossPokemon('Seismitoad', 48000000, 100),
         new DungeonBossPokemon('Whiscash', 48000000, 100),
     ],
-    356500, 8, 100);
-
-dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
-    ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant', 'Sawsbuck (Autumn)', 'Sawsbuck (Winter)'],
-    [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
-    5203000,
-    [new DungeonBossPokemon('Keldeo (Resolute)', 52000000, 100)],
     356500, 8, 100);
 
 dungeonList['Pinwheel Forest'] = new Dungeon('Pinwheel Forest',

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -2732,6 +2732,7 @@ dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
     ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant', 'Sawsbuck (Autumn)', 'Sawsbuck (Winter)'],
     [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
     5203000,
+    [new DungeonBossPokemon('Keldeo (Resolute)', 52000000, 100)],
     356500, 8, 100);
 
 dungeonList['Pinwheel Forest'] = new Dungeon('Pinwheel Forest',

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1639,18 +1639,6 @@ dungeonList['Stark Mountain'] = new Dungeon('Stark Mountain',
 // Unova
 // TODO: Balancing of dungeon Pokemon HP & rewards.
 
-dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
-    ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant'],
-    [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
-    2403000,
-    [
-        new DungeonBossPokemon('Sawsbuck (Autumn)', 13000000, 100),
-        new DungeonBossPokemon('Sawsbuck (Winter)', 13000000, 100),
-        new DungeonBossPokemon('Keldeo (Resolute)', 52000000, 100, {requirement: new
-        ObtainedPokemonRequirement(pokemonMap.Keldeo)}),
-    ],
-    106500, 20, 100);
-
 dungeonList['Floccesy Ranch'] = new Dungeon('Floccesy Ranch',
     [
         {pokemon: 'Psyduck', options: { weight: 2 }},
@@ -2738,6 +2726,12 @@ dungeonList['Moor of Icirrus'] = new Dungeon('Moor of Icirrus',
         new DungeonBossPokemon('Seismitoad', 48000000, 100),
         new DungeonBossPokemon('Whiscash', 48000000, 100),
     ],
+    356500, 8, 100);
+
+dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
+    ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant', 'Sawsbuck (Autumn)', 'Sawsbuck (Winter)'],
+    [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
+    5203000, new DungeonBossPokemon('Keldeo (Resolute)', 52000000, 100),
     356500, 8, 100);
 
 dungeonList['Pinwheel Forest'] = new Dungeon('Pinwheel Forest',

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -2731,7 +2731,7 @@ dungeonList['Moor of Icirrus'] = new Dungeon('Moor of Icirrus',
 dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
     ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant', 'Sawsbuck (Autumn)', 'Sawsbuck (Winter)'],
     [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
-    5203000, new DungeonBossPokemon('Keldeo (Resolute)', 52000000, 100),
+    5203000,
     356500, 8, 100);
 
 dungeonList['Pinwheel Forest'] = new Dungeon('Pinwheel Forest',

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1638,12 +1638,6 @@ dungeonList['Stark Mountain'] = new Dungeon('Stark Mountain',
 
 // Unova
 // TODO: Balancing of dungeon Pokemon HP & rewards.
-dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
-    ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant', 'Sawsbuck (Autumn)', 'Sawsbuck (Winter)'],
-    [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
-    2403000,
-    [new DungeonBossPokemon('Keldeo (Resolute)', 12000000, 100)],
-    106500, 20, 100);
 
 dungeonList['Floccesy Ranch'] = new Dungeon('Floccesy Ranch',
     [
@@ -2734,6 +2728,13 @@ dungeonList['Moor of Icirrus'] = new Dungeon('Moor of Icirrus',
     ],
     356500, 8, 100);
 
+dungeonList['Pledge Grove'] = new Dungeon('Pledge Grove',
+    ['Fearow', 'Furret', 'Ledian', 'Sudowoodo', 'Stantler', 'Breloom', 'Unfezant', 'Sawsbuck (Autumn)', 'Sawsbuck (Winter)'],
+    [GameConstants.BattleItemType.xClick, GameConstants.BattleItemType.Item_magnet],
+    5203000,
+    [new DungeonBossPokemon('Keldeo (Resolute)', 52000000, 100)],
+    356500, 8, 100);
+
 dungeonList['Pinwheel Forest'] = new Dungeon('Pinwheel Forest',
     [
         {pokemon: 'Goldeen', options: { weight: 6.57 }},
@@ -2892,6 +2893,7 @@ dungeonList['Pinwheel Forest'] = new Dungeon('Pinwheel Forest',
         new DungeonBossPokemon('Virizion', 48000000, 100),
     ],
     356500, 3, 100);
+
 dungeonList['Dreamyard'] = new Dungeon('Dreamyard',
     [
         {pokemon: 'Raticate', options: { weight: 4.67 }},

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -1585,7 +1585,7 @@ TownList['Anville Town'] = new Town(
 TownList['Pledge Grove'] = new DungeonTown(
     'Pledge Grove',
     GameConstants.Region.unova,
-    [new ObtainedPokemonRequirement(pokemonMap.Keldeo)]
+    [new RouteKillRequirement(10, GameConstants.Region.unova, 19)]
 );
 TownList['Floccesy Ranch'] = new DungeonTown(
     'Floccesy Ranch',

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -1585,7 +1585,7 @@ TownList['Anville Town'] = new Town(
 TownList['Pledge Grove'] = new DungeonTown(
     'Pledge Grove',
     GameConstants.Region.unova,
-    [{requirement: new ObtainedPokemonRequirement(pokemonMap.Keldeo)}]
+    [new ObtainedPokemonRequirement(pokemonMap.Keldeo)]
 );
 TownList['Floccesy Ranch'] = new DungeonTown(
     'Floccesy Ranch',

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -1585,7 +1585,7 @@ TownList['Anville Town'] = new Town(
 TownList['Pledge Grove'] = new DungeonTown(
     'Pledge Grove',
     GameConstants.Region.unova,
-    [new RouteKillRequirement(10, GameConstants.Region.unova, 19)]
+    [{requirement: new ObtainedPokemonRequirement(pokemonMap.Keldeo)}]
 );
 TownList['Floccesy Ranch'] = new DungeonTown(
     'Floccesy Ranch',


### PR DESCRIPTION
Pledge Grove was super underpowered relative to when it is unlocked. I made it roughly equivalent in difficulty to the Moor of Icirrus which is a pre-req for unlocking the dungeon. Ultima liked this change better so I reverted it back to this one.

~With help from Dev-chat I made a better change. Now Pledge Grove is unlocked with Floccesy Town and is an "optional" dungeon. Two Sawsbuck forms (and the Deerlings) can be obtained early, which is a good reward for early Unova. Keldeo Resolute is a dungeon boss still locked behind Keldeo standard form in the Moor of Icirrus.~