### PR TITLE
Adjust quests

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -199,7 +199,7 @@ export const SHINY_BASE_REWARD = questBase * 3000;
 export const DEFEAT_POKEMONS_BASE_REWARD = questBase * 1;
 
 // Defeat reward divided by chance to catch (guessed)
-export const CAPTURE_POKEMONS_BASE_REWARD = DEFEAT_POKEMONS_BASE_REWARD / 0.8;
+export const CAPTURE_POKEMONS_BASE_REWARD = DEFEAT_POKEMONS_BASE_REWARD / 0.74;
 
 // Average of 1/4 squares revealed = 75 energy ~ 12 minutes ~ 720 pokemons
 export const MINE_LAYERS_BASE_REWARD = questBase * 720;

--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -28,6 +28,10 @@ abstract class Quest {
         this.onLoadCalled = false;
     }
 
+    public static canComplete() {
+        return true;
+    }
+
     get description(): string {
         return this.customDescription ?? 'Generic Quest Description. This should be overriden.';
     }

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -56,9 +56,7 @@ class QuestHelper {
 
         // Only use unlocked quest types
         const QuestTypes = new Set(Object.entries(this.quests).filter(([key, quest]) => quest.canComplete()).map(([key]) => key));
-        const maxAttempts = 20;
-        let attempts = 0;
-        while (quests.length < amount && attempts++ < maxAttempts) {
+        while (quests.length < amount && QuestTypes.size) {
             const questType = SeededRand.fromArray(Array.from(QuestTypes));
             if (uniqueQuestTypes) {
                 QuestTypes.delete(questType);

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -54,16 +54,14 @@ class QuestHelper {
 
         SeededRand.seed(+seed);
 
-        const QuestTypes = new Set(Object.keys(this.quests));
+        // Only use unlocked quest types
+        const QuestTypes = new Set(Object.entries(this.quests).filter(([key, quest]) => quest.canComplete()).map(([key]) => key));
         const maxAttempts = 20;
         let attempts = 0;
         while (quests.length < amount && attempts++ < maxAttempts) {
             const questType = SeededRand.fromArray(Array.from(QuestTypes));
             if (uniqueQuestTypes) {
                 QuestTypes.delete(questType);
-            }
-            if (questType == 'UseOakItemQuest' && App.game.challenges.list.disableOakItems.active()) {
-                continue;
             }
             const quest = this.createQuest(questType);
             quest.index = quests.length;

--- a/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
+++ b/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
@@ -27,6 +27,7 @@ class CapturePokemonTypesQuest extends Quest implements QuestInterface {
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(50, 250);
         let type = SeededRand.fromEnum(PokemonType);
+        // Don't allow type quest for types we can't encounter
         while (this.typeWeight(type) >= this.maxWeight) {
             type = SeededRand.fromEnum(PokemonType);
         }

--- a/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
+++ b/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
@@ -1,43 +1,40 @@
 /// <reference path="../Quest.ts" />
 
 class CapturePokemonTypesQuest extends Quest implements QuestInterface {
+    public static maxWeight = 4;
 
     constructor(capturesNeeded: number, reward: number, public type: PokemonType) {
         super(capturesNeeded, reward);
         this.focus = ko.pureComputed(() => pokemonMap.filter(p => p.type.includes(this.type)).map(p => App.game.statistics.pokemonCaptured[p.id]()).reduce((a,b) => a + b, 0));
     }
 
-    public static rewardWeight: Record<PokemonType, number> = {
-        [PokemonType.None]:     0,
-        [PokemonType.Normal]:   1.4,
-        [PokemonType.Fire]:     2,
-        [PokemonType.Water]:    1.4,
-        [PokemonType.Electric]: 2,
-        [PokemonType.Grass]:    2,
-        [PokemonType.Ice]:      4,
-        [PokemonType.Fighting]: 1.4,
-        [PokemonType.Poison]:   1.4,
-        [PokemonType.Ground]:   2,
-        [PokemonType.Flying]:   1.4,
-        [PokemonType.Psychic]:  4,
-        [PokemonType.Bug]:      3,
-        [PokemonType.Rock]:     2,
-        [PokemonType.Ghost]:    4,
-        [PokemonType.Dragon]:   5,
-        [PokemonType.Dark]:     3,
-        [PokemonType.Steel]:    3,
-        [PokemonType.Fairy]:    5,
+    public static typeWeight(type: PokemonType): number {
+        const types = new Array(GameHelper.enumLength(PokemonType) - 1).fill(0);
+        Routes.regionRoutes.filter(r => r.isUnlocked()).forEach(r => {
+            Object.values(r.pokemon).flat().forEach(p => {
+                const pokemon = pokemonMap[p];
+                if (!pokemon || pokemon.id <= 0) {
+                    return;
+                }
+                pokemon.type.forEach(t => types[t]++);
+            });
+        });
+        const max = Math.max(...types);
+        return types.map(v => (-v + max) / max * this.maxWeight).map((v, i) => Math.max(1.2, Math.round(v * 100) / 100))[type];
     }
 
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(50, 250);
-        const type = SeededRand.fromEnum(PokemonType);
+        let type = SeededRand.fromEnum(PokemonType);
+        while (this.typeWeight(type) >= this.maxWeight) {
+            type = SeededRand.fromEnum(PokemonType);
+        }
         const reward = this.calcReward(amount, type);
         return [amount, reward, type];
     }
 
     private static calcReward(amount: number, type: PokemonType): number {
-        const reward = amount * GameConstants.CAPTURE_POKEMONS_BASE_REWARD * this.rewardWeight[type];
+        const reward = amount * GameConstants.CAPTURE_POKEMONS_BASE_REWARD * this.typeWeight(type);
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
+++ b/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
@@ -7,15 +7,37 @@ class CapturePokemonTypesQuest extends Quest implements QuestInterface {
         this.focus = ko.pureComputed(() => pokemonMap.filter(p => p.type.includes(this.type)).map(p => App.game.statistics.pokemonCaptured[p.id]()).reduce((a,b) => a + b, 0));
     }
 
+    public static rewardWeight: Record<PokemonType, number> = {
+        [PokemonType.None]:     0,
+        [PokemonType.Normal]:   1.4,
+        [PokemonType.Fire]:     2,
+        [PokemonType.Water]:    1.4,
+        [PokemonType.Electric]: 2,
+        [PokemonType.Grass]:    2,
+        [PokemonType.Ice]:      4,
+        [PokemonType.Fighting]: 1.4,
+        [PokemonType.Poison]:   1.4,
+        [PokemonType.Ground]:   2,
+        [PokemonType.Flying]:   1.4,
+        [PokemonType.Psychic]:  4,
+        [PokemonType.Bug]:      3,
+        [PokemonType.Rock]:     2,
+        [PokemonType.Ghost]:    4,
+        [PokemonType.Dragon]:   5,
+        [PokemonType.Dark]:     3,
+        [PokemonType.Steel]:    3,
+        [PokemonType.Fairy]:    5,
+    }
+
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(50, 250);
-        const reward = this.calcReward(amount);
         const type = SeededRand.fromEnum(PokemonType);
+        const reward = this.calcReward(amount, type);
         return [amount, reward, type];
     }
 
-    private static calcReward(amount: number): number {
-        const reward = amount * GameConstants.CAPTURE_POKEMONS_BASE_REWARD * 1.4;
+    private static calcReward(amount: number, type: PokemonType): number {
+        const reward = amount * GameConstants.CAPTURE_POKEMONS_BASE_REWARD * this.rewardWeight[type];
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
+++ b/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
@@ -2,6 +2,7 @@
 
 class CapturePokemonTypesQuest extends Quest implements QuestInterface {
     public static maxWeight = 4;
+    public static minWeight = 1.2;
 
     constructor(capturesNeeded: number, reward: number, public type: PokemonType) {
         super(capturesNeeded, reward);
@@ -20,7 +21,7 @@ class CapturePokemonTypesQuest extends Quest implements QuestInterface {
             });
         });
         const max = Math.max(...types);
-        return types.map(v => (-v + max) / max * this.maxWeight).map((v, i) => Math.max(1.2, Math.round(v * 100) / 100))[type];
+        return types.map(v => ((-v + max) / max) * (this.maxWeight - this.minWeight)).map(v => Math.round((v + this.minWeight) * 100) / 100)[type];
     }
 
     public static generateData(): any[] {

--- a/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
+++ b/src/scripts/quests/questTypes/CapturePokemonTypesQuest.ts
@@ -3,13 +3,14 @@
 class CapturePokemonTypesQuest extends Quest implements QuestInterface {
     public static maxWeight = 4;
     public static minWeight = 1.2;
+    public static weights: Array<Record<string, number>> = [];
 
     constructor(capturesNeeded: number, reward: number, public type: PokemonType) {
         super(capturesNeeded, reward);
         this.focus = ko.pureComputed(() => pokemonMap.filter(p => p.type.includes(this.type)).map(p => App.game.statistics.pokemonCaptured[p.id]()).reduce((a,b) => a + b, 0));
     }
 
-    public static typeWeight(type: PokemonType): number {
+    public static typeWeights(): Array<Record<string, number>> {
         const types = new Array(GameHelper.enumLength(PokemonType) - 1).fill(0);
         Routes.regionRoutes.filter(r => r.isUnlocked()).forEach(r => {
             Object.values(r.pokemon).flat().forEach(p => {
@@ -21,22 +22,22 @@ class CapturePokemonTypesQuest extends Quest implements QuestInterface {
             });
         });
         const max = Math.max(...types);
-        return types.map(v => ((-v + max) / max) * (this.maxWeight - this.minWeight)).map(v => Math.round((v + this.minWeight) * 100) / 100)[type];
+        // Calculate the weight
+        return types.map(v => ((-v + max) / max) * (this.maxWeight - this.minWeight))
+            // map the type and rounded values
+            .map((weight, type) => ({type, weight: Math.round((weight + this.minWeight) * 100) / 100}));
     }
 
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(50, 250);
-        let type = SeededRand.fromEnum(PokemonType);
-        // Don't allow type quest for types we can't encounter
-        while (this.typeWeight(type) >= this.maxWeight) {
-            type = SeededRand.fromEnum(PokemonType);
-        }
+        this.weights = this.typeWeights();
+        const type = SeededRand.fromArray(this.weights.filter(w => w.weight < this.maxWeight).map(w => w.type));
         const reward = this.calcReward(amount, type);
         return [amount, reward, type];
     }
 
     private static calcReward(amount: number, type: PokemonType): number {
-        const reward = amount * GameConstants.CAPTURE_POKEMONS_BASE_REWARD * this.typeWeight(type);
+        const reward = amount * GameConstants.CAPTURE_POKEMONS_BASE_REWARD * this.weights[type].weight;
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
@@ -18,10 +18,9 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
         const amount = SeededRand.intBetween(5, 20);
         const region = SeededRand.intBetween(0, player.highestRegion());
         // Only use unlocked dungeons
-        let possibleDungeons = GameConstants.RegionDungeons[region].filter(dungeon => TownList[dungeon].isUnlocked());
+        const possibleDungeons = GameConstants.RegionDungeons[region].filter(dungeon => TownList[dungeon].isUnlocked());
         // If no dungeons unlocked in this region, just use the first dungeon of the region
-        possibleDungeons = possibleDungeons.length ? possibleDungeons : [GameConstants.RegionDungeons[region][0]];
-        const dungeon = SeededRand.fromArray(possibleDungeons);
+        const dungeon = possibleDungeons.length ? SeededRand.fromArray(possibleDungeons) : GameConstants.RegionDungeons[region][0];
         const reward = this.calcReward(amount, dungeon);
         return [amount, reward, dungeon];
     }

--- a/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
@@ -16,14 +16,12 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
     public static generateData(): any[] {
         // Allow up to highest region
         const amount = SeededRand.intBetween(5, 20);
-        let attempts = 0;
-        let region = GameConstants.Region.kanto;
-        let dungeon = GameConstants.RegionDungeons[region][0];
-        // Try to find unlocked dungeon, end after 10 attempts
-        do {
-            region = SeededRand.intBetween(0, player.highestRegion());
-            dungeon = SeededRand.fromArray(GameConstants.RegionDungeons[region]);
-        } while (!TownList[dungeon].isUnlocked() && ++attempts < 10);
+        const region = SeededRand.intBetween(0, player.highestRegion());
+        // Only use unlocked dungeons
+        let possibleDungeons = GameConstants.RegionDungeons[region].filter(dungeon => TownList[dungeon].isUnlocked());
+        // If no dungeons unlocked in this region, just use the first dungeon of the region
+        possibleDungeons = possibleDungeons.length ? possibleDungeons : [GameConstants.RegionDungeons[region][0]];
+        const dungeon = SeededRand.fromArray(possibleDungeons);
         const reward = this.calcReward(amount, dungeon);
         return [amount, reward, dungeon];
     }

--- a/src/scripts/quests/questTypes/DefeatGymQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatGymQuest.ts
@@ -15,15 +15,11 @@ class DefeatGymQuest extends Quest implements QuestInterface {
 
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(5, 20);
-        let attempts = 0;
-        let region = GameConstants.Region.kanto;
-        let gymTown = GameConstants.RegionGyms[region][0];
-        // Try to find unlocked gym, end after 10 attempts
-        do {
-            region = SeededRand.intBetween(0, player.highestRegion());
-            gymTown = SeededRand.fromArray(GameConstants.RegionGyms[region]);
-        } while (!Gym.isUnlocked(gymList[gymTown]) && ++attempts < 10);
-
+        const region = SeededRand.intBetween(0, player.highestRegion());
+        // Only use unlocked gyms
+        const possibleGyms = GameConstants.RegionGyms[region].filter(gymTown => Gym.isUnlocked(gymList[gymTown]));
+        // If no gyms unlocked in this region, just use the first gym of the region
+        const gymTown = possibleGyms.length ? SeededRand.fromArray(possibleGyms) : GameConstants.RegionGyms[region][0];
         const reward = this.calcReward(amount, gymTown);
         return [amount, reward, gymTown];
     }

--- a/src/scripts/quests/questTypes/DefeatPokemonsQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatPokemonsQuest.ts
@@ -14,14 +14,11 @@ class DefeatPokemonsQuest extends Quest implements QuestInterface {
 
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(100, 500);
-        let attempts = 0;
-        let region = GameConstants.Region.kanto;
-        let route = 1;
-        // Try to find unlocked route, end after 10 attempts
-        do {
-            region = SeededRand.intBetween(0, player.highestRegion());
-            route = SeededRand.fromArray(Routes.getRoutesByRegion(region)).number;
-        } while (!MapHelper.accessToRoute(route, region) && ++attempts < 10);
+        const region = SeededRand.intBetween(0, player.highestRegion());
+        // Only use unlocked routes
+        const possibleRoutes = Routes.getRoutesByRegion(region).map(route => route.number).filter(route => MapHelper.accessToRoute(route, region));
+        // If no routes unlocked in this region, just use the first route of the region
+        const route = possibleRoutes.length ? SeededRand.fromArray(possibleRoutes) : GameConstants.StartingRoutes[region];
         const reward = this.calcReward(amount, route, region);
         return [amount, reward, route, region];
     }

--- a/src/scripts/quests/questTypes/GainFarmPointsQuest.ts
+++ b/src/scripts/quests/questTypes/GainFarmPointsQuest.ts
@@ -7,6 +7,10 @@ class GainFarmPointsQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.totalFarmPoints;
     }
 
+    public static canComplete() {
+        return App.game.farming.canAccess();
+    }
+
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(500, 5000);
         const reward = this.calcReward(amount);

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -1,6 +1,7 @@
 /// <reference path="../Quest.ts" />
 
 class GainShardsQuest extends Quest implements QuestInterface {
+    public static maxWeight = 4;
 
     private type: PokemonType;
 
@@ -10,37 +11,33 @@ class GainShardsQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.shardsGained[this.type];
     }
 
-    public static rewardWeight: Record<PokemonType, number> = {
-        [PokemonType.None]:     0,
-        [PokemonType.Normal]:   1,
-        [PokemonType.Fire]:     2,
-        [PokemonType.Water]:    1,
-        [PokemonType.Electric]: 2,
-        [PokemonType.Grass]:    2,
-        [PokemonType.Ice]:      4,
-        [PokemonType.Fighting]: 1,
-        [PokemonType.Poison]:   1,
-        [PokemonType.Ground]:   2,
-        [PokemonType.Flying]:   1,
-        [PokemonType.Psychic]:  4,
-        [PokemonType.Bug]:      3,
-        [PokemonType.Rock]:     2,
-        [PokemonType.Ghost]:    4,
-        [PokemonType.Dragon]:   5,
-        [PokemonType.Dark]:     3,
-        [PokemonType.Steel]:    3,
-        [PokemonType.Fairy]:    5,
+    public static typeWeight(type: PokemonType): number {
+        const types = new Array(GameHelper.enumLength(PokemonType) - 1).fill(0);
+        Routes.regionRoutes.filter(r => r.isUnlocked()).forEach(r => {
+            Object.values(r.pokemon).flat().forEach(p => {
+                const pokemon = pokemonMap[p];
+                if (!pokemon || pokemon.id <= 0) {
+                    return;
+                }
+                pokemon.type.forEach(t => types[t]++);
+            });
+        });
+        const max = Math.max(...types);
+        return types.map(v => (-v + max) / max * this.maxWeight).map((v, i) => Math.max(1.2, Math.round(v * 100) / 100))[type];
     }
 
     public static generateData(): any[] {
-        const type = SeededRand.fromEnum(PokemonType);
         const amount = SeededRand.intBetween(200, 600);
+        let type = SeededRand.fromEnum(PokemonType);
+        while (this.typeWeight(type) >= this.maxWeight) {
+            type = SeededRand.fromEnum(PokemonType);
+        }
         const reward = this.calcReward(type, amount);
         return [amount, reward, type];
     }
 
     private static calcReward(type: PokemonType, amount: number): number {
-        const reward = amount * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * this.rewardWeight[type];
+        const reward = amount * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * this.typeWeight(type);
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -3,6 +3,7 @@
 class GainShardsQuest extends Quest implements QuestInterface {
     public static maxWeight = 4;
     public static minWeight = 1.2;
+    public static weights: Array<Record<string, number>> = [];
 
     private type: PokemonType;
 
@@ -12,7 +13,7 @@ class GainShardsQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.shardsGained[this.type];
     }
 
-    public static typeWeight(type: PokemonType): number {
+    public static typeWeights(): Array<Record<string, number>> {
         const types = new Array(GameHelper.enumLength(PokemonType) - 1).fill(0);
         Routes.regionRoutes.filter(r => r.isUnlocked()).forEach(r => {
             Object.values(r.pokemon).flat().forEach(p => {
@@ -24,22 +25,22 @@ class GainShardsQuest extends Quest implements QuestInterface {
             });
         });
         const max = Math.max(...types);
-        return types.map(v => ((-v + max) / max) * (this.maxWeight - this.minWeight)).map(v => Math.round((v + this.minWeight) * 100) / 100)[type];
+        // Calculate the weight
+        return types.map(v => ((-v + max) / max) * (this.maxWeight - this.minWeight))
+            // map the type and rounded values
+            .map((weight, type) => ({type, weight: Math.round((weight + this.minWeight) * 100) / 100}));
     }
 
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(200, 600);
-        let type = SeededRand.fromEnum(PokemonType);
-        // Don't allow type quest for types we can't encounter
-        while (this.typeWeight(type) >= this.maxWeight) {
-            type = SeededRand.fromEnum(PokemonType);
-        }
+        this.weights = this.typeWeights();
+        const type = SeededRand.fromArray(this.weights.filter(w => w.weight < this.maxWeight).map(w => w.type));
         const reward = this.calcReward(type, amount);
         return [amount, reward, type];
     }
 
     private static calcReward(type: PokemonType, amount: number): number {
-        const reward = amount * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * this.typeWeight(type);
+        const reward = amount * GameConstants.DEFEAT_POKEMONS_BASE_REWARD * this.weights[type].weight;
         return super.randomizeReward(reward);
     }
 

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -13,6 +13,10 @@ class GainShardsQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.shardsGained[this.type];
     }
 
+    public static canComplete() {
+        return App.game.shards.canAccess();
+    }
+
     public static typeWeights(): Array<Record<string, number>> {
         const types = new Array(GameHelper.enumLength(PokemonType) - 1).fill(0);
         Routes.regionRoutes.filter(r => r.isUnlocked()).forEach(r => {

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -2,6 +2,7 @@
 
 class GainShardsQuest extends Quest implements QuestInterface {
     public static maxWeight = 4;
+    public static minWeight = 1.2;
 
     private type: PokemonType;
 
@@ -23,7 +24,7 @@ class GainShardsQuest extends Quest implements QuestInterface {
             });
         });
         const max = Math.max(...types);
-        return types.map(v => (-v + max) / max * this.maxWeight).map((v, i) => Math.max(1.2, Math.round(v * 100) / 100))[type];
+        return types.map(v => ((-v + max) / max) * (this.maxWeight - this.minWeight)).map(v => Math.round((v + this.minWeight) * 100) / 100)[type];
     }
 
     public static generateData(): any[] {

--- a/src/scripts/quests/questTypes/GainShardsQuest.ts
+++ b/src/scripts/quests/questTypes/GainShardsQuest.ts
@@ -30,6 +30,7 @@ class GainShardsQuest extends Quest implements QuestInterface {
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(200, 600);
         let type = SeededRand.fromEnum(PokemonType);
+        // Don't allow type quest for types we can't encounter
         while (this.typeWeight(type) >= this.maxWeight) {
             type = SeededRand.fromEnum(PokemonType);
         }

--- a/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
+++ b/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
@@ -10,6 +10,10 @@ class HarvestBerriesQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.berriesHarvested[this.berryType];
     }
 
+    public static canComplete() {
+        return App.game.farming.canAccess();
+    }
+
     public static generateData(): any[] {
         // Getting available Berries (always include Gen 1 Berries)
         const availableBerries = App.game.farming.berryData.filter(berry => App.game.farming.unlockedBerries[berry.type]() || berry.type < BerryType.Persim);

--- a/src/scripts/quests/questTypes/HatchEggsQuest.ts
+++ b/src/scripts/quests/questTypes/HatchEggsQuest.ts
@@ -7,6 +7,10 @@ class HatchEggsQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.totalPokemonHatched;
     }
 
+    public static canComplete() {
+        return App.game.breeding.canAccess();
+    }
+
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(1, 30);
         const reward = this.calcReward(amount);

--- a/src/scripts/quests/questTypes/MineItemsQuest.ts
+++ b/src/scripts/quests/questTypes/MineItemsQuest.ts
@@ -7,6 +7,10 @@ class MineItemsQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.undergroundItemsFound;
     }
 
+    public static canComplete() {
+        return App.game.underground.canAccess();
+    }
+
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(3, 15);
         const reward = this.calcReward(amount);

--- a/src/scripts/quests/questTypes/MineLayersQuest.ts
+++ b/src/scripts/quests/questTypes/MineLayersQuest.ts
@@ -7,6 +7,10 @@ class MineLayersQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.undergroundLayersMined;
     }
 
+    public static canComplete() {
+        return App.game.underground.canAccess();
+    }
+
     public static generateData(): any[] {
         const amount = SeededRand.intBetween(1, 3);
         const reward = this.calcReward(amount);

--- a/src/scripts/quests/questTypes/UseOakItemQuest.ts
+++ b/src/scripts/quests/questTypes/UseOakItemQuest.ts
@@ -10,6 +10,10 @@ class UseOakItemQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.oakItemUses[this.item];
     }
 
+    public static canComplete() {
+        return App.game.oakItems.canAccess() && !App.game.challenges.list.disableOakItems.active();
+    }
+
     public static generateData(): any[] {
         const possibleItems = [
             OakItems.OakItem.Magic_Ball,


### PR DESCRIPTION
Adjusted type quests.

Slightly buffed capture Pokémon quest reward.
Can no longer receive a typed quest for Pokémon types you can't encounter on routes.
Reward amount is based on how many of that type can be encountered across all unlocked routes.
_(minimum 1.2x, maximum 4x)_

No longer gives quest that cannot be completed (shards without shard case, eggs without hatchery, berries without farm etc)
Will only give maximum of total unique quest available (9 at the start of the game)