### PR TITLE
Reward DT when defeating a trainer rather than for each trainer mon defeated

### DIFF
--- a/src/scripts/dungeons/DungeonBattle.ts
+++ b/src/scripts/dungeons/DungeonBattle.ts
@@ -83,6 +83,9 @@ class DungeonBattle extends Battle {
                 // Reward back 50% or 100% (boss) of the total dungeon DT cost as money
                 const money = Math.round(DungeonRunner.dungeon.tokenCost * (DungeonRunner.fightingBoss() ? 1 : 0.5));
                 App.game.wallet.gainMoney(money);
+                // Reward back 2% or 5% (boss) of the total dungeon DT cost
+                const tokens = Math.round(DungeonRunner.dungeon.tokenCost * (DungeonRunner.fightingBoss() ? 0.05 : 0.02));
+                App.game.wallet.gainDungeonTokens(tokens);
             }
 
             DungeonRunner.fighting(false);

--- a/src/scripts/dungeons/DungeonBattle.ts
+++ b/src/scripts/dungeons/DungeonBattle.ts
@@ -76,16 +76,18 @@ class DungeonBattle extends Battle {
 
         // No Pokemon left, trainer defeated
         if (this.trainerPokemonIndex() >= this.trainer().team.length) {
+            // rewards for defeating trainer
             if (this.trainer().options.reward) {
                 // Custom reward amount on defeat
                 App.game.wallet.addAmount(this.trainer().options.reward);
             } else {
-                // Reward back 50% or 100% (boss) of the total dungeon DT cost as money
-                const money = Math.round(DungeonRunner.dungeon.tokenCost * (DungeonRunner.fightingBoss() ? 1 : 0.5));
-                App.game.wallet.gainMoney(money);
-                // Reward back 2% or 5% (boss) of the total dungeon DT cost
-                const tokens = Math.round(DungeonRunner.dungeon.tokenCost * (DungeonRunner.fightingBoss() ? 0.05 : 0.02));
-                App.game.wallet.gainDungeonTokens(tokens);
+                const dungeonCost = DungeonRunner.dungeon.tokenCost;
+                // Reward back 50% or 100% (boss) of the total dungeon DT cost as money (excludes achievement multiplier)
+                const money = Math.round(dungeonCost * (DungeonRunner.fightingBoss() ? 1 : 0.5));
+                App.game.wallet.gainMoney(money, true);
+                // Reward back 3% or 10% (boss) of the total dungeon DT cost (excludes achievement multiplier)
+                const tokens = Math.round(dungeonCost * (DungeonRunner.fightingBoss() ? 0.1 : 0.04));
+                App.game.wallet.gainDungeonTokens(tokens, true);
             }
 
             DungeonRunner.fighting(false);

--- a/src/scripts/dungeons/DungeonBattle.ts
+++ b/src/scripts/dungeons/DungeonBattle.ts
@@ -85,7 +85,7 @@ class DungeonBattle extends Battle {
                 // Reward back 50% or 100% (boss) of the total dungeon DT cost as money (excludes achievement multiplier)
                 const money = Math.round(dungeonCost * (DungeonRunner.fightingBoss() ? 1 : 0.5));
                 App.game.wallet.gainMoney(money, true);
-                // Reward back 3% or 10% (boss) of the total dungeon DT cost (excludes achievement multiplier)
+                // Reward back 4% or 10% (boss) of the total dungeon DT cost (excludes achievement multiplier)
                 const tokens = Math.round(dungeonCost * (DungeonRunner.fightingBoss() ? 0.1 : 0.04));
                 App.game.wallet.gainDungeonTokens(tokens, true);
             }

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -146,8 +146,8 @@ class PokemonFactory {
         const exp: number = basePokemon.exp;
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_DUNGEON);
         // Reward 2% or 5% (boss) of dungeon DT cost when the trainer mons are defeated
-        const tokens = Math.round(DungeonRunner.dungeon.tokenCost * (DungeonRunner.fightingBoss() ? 0.05 : 0.02));
-        return new BattlePokemon(name, basePokemon.id, basePokemon.type1, basePokemon.type2, maxHealth, level, 0, exp, new Amount(tokens, GameConstants.Currency.dungeonToken), shiny, GameConstants.DUNGEON_SHARDS);
+        const money = 0;
+        return new BattlePokemon(name, basePokemon.id, basePokemon.type1, basePokemon.type2, maxHealth, level, 0, exp, new Amount(money, GameConstants.Currency.money), shiny, GameConstants.DUNGEON_SHARDS);
     }
 
     public static generateDungeonBoss(bossPokemon: DungeonBossPokemon, chestsOpened: number): BattlePokemon {


### PR DESCRIPTION
Reward DT when defeating the trainer rather than for each mon defeated
Reward now ignores Achievement bonuses.
Changed DT gain from 2% and 5% per mon to 4% and 10% per trainer.