### PR TITLE
Add option to hide challenge related modules

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -1,4 +1,4 @@
-<div id="battleItemContainer" class="card sortable border-secondary mb-3">
+<div id="battleItemContainer" class="card sortable border-secondary mb-3" data-bind="visible: !(Settings.getSetting('hideChallengeRelatedModules').observableValue() && App.game.challenges.list.disableBattleItems.active())">
     <div class="card-header p-0" data-toggle="collapse" href="#battleItemContainerBody">
       <span>Battle Items</span>
     </div>

--- a/src/components/oakItemsContainer.html
+++ b/src/components/oakItemsContainer.html
@@ -1,4 +1,4 @@
-<div id="oakItemsContainer" class="card sortable border-secondary mb-3" data-bind="visible: App.game.oakItems.canAccess()">
+<div id="oakItemsContainer" class="card sortable border-secondary mb-3" data-bind="visible: App.game.oakItems.canAccess() && !(Settings.getSetting('hideChallengeRelatedModules').observableValue() && App.game.challenges.list.disableOakItems.active())">
     <div class="card-header p-0" data-toggle="collapse" href="#oakItemsBody">
         <span style="text-align:center">Oak Items</span>
     </div>

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -34,6 +34,7 @@
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('hideHatchery')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('farmDisplay')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showCurrencyGainedAnimation')}"></tr>
+                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('hideChallengeRelatedModules')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('currencyMainDisplayReduced')}"></tr>
                             </tbody>
                         </table>

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -34,7 +34,7 @@
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('hideHatchery')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('farmDisplay')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showCurrencyGainedAnimation')}"></tr>
-                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('hideChallengeRelatedModules')}"></tr>
+                                <tr data-bind="visible: Object.values(App.game.challenges.list).filter(c => c.active()).length > 0, template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('hideChallengeRelatedModules')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('currencyMainDisplayReduced')}"></tr>
                             </tbody>
                         </table>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -57,6 +57,7 @@ Settings.add(new Setting<string>('shopButtons', 'Shop amount buttons:',
     ],
     'original'));
 Settings.add(new BooleanSetting('showCurrencyGainedAnimation', 'Show currency gained animation', true));
+Settings.add(new BooleanSetting('hideChallengeRelatedModules', 'Hide challenge related modules', false));
 Settings.add(new Setting<string>('backgroundImage', 'Background image:',
     [
         new SettingOption('Day', 'background-day'),


### PR DESCRIPTION
Add an option to the settings menu to hide challenge related modules.
Currently only includes the Oak Items and Battle Items.

Setting will only be shown if a challenge is activated.
![image](https://user-images.githubusercontent.com/7288322/131219103-f33f4cab-2d3e-416e-89cc-41f74c7813fa.png)

No oak items/Battle items:
![image](https://user-images.githubusercontent.com/7288322/131219110-985c823b-8fc3-483a-a470-58fed98e73b1.png)
