### PR TITLE
Fix cosmo theme text size on progress bars, Minor tidy up of themes.less

### DIFF
--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -69,14 +69,6 @@
   -webkit-filter: brightness(0%); /* Safari 6.0 - 9.0 */
   filter: brightness(0%);
   opacity: 0.2;
-  body.cyborg &,
-  body.darkly &,
-  body.slate &,
-  body.superhero & {
-    -webkit-filter: brightness(0%) invert(100%); /* Safari 6.0 - 9.0 */
-    filter: brightness(0%) invert(100%);
-    opacity: 0.3;
-  }
 }
 
 .dungeon-pokemon-preview {

--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -1,18 +1,38 @@
 // Any changes needed for specific bootswatch themes should be put in here
 
+/* Light themes */
 .cerulean, .cosmo, .flatly, .journal, .litera, .lumen, .lux, .materia, .minty, .pulse, .sandstone, .simplex, .spacelab, .sketchy, .united, .yeti {
-    img[src="assets/images/dungeons/boss.svg"] {
-        filter: invert(1) brightness(90%);
-    }
+  // make the boss icon dark
+  img[src="assets/images/dungeons/boss.svg"] {
+    filter: invert(1) brightness(90%);
+  }
+}
+
+/* Dark themes */
+.cyborg, .darkly, .slate, .superhero {
+  // make pokeball image lighter
+  img[src="assets/images/pokeball/None.svg"] {
+    filter: invert(1) brightness(90%);
+  }
+
+  // make the pokemon silhouettes lighter
+  .dungeon-pokemon-locked {
+    -webkit-filter: brightness(0%) invert(100%); /* Safari 6.0 - 9.0 */
+    filter: brightness(0%) invert(100%);
+    opacity: 0.3;
+  }
+}
+
+/* Individual themes */
+.cosmo {
+  .progress, .progress-bar {
+    font-size: 10px;
+  }
 }
 
 .cyborg {
   .text-light {
     color: whitesmoke !important;
-  }
-
-  img[src="assets/images/pokeball/None.svg"] {
-    filter: invert(1) brightness(90%);
   }
 }
 
@@ -20,11 +40,8 @@
   .text-primary, .text-light {
     color: whitesmoke !important;
   }
-
-  img[src="assets/images/pokeball/None.svg"] {
-    filter: invert(1) brightness(90%);
-  }
 }
+
 .sketchy {
   // Fix double close button
   #toaster .toast-body, .text-light {
@@ -64,10 +81,6 @@
       color: whitesmoke !important;
     }
   }
-
-  img[src="assets/images/pokeball/None.svg"] {
-    filter: invert(1) brightness(90%);
-  }
 }
 
 .solar {
@@ -81,7 +94,4 @@
     color: whitesmoke !important;
   }
 
-  img[src="assets/images/pokeball/None.svg"] {
-    filter: invert(1) brightness(90%);
-  }
 }


### PR DESCRIPTION
Cosmo theme text in progress bars was too small, this PR fixes that.

Also tidied up the `themes.less` file a little bit, moved some stuff out of `dungeons.less` here as well.