### PR TITLE
Add check for tutorial quest completion (fix quest module not showing)

### DIFF
--- a/src/components/achievementsModal.html
+++ b/src/components/achievementsModal.html
@@ -3,7 +3,7 @@ aria-labelledby="AchievementsModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 data-bind="tooltip: { title: 'As you earn achievements, you gain up to 100% (per region) more Money, Dungeon Tokens and Experience and from all sources.', trigger: 'hover', placement:'right' }">Achievements Bonus: <u class="text-primary" data-bind="text: AchievementHandler.achievementBonusPercent()"></u></h5>
+                <h5 data-bind="tooltip: { title: 'As you earn achievements, you gain up to 100% (per region) more Click Attack, Money, Dungeon Tokens and Experience from all sources.', trigger: 'hover', placement:'right' }">Achievements Bonus: <u class="text-primary" data-bind="text: AchievementHandler.achievementBonusPercent()"></u></h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -89,6 +89,7 @@ class Game {
         RoamingPokemonList.generateIncreasedChanceRoutes(now);
 
         this.computeOfflineEarnings();
+        this.checkAndFix();
 
         this.gameState = GameConstants.GameState.fighting;
     }
@@ -142,6 +143,20 @@ class Game {
                 message: `Defeated: ${numberOfPokemonDefeated} Pokémon\nEarned: <img src="./assets/images/currency/money.svg" height="24px"/> ${moneyToEarn.toLocaleString('en-US')}`,
                 timeout: 2 * GameConstants.MINUTE,
             });
+        }
+    }
+
+    checkAndFix() {
+        // Quest box not showing (game thinking tutorial is not completed)
+        if (App.game.quests.getQuestLine('Tutorial Quests').state() == QuestLineState.inactive) {
+            if (App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Pewter City')]() >= 1) {
+                // Defeated Brock, Has completed the Tutorial
+                App.game.quests.getQuestLine('Tutorial Quests').state(QuestLineState.ended);
+            } else if (player.starter() >= 0) {
+                // Has chosen a starter, Tutorial is started
+                App.game.quests.getQuestLine('Tutorial Quests').state(QuestLineState.started);
+                App.game.quests.getQuestLine('Tutorial Quests').beginQuest(App.game.quests.getQuestLine('Tutorial Quests').curQuest());
+            }
         }
     }
 

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -599,6 +599,17 @@ class Update implements Saveable {
             return;
         }
 
+        if (this.isNewerVersion(this.saveVersion, this.version)) {
+            Notifier.notify({
+                title: 'Save version is newer than game version!',
+                message: `Please update your game before attempting to load this save..\n\nSave version: ${this.saveVersion}\nGame version: ${this.version}`,
+                type: NotificationConstants.NotificationOption.danger,
+                timeout: GameConstants.DAY,
+            });
+            throw new Error(`Save is newer than game version\nSave version: ${this.saveVersion}\nGame version: ${this.version}`);
+            return;
+        }
+
         const [backupButton, backupSaveData] = this.getBackupButton();
 
         // Must modify these object when updating

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -599,6 +599,7 @@ class Update implements Saveable {
             return;
         }
 
+        // Check if the save is newer than the current client, don't allow it to load.
         if (this.isNewerVersion(this.saveVersion, this.version)) {
             Notifier.notify({
                 title: 'Save version is newer than game version!',

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -32,9 +32,9 @@ class QuestLineHelper {
         tutorial.addQuest(buyDungeonTicket);
 
         //Clear Viridian Forest
-        const clearMtMoon = new DefeatDungeonQuest(1, 50, 'Viridian Forest');
-        clearMtMoon.customDescription = 'Gather 50 Dungeon tokens by (re)capturing Pokémon, then clear the Viridian Forest dungeon.';
-        tutorial.addQuest(clearMtMoon);
+        const clearViridianForest = new DefeatDungeonQuest(1, 50, 'Viridian Forest');
+        clearViridianForest.customDescription = 'Gather 50 Dungeon tokens by (re)capturing Pokémon, then clear the Viridian Forest dungeon.';
+        tutorial.addQuest(clearViridianForest);
 
         //Defeat Pewter Gym
         const pewterReward = () => {


### PR DESCRIPTION
Add a check when the game loads for Tutorial quest completion.

The Quest module seems to disappear semi often, this should resolve that, although it isn't fixing whatever is causing the issue..

Also added a check for people trying to load a newer save into an older client.

closes #1303 