### PR TITLE
Add Farm Hands (Farming semi automation)

### DIFF
--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -240,42 +240,81 @@
                 </div>
 
                 <div id="farmHandsView" class="tab-pane fade">
-                    <div class="row m-0" data-bind="foreach: App.game.farming.farmHands.available()" style="max-width: 100%;">
+                    <div class="row m-0 justify-content-center" data-bind="foreach: App.game.farming.farmHands.available()" style="max-width: 100%;">
                         <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
                             <h5 class="card-header">
                                 <knockout data-bind="text: $data.name">Name</knockout>
                                 <img class="float-right" src="" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                             </h5>
-                            <div class="card-body">
+                            <div class="card-body p-0">
+                                <table class="table table-striped table-hover table-bordered table-sm m-0">
+                                    <thead>
+                                        <tr>
+                                            <th colspan="2" class="text-center text-light bg-dark">
+                                                <h5 class="m-0">Information</h5>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="text-left">Cost:</td>
+                                            <td class="text-right tight"><img alt="Farm Points" src="assets/images/currency/farmPoint.svg" style="height: 24px; width: 24px;">&nbsp;<knockout data-bind="text: `${$data.cost.amount.toLocaleString('en-US')}/hour`">0/hour</knockout></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left">Work Speed:</td>
+                                            <td class="text-right tight" data-bind="text: GameConstants.formatTimeFullLetters($data.workTick / 1000)">01m 00s</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left">Efficiency:</td>
+                                            <td class="text-right tight">
+                                                <div class="progress">
+                                                    <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
+                                                        <span data-bind="text: $data.efficiency.toLocaleString('en-US')">0</span>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left">Energy:</td>
+                                            <td class="text-right tight">
+                                                <div class="progress">
+                                                    <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
+                                                        <span data-bind="text: $data.maxEnergy.toLocaleString('en-US')">0</span>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                    <thead>
+                                        <tr>
+                                            <th colspan="2" class="text-center text-light bg-dark">
+                                                <h5 class="m-0">Settings</h5>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="text-left">Should Harvest:</td>
+                                            <td class="text-center tight align-middle">
+                                                <input class="clickable" type="checkbox" data-bind="checked: $data.shouldHarvest"/>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left align-middle">Berry Planting:</td>
+                                            <td class="text-right tight">
+                                                <select autocomplete="off" class="custom-select custom-select-sm" data-bind="options: GameHelper.enumNumbers(FarmHandBerryTypes).sort((a, b) => a - b), optionsText: i => FarmHandBerryTypes[i], value: $data.focus"></select>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                    <tfoot>
+                                        <tr>
+                                            <td colspan="2">
+                                                <button class="btn btn-block" data-bind="css: { 'btn-success': !$data.hired(), 'btn-danger': $data.hired() }, click: () => !$data.hired() ? $data.hire() : $data.fire(), text: !$data.hired() ? 'Hire!' : 'Fire!'">Hire!</button>
+                                            </td>
+                                        </tr>
+                                    </tfoot>
+                                </table>
                                 <p class="card-text">
-                                    Cost: <img alt="Farm Points" src="assets/images/currency/farmPoint.svg" style="height: 24px; width: 24px;">&nbsp;<knockout data-bind="text: $data.cost.amount.toLocaleString('en-US')">0</knockout>/hour
-                                    <br/>Work Speed: <knockout data-bind="text: GameConstants.formatTimeFullLetters($data.workTick / 1000)">0</knockout>
-                                    <br/>Efficiency:
-                                    <br/>
-                                    <div class="progress">
-                                        <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
-                                            <span data-bind="text: $data.efficiency.toLocaleString('en-US')">0</span>
-                                        </div>
-                                    </div>
-                                    <br/>Max Energy:
-                                    <br/>
-                                    <div class="progress">
-                                        <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
-                                            <span data-bind="text: $data.maxEnergy.toLocaleString('en-US')">0</span>
-                                        </div>
-                                    </div>
-                                    <!-- ko if: !$data.hired() -->
-                                        <button class="btn btn-primary" data-bind="click: () => $data.hire()">Hire!</button>
-                                    <!-- /ko -->
-                                    <!-- ko if: $data.hired() -->
-                                        <br/>Should Harvest: 
-                                        <input class="clickable float-right" type="checkbox" style="margin: 8px;"
-                                            data-bind="checked: $data.shouldHarvest"/>
-                                        <br/>Berry Planting:
-                                        <br/>
-                                        <select autocomplete="off" class="custom-select" data-bind="options: GameHelper.enumNumbers(FarmHandBerryTypes).sort((a, b) => a - b), optionsText: i => FarmHandBerryTypes[i], value: $data.focus"></select>
-                                        <button class="btn btn-danger" data-bind="click: () => $data.fire()">Fire!</button>
-                                    <!-- /ko -->
                                 </p>
                             </div>
                         </div>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -275,7 +275,7 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td class="text-left">Energy:</td>
+                                            <td class="text-left">Max Energy:</td>
                                             <td class="text-right tight">
                                                 <div class="progress">
                                                     <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -241,11 +241,11 @@
                     <h4><u>Farm Hands (BETA)</u></h4>
                     <p><i>(unlocked after obtaining 8 unique berries)</i></p>
                     <p>Farm Hands can help around the Farm, they will harvest and plant berries as needed.</p>
-                    <p class="text-danger"><i>NOTE: This is a beta feature, things will likely change in the future, feel free to post any feedback/bugs in the <a href="https://discord.gg/a6DFe4p" target="_blank">Discord</a>.</i></p>
+                    <p class="text-danger"><i>NOTE: This is a <strong>beta</strong> feature, things will likely change in the future, feel free to post any feedback/bugs in the <a href="https://discord.gg/a6DFe4p" target="_blank">Discord</a>.</i></p>
                     <p>Up to 3 Farm Hands can be hired at a time.</p>
                     <p>If they run out of energy, they won't do any work for that cycle but will regenerate some energy instead, if there's no work to do currently, they will also regenerate some energy.</p>
                     <p>Efficiency refers to how many actions they can do per work cycle.</p>
-                    <p><i>More Farm Hands can be unlocked through shops or unlocking unique berries</i></p>
+                    <p><i>More Farm Hands can be unlocked through shops and unlocking unique berries</i></p>
                 </div>
 
                 <div id="farmHandsView" class="tab-pane fade">

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -318,7 +318,7 @@
                                             <td colspan="2" class="clickable" data-toggle="collapse" data-bind="attr: { href: `#allowedPlots${$data.name}`}" >Allowed Plots:</td>
                                         </tr>
                                         <tr>
-                                            <td colspan="2">
+                                            <td class="p-0" colspan="2">
                                                 <div class="row m-0 collapse" data-bind="attr: { id: `allowedPlots${$data.name}`}, foreach: App.game.farming.plotList">
                                                     <!-- ko if: $index() % GameConstants.FARM_PLOT_WIDTH == 0 -->
                                                     <div class="w-100"></div>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -6,9 +6,9 @@
             <div class="modal-header p-0">
                 <ul class="nav nav-tabs nav-fill">
                     <li class="nav-item"><a data-toggle='tab' class='nav-link active' href="#berryFarmView">Farm</a></li>
+                    <li class='nav-item' data-bind="visible: App.game.farming.farmHands.isUnlocked()"><a data-toggle='tab' class='nav-link' href="#farmHandsView">Farm Hands (BETA)</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#berryDexView">Berrydex</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#helpView">Help</a></li>
-                    <li class='nav-item' data-bind="visible: App.game.farming.farmHands.isUnlocked()"><a data-toggle='tab' class='nav-link' href="#farmHandsView">Farm Hands [BETA]</a></li>
                     <!-- TODO: HLXII Add Apricorn Tab ? -->
                     <btn class="btn btn-primary">
                         <span data-bind="template: { name: 'currencyTemplate', data: {'amount': App.game.wallet.currencies[GameConstants.Currency.farmPoint](), 'currency': GameConstants.Currency.farmPoint}}"></span>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -128,7 +128,7 @@
 
                         <div class="col-12 col-lg-8">
                             <div id="plotList" class="row" data-bind="foreach: App.game.farming.plotList">
-                                <!-- ko if: $index() % Farming.PLOT_WIDTH == 0 -->
+                                <!-- ko if: $index() % GameConstants.FARM_PLOT_WIDTH == 0 -->
                                 <div class="w-100"></div>
                                 <!-- /ko -->
                                 <div class="plot col" data-bind="css: { plotLocked : !$data.isUnlocked }">
@@ -310,6 +310,25 @@
                                             <td class="text-left align-middle">Berry Planting:</td>
                                             <td class="text-right tight">
                                                 <select autocomplete="off" class="custom-select custom-select-sm" data-bind="options: App.game.farming.farmHands.availableBerries, optionsText: i => FarmHandBerryTypes[i], value: $data.focus"></select>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="2" class="clickable" data-toggle="collapse" data-bind="attr: { href: `#allowedPlots${$data.name}`}" >Allowed Plots:</td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="2">
+                                                <div class="row m-0 collapse" data-bind="attr: { id: `allowedPlots${$data.name}`}, foreach: App.game.farming.plotList">
+                                                    <!-- ko if: $index() % GameConstants.FARM_PLOT_WIDTH == 0 -->
+                                                    <div class="w-100"></div>
+                                                    <!-- /ko -->
+                                                    <div class="plot col p-1">
+                                                        <div class="plot-content clickable" data-bind="click: () => { $parent.togglePlot($index()) }">
+                                                            <div class="plotImage">
+                                                                <img style="width: 100%" src="assets/images/farm/soil.png" data-bind="css: { plotEnabled : $parent.plots().includes($index()), plotDisabled : !$parent.plots().includes($index()) }">
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
                                             </td>
                                         </tr>
                                     </tbody>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -241,10 +241,11 @@
                     <h4><u>Farm Hands (BETA)</u></h4>
                     <p><i>(unlocked after obtaining 8 unique berries)</i></p>
                     <p>Farm Hands can help around the Farm, they will harvest and plant berries as needed.</p>
+                    <p class="text-danger"><i>NOTE: This is a beta feature, things will likely change in the future, feel free to post any feedback/bugs in the <a href="https://discord.gg/a6DFe4p" target="_blank">Discord</a>.</i></p>
+                    <p>Up to 3 Farm Hands can be hired at a time.</p>
                     <p>If they run out of energy, they won't do any work for that cycle but will regenerate some energy instead, if there's no work to do currently, they will also regenerate some energy.</p>
                     <p>Efficiency refers to how many actions they can do per work cycle.</p>
-                    <p><i>More Farm Hands will become available as you unlock more berries.</i></p>
-                    <p><i>As this is a beta feature, some things may change in the future, feel free to post any feedback/bugs in the <a href="https://discord.gg/a6DFe4p" target="_blank">Discord</a>.</i></p>
+                    <p><i>More Farm Hands can be unlocked through shops or unlocking unique berries</i></p>
                 </div>
 
                 <div id="farmHandsView" class="tab-pane fade">
@@ -336,7 +337,7 @@
                                     <tfoot>
                                         <tr>
                                             <td colspan="2">
-                                                <button class="btn btn-block" data-bind="css: { 'btn-success': !$data.hired(), 'btn-danger': $data.hired() }, click: () => !$data.hired() ? $data.hire() : $data.fire(), text: !$data.hired() ? 'Hire!' : 'Fire!'">Hire!</button>
+                                                <button class="btn btn-block" data-bind="attr: { disabled: !$data.hired() && !App.game.farming.farmHands.canHire() }, css: { 'btn-success': !$data.hired(), 'btn-danger': $data.hired() }, click: () => !$data.hired() ? $data.hire() : $data.fire(), text: !$data.hired() ? 'Hire!' : 'Fire!'">Hire!</button>
                                             </td>
                                         </tr>
                                     </tfoot>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -8,7 +8,7 @@
                     <li class="nav-item"><a data-toggle='tab' class='nav-link active' href="#berryFarmView">Farm</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#berryDexView">Berrydex</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#helpView">Help</a></li>
-                    <li class='nav-item' data-bind="visible: App.game.farming.farmHands.isUnlocked()"><a data-toggle='tab' class='nav-link' href="#farmHandsView">Farm Hands</a></li>
+                    <li class='nav-item' data-bind="visible: App.game.farming.farmHands.isUnlocked()"><a data-toggle='tab' class='nav-link' href="#farmHandsView">Farm Hands [BETA]</a></li>
                     <!-- TODO: HLXII Add Apricorn Tab ? -->
                     <btn class="btn btn-primary">
                         <span data-bind="template: { name: 'currencyTemplate', data: {'amount': App.game.wallet.currencies[GameConstants.Currency.farmPoint](), 'currency': GameConstants.Currency.farmPoint}}"></span>
@@ -237,6 +237,49 @@
 
                     <h4><u>Wandering Pokémon</u></h4>
                     <p>Ripe Berry plants may attract wild Pokémon that will join your party. Some Pokémon can only be found using certain Berry species.</p>
+                </div>
+
+                <div id="farmHandsView" class="tab-pane fade">
+                    <div class="row m-0" data-bind="foreach: App.game.farming.farmHands.available()" style="max-width: 100%;">
+                        <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
+                            <h5 class="card-header">
+                                <knockout data-bind="text: $data.name">Name</knockout>
+                                <img class="float-right" src="" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                            </h5>
+                            <div class="card-body">
+                                <p class="card-text">
+                                    Cost: <img alt="Farm Points" src="assets/images/currency/farmPoint.svg" style="height: 24px; width: 24px;">&nbsp;<knockout data-bind="text: $data.cost.amount.toLocaleString('en-US')">0</knockout>/hour
+                                    <br/>Work Speed: <knockout data-bind="text: GameConstants.formatTimeFullLetters($data.workTick / 1000)">0</knockout>
+                                    <br/>Efficiency:
+                                    <br/>
+                                    <div class="progress">
+                                        <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
+                                            <span data-bind="text: $data.efficiency.toLocaleString('en-US')">0</span>
+                                        </div>
+                                    </div>
+                                    <br/>Max Energy:
+                                    <br/>
+                                    <div class="progress">
+                                        <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
+                                            <span data-bind="text: $data.maxEnergy.toLocaleString('en-US')">0</span>
+                                        </div>
+                                    </div>
+                                    <!-- ko if: !$data.hired() -->
+                                        <button class="btn btn-primary" data-bind="click: () => $data.hire()">Hire!</button>
+                                    <!-- /ko -->
+                                    <!-- ko if: $data.hired() -->
+                                        <br/>Should Harvest: 
+                                        <input class="clickable float-right" type="checkbox" style="margin: 8px;"
+                                            data-bind="checked: $data.shouldHarvest"/>
+                                        <br/>Berry Planting:
+                                        <br/>
+                                        <select autocomplete="off" class="custom-select" data-bind="options: GameHelper.enumNumbers(FarmHandBerryTypes).sort((a, b) => a - b), optionsText: i => FarmHandBerryTypes[i], value: $data.focus"></select>
+                                        <button class="btn btn-danger" data-bind="click: () => $data.fire()">Fire!</button>
+                                    <!-- /ko -->
+                                </p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -237,6 +237,13 @@
 
                     <h4><u>Wandering Pokémon</u></h4>
                     <p>Ripe Berry plants may attract wild Pokémon that will join your party. Some Pokémon can only be found using certain Berry species.</p>
+                    
+                    <h4><u>Farm Hands (BETA)</u></h4>
+                    <p><i>(unlocked after obtaining 8 unique berries)</i></p>
+                    <p>Farm Hands can help around the Farm, they will harvest and plant berries as needed.</p>
+                    <p>If they run out of energy, they won't do any work for that cycle but will regenerate some energy instead, if there's no work to do currently, they will also regenerate some energy.</p>
+                    <p>Efficiency refers to how many actions they can do per work cycle.</p>
+                    <p><i>More Farm Hands will become available as you unlock more berries.</i></p>
                 </div>
 
                 <div id="farmHandsView" class="tab-pane fade">

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -8,6 +8,7 @@
                     <li class="nav-item"><a data-toggle='tab' class='nav-link active' href="#berryFarmView">Farm</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#berryDexView">Berrydex</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#helpView">Help</a></li>
+                    <li class='nav-item' data-bind="visible: App.game.farmHands.isUnlocked()"><a data-toggle='tab' class='nav-link' href="#farmHandsView">Farm Hands</a></li>
                     <!-- TODO: HLXII Add Apricorn Tab ? -->
                     <btn class="btn btn-primary">
                         <span data-bind="template: { name: 'currencyTemplate', data: {'amount': App.game.wallet.currencies[GameConstants.Currency.farmPoint](), 'currency': GameConstants.Currency.farmPoint}}"></span>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -244,7 +244,7 @@
                         <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
                             <h5 class="card-header">
                                 <knockout data-bind="text: $data.name">Name</knockout>
-                                <img class="float-right" src="" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                                <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                             </h5>
                             <div class="card-body p-0">
                                 <table class="table table-striped table-hover table-bordered table-sm m-0">
@@ -268,7 +268,7 @@
                                             <td class="text-left">Efficiency:</td>
                                             <td class="text-right tight">
                                                 <div class="progress">
-                                                    <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
+                                                    <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
                                                         <span data-bind="text: $data.efficiency.toLocaleString('en-US')">0</span>
                                                     </div>
                                                 </div>
@@ -278,7 +278,7 @@
                                             <td class="text-left">Max Energy:</td>
                                             <td class="text-right tight">
                                                 <div class="progress">
-                                                    <div class="progress-bar bg-info" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
+                                                    <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
                                                         <span data-bind="text: $data.maxEnergy.toLocaleString('en-US')">0</span>
                                                     </div>
                                                 </div>
@@ -302,7 +302,7 @@
                                         <tr>
                                             <td class="text-left align-middle">Berry Planting:</td>
                                             <td class="text-right tight">
-                                                <select autocomplete="off" class="custom-select custom-select-sm" data-bind="options: GameHelper.enumNumbers(FarmHandBerryTypes).sort((a, b) => a - b), optionsText: i => FarmHandBerryTypes[i], value: $data.focus"></select>
+                                                <select autocomplete="off" class="custom-select custom-select-sm" data-bind="options: App.game.farming.farmHands.availableBerries, optionsText: i => FarmHandBerryTypes[i], value: $data.focus"></select>
                                             </td>
                                         </tr>
                                     </tbody>
@@ -331,6 +331,15 @@
                         placement:'top',
                         html: true,
                     }">ⓘ</button>
+                <knockout class="mr-auto" data-bind="foreach: App.game.farming.farmHands.hired()">
+                    <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` },
+                    tooltip: {
+                        title: $data.tooltip(),
+                        trigger: 'hover',
+                        placement:'top',
+                        html: true,
+                    }">
+                </knockout>
                 <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
             </div>
         </div>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -8,7 +8,7 @@
                     <li class="nav-item"><a data-toggle='tab' class='nav-link active' href="#berryFarmView">Farm</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#berryDexView">Berrydex</a></li>
                     <li class='nav-item'><a data-toggle='tab' class='nav-link' href="#helpView">Help</a></li>
-                    <li class='nav-item' data-bind="visible: App.game.farmHands.isUnlocked()"><a data-toggle='tab' class='nav-link' href="#farmHandsView">Farm Hands</a></li>
+                    <li class='nav-item' data-bind="visible: App.game.farming.farmHands.isUnlocked()"><a data-toggle='tab' class='nav-link' href="#farmHandsView">Farm Hands</a></li>
                     <!-- TODO: HLXII Add Apricorn Tab ? -->
                     <btn class="btn btn-primary">
                         <span data-bind="template: { name: 'currencyTemplate', data: {'amount': App.game.wallet.currencies[GameConstants.Currency.farmPoint](), 'currency': GameConstants.Currency.farmPoint}}"></span>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -244,6 +244,7 @@
                     <p>If they run out of energy, they won't do any work for that cycle but will regenerate some energy instead, if there's no work to do currently, they will also regenerate some energy.</p>
                     <p>Efficiency refers to how many actions they can do per work cycle.</p>
                     <p><i>More Farm Hands will become available as you unlock more berries.</i></p>
+                    <p><i>As this is a beta feature, some things may change in the future, feel free to post any feedback/bugs in the <a href="https://discord.gg/a6DFe4p" target="_blank">Discord</a>.</i></p>
                 </div>
 
                 <div id="farmHandsView" class="tab-pane fade">

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -77,6 +77,9 @@ export const PLATE_VALUE = 100;
 export const BREEDING_ATTACK_BONUS = 25;
 
 // Farming
+export const FARM_PLOT_WIDTH = 5;
+export const FARM_PLOT_HEIGHT = 5;
+
 export const BerryDistribution = [0.39, 0.63, 0.78, 0.87, 0.93, 0.96, 0.98, 1];
 
 export const MULCH_USE_TIME = 300;

--- a/src/modules/GameHelper.ts
+++ b/src/modules/GameHelper.ts
@@ -55,6 +55,11 @@ export default class GameHelper {
         return Object.keys(enumerable).map(Number).filter((k) => !Number.isNaN(k));
     }
 
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    public static enumSelectOption(enumerable: any): { name: string; value: any; }[] {
+        return Object.keys(enumerable).filter((k) => Number.isNaN(Number(k))).map((key) => ({ name: key, value: enumerable[key] }));
+    }
+
     // default value as a function so objects/arrays as defaults creates a new one for each key
     public static objectFromEnumStrings<T extends {}, V>(enumerable: T, defaultValue: () => V): Record<keyof T, V> {
         return (this.enumStrings(enumerable).reduce((keys, type) => ({ ...keys, [type]: defaultValue() }), {}) as Record<keyof T, V>);

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -174,6 +174,7 @@ namespace GameConstants {
     declare function camelCaseToString(str: string): string;
     declare function formatDate(date: Date): string;
     declare function formatTime(input: number | Date): string;
+    declare function formatTimeFullLetters(input: number): string;
     declare function formatTimeShortWords(input: number): string;
     declare function formatNumber(input: number): string;
     declare enum Region {

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -50,6 +50,8 @@ namespace GameConstants {
     declare const ITEM_PRICE_DEDUCT: number;
     declare const PLATE_VALUE: number;
     declare const BREEDING_ATTACK_BONUS: number;
+    declare const FARM_PLOT_WIDTH: number;
+    declare const FARM_PLOT_HEIGHT: number;
     declare const BerryDistribution: number[];
     declare const MULCH_USE_TIME: number;
     declare const BOOST_MULCH_MULTIPLIER: number;

--- a/src/scripts/achievements/BerriesUnlockedRequirement.ts
+++ b/src/scripts/achievements/BerriesUnlockedRequirement.ts
@@ -6,7 +6,7 @@ class BerriesUnlockedRequirement extends AchievementRequirement {
     }
 
     public getProgress() {
-        return Math.min( App.game.farming.unlockedBerries.filter(b => b()).length, this.requiredValue);
+        return Math.min(App.game.farming.unlockedBerries.filter(b => b()).length, this.requiredValue);
     }
 
     public hint(): string {

--- a/src/scripts/achievements/ItemOwnedRequirement.ts
+++ b/src/scripts/achievements/ItemOwnedRequirement.ts
@@ -1,0 +1,15 @@
+///<reference path="Requirement.ts"/>
+
+class ItemOwnedRequirement extends Requirement {
+    constructor(public itemName: string, value = 1, option: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+        super(value, option);
+    }
+
+    public getProgress() {
+        return Math.min(player.itemList[this.itemName](), this.requiredValue);
+    }
+
+    public hint(): string {
+        return `${this.requiredValue} ${ItemList[this.itemName].displayName} needs to be purchased first.`;
+    }
+}

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -282,15 +282,18 @@ class FarmHands {
         this.list.push(farmHand);
     }
 
+    public MAX_HIRES = 3;
     public available: KnockoutComputed<FarmHand[]>;
     public hired: KnockoutComputed<FarmHand[]>;
     public availableBerries: KnockoutComputed<FarmHandBerryTypes[]>;
+    public canHire: KnockoutComputed<boolean>;
     public requirement = new BerriesUnlockedRequirement(8);
 
     constructor() {
         this.available = ko.pureComputed(() => FarmHands.list.filter(f => f.isUnlocked()));
         this.hired = ko.pureComputed(() => FarmHands.list.filter(f => f.hired()));
         this.availableBerries = ko.pureComputed(() => GameHelper.enumNumbers(FarmHandBerryTypes).filter(b => App.game.farming.unlockedBerries[b]?.() || b < 0).sort((a, b) => a - b));
+        this.canHire =  ko.pureComputed(() => this.hired().length < this.MAX_HIRES);
     }
 
     public isUnlocked() {

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -264,6 +264,7 @@ class FarmHands {
     public available: KnockoutComputed<FarmHand[]>;
     public hired: KnockoutComputed<FarmHand[]>;
     public availableBerries: KnockoutComputed<FarmHandBerryTypes[]>;
+    public requirement = new BerriesUnlockedRequirement(8);
 
     constructor() {
         this.available = ko.pureComputed(() => FarmHands.list.filter(f => f.isUnlocked()));
@@ -272,7 +273,7 @@ class FarmHands {
     }
 
     public isUnlocked() {
-        return player.highestRegion() >= GameConstants.Region.hoenn;
+        return this.requirement.isCompleted();
     }
 
     public tick() {
@@ -281,7 +282,7 @@ class FarmHands {
     }
 
     public toJSON(): Record<string, any>[] {
-        return FarmHands.list.map(f => f.toJSON());
+        return this.available().map(f => f.toJSON());
     }
 
     public fromJSON(json: Array<any>): void {
@@ -298,9 +299,9 @@ class FarmHands {
     }
 }
 
-FarmHands.add(new FarmHand('Alex', 10, 1, FarmHandSpeeds.Lazy, 1, 1));
-FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slower, 2, 3));
-FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.Average, 7, 6));
-FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8));
-FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10));
-FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12));
+FarmHands.add(new FarmHand('Alex', 10, 1, FarmHandSpeeds.Lazy, 1, 1, new BerriesUnlockedRequirement(8)));
+FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slower, 2, 3, new BerriesUnlockedRequirement(16)));
+FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.Average, 7, 6, new BerriesUnlockedRequirement(24)));
+FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8, new BerriesUnlockedRequirement(30)));
+FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10, new BerriesUnlockedRequirement(36)));
+FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12, new BerriesUnlockedRequirement(42)));

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -1,0 +1,129 @@
+const FarmHandSkills = [
+    'energy',
+    'efficiency',
+    'accuracy',
+    'cost',
+];
+
+enum FarmHandSpeeds {
+    Fastest,
+    Faster,
+    Fast,
+    AboveAverage,
+    Average,
+    BelowAverage,
+    Slow,
+    Slower,
+    Slowest,
+    SnailPaced,
+    Lazy,
+}
+
+/*
+TODO:
+Make in game menu for hiring/firing/settings
+Work in levels/experience somehow
+Ability to hire multiple people?
+Use accuracy to decide if they plant the right berry or plant a berry at all (still use up energy?)
+Use accuracy to decide if they harvest a berry by accident? (still use up energy?)
+*/
+class FarmHand {
+    private maxEfficiency = 10;
+    // Negative value so they are charged on the first tick and work on the first tick
+    public workTicks = -GameConstants.TICK_TIME;
+    public costTicks = -GameConstants.TICK_TIME;
+    // When to charge the player whatever the cost is
+    public workTick;
+    public costTick = GameConstants.HOUR;
+
+    public focus: KnockoutObservable<BerryType> = ko.observable(BerryType.Cheri);
+    public shouldHarvest: KnockoutObservable<boolean> = ko.observable(true).extend({ boolean: null });
+    public level: number;
+    public experience: number;
+    public energy = 0;
+
+    constructor(
+        public name: string,
+        public maxEnergy: number, // 10 - 100
+        public efficiency: number, // 1 - 50?
+        public speed: FarmHandSpeeds,
+        public accuracy: number, // 0 - 10 (80% - 100%)
+        public cost: number, // 0 - 10
+        public unlockRequirement?: Requirement | MultiRequirement | OneFromManyRequirement
+    ) {
+        this.workTicks = -GameConstants.TICK_TIME;
+        this.costTicks = -GameConstants.TICK_TIME;
+        // Set initial energy to maximum energy
+        this.energy = this.maxEnergy;
+        // Calculate how much to charge the player in farm points
+        this.cost = +Math.pow(100, 1 + this.cost * 0.08).toPrecision(2);
+        // Calculate how often they work
+        this.workTick = this.calcWorkTick(this.speed);
+    }
+
+    private calcWorkTick(speed: FarmHandSpeeds): number {
+        speed = ((speed + 1) * 0.03) + 1;
+        let time = Math.pow(GameConstants.MINUTE, speed);
+        time -= time > 5 * GameConstants.MINUTE ? time % GameConstants.MINUTE : time % (30 * GameConstants.SECOND);
+        return time;
+    }
+
+    isUnlocked(): boolean {
+        return this.unlockRequirement?.isCompleted() ?? true;
+    }
+
+    tick(): void {
+        // Work when work ticks reached
+        this.workTicks += GameConstants.TICK_TIME;
+        if (this.workTicks % this.workTick < GameConstants.TICK_TIME) {
+            this.work();
+        }
+        // Charge player when cost tick reached
+        this.costTicks += GameConstants.TICK_TIME;
+        if (this.costTicks % this.costTick < GameConstants.TICK_TIME) {
+            this.costTicks = 0;
+        }
+    }
+
+    work(): void {
+        // Out of energy cannot work right now..
+        if (!this.energy) {
+            this.energy++;
+            return;
+        }
+
+        // flip this is they worked, otherwise restore energy points
+        let worked = false;
+        let workTimes = this.efficiency;
+        let readyPlotIndex;
+        do {
+            readyPlotIndex = App.game.farming.plotList.findIndex(p => p.isUnlocked && p.berry !== BerryType.None && p.stage() >= PlotStage.Berry);
+            if (readyPlotIndex >= 0 && workTimes) {
+                App.game.farming.harvest(readyPlotIndex);
+                workTimes--;
+                worked = true;
+            }
+        } while (readyPlotIndex >= 0 && workTimes);
+        let emptyPlotIndex;
+        do {
+            emptyPlotIndex = App.game.farming.plotList.findIndex(p => p.isUnlocked && p.berry == BerryType.None);
+            if (emptyPlotIndex && workTimes) {
+                App.game.farming.plant(emptyPlotIndex, this.focus());
+                workTimes--;
+                worked = true;
+            }
+        } while (emptyPlotIndex >= 0 && workTimes);
+
+        if (!worked) {
+            this.energy++;
+        } else {
+            this.energy--;
+        }
+    }
+}
+
+const FarmHands: FarmHand[] = [
+    new FarmHand('Jake', 10, 1, FarmHandSpeeds.SnailPaced, 1, 1),
+    new FarmHand('Paul', 15, 3, FarmHandSpeeds.Slowest, 1, 3),
+    new FarmHand('Fred', 100, 10, FarmHandSpeeds.Fastest, 10, 10),
+];

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -189,22 +189,22 @@ class FarmHand {
             do {
                 // Find empty plots
                 emptyPlotIndex = App.game.farming.plotList.findIndex((p, i) => p.isUnlocked && p.berry == BerryType.None && this.plots().includes(i));
-                // Plant the expected berry
-                let berry;
-                switch (this.focus()) {
-                    case FarmHandBerryTypes.Replant: // Re-plant last berry used
-                        berry = App.game.farming.plotList[emptyPlotIndex].lastPlanted;
-                        break;
-                    case FarmHandBerryTypes.Random: // Plant a random berry
-                        berry = Rand.fromArray(App.game.farming.farmHands.availableBerries().filter(b => b >= 0));
-                        break;
-                    default:
-                        berry = this.focus();
-                }
-                // If we somehow didn't find a berry to use, just plant a Cheri..
-                berry = berry < 0 ? BerryType.Cheri : berry;
                 // Plant the berry
                 if (emptyPlotIndex >= 0 && workTimes > 0) {
+                    // Plant the expected berry
+                    let berry;
+                    switch (this.focus()) {
+                        case FarmHandBerryTypes.Replant: // Re-plant last berry used
+                            berry = App.game.farming.plotList[emptyPlotIndex].lastPlanted;
+                            break;
+                        case FarmHandBerryTypes.Random: // Plant a random berry
+                            berry = Rand.fromArray(App.game.farming.farmHands.availableBerries().filter(b => b >= 0));
+                            break;
+                        default:
+                            berry = this.focus();
+                    }
+                    // If we somehow didn't find a berry to use, just plant a Cheri..
+                    berry = berry < 0 ? BerryType.Cheri : berry;
                     App.game.farming.plant(emptyPlotIndex, berry as BerryType);
                     workTimes--;
                     worked = true;

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -325,8 +325,11 @@ class FarmHands {
 
 // Note: Gender-neutral names used as the trainer sprite is (seeded) randomly generated
 FarmHands.add(new FarmHand('Alex', 10, 1, FarmHandSpeeds.Lazy, 1, 1, new BerriesUnlockedRequirement(8)));
-FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slower, 2, 4, new BerriesUnlockedRequirement(22)));
-FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.Average, 7, 6, new BerriesUnlockedRequirement(30)));
+FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slowest, 2, 4, new BerriesUnlockedRequirement(16)));
+FarmHands.add(new FarmHand('Joey', 10, 5, FarmHandSpeeds.Slow, 2, 5, new BerriesUnlockedRequirement(24)));
+FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.BelowAverage, 7, 6, new BerriesUnlockedRequirement(32)));
+FarmHands.add(new FarmHand('Bailey', 10, 12, FarmHandSpeeds.Average, 7, 7, new ItemOwnedRequirement('FarmHandBailey')));
 FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8, new ItemOwnedRequirement('FarmHandKerry')));
 FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10, new ItemOwnedRequirement('FarmHandRiley')));
-FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12, new ItemOwnedRequirement('FarmHandJessie')));
+FarmHands.add(new FarmHand('Jamie', 65, 5, FarmHandSpeeds.Faster, 9, 10, new ItemOwnedRequirement('FarmHandJamie')));
+FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12, new BerriesUnlockedRequirement(56)));

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -165,41 +165,41 @@ class FarmHand {
         let workTimes = this.efficiency;
 
         // Harvesting berries
-        let readyPlotIndex;
-        do {
-            readyPlotIndex = App.game.farming.plotList.findIndex((p, i) => p.isUnlocked && p.berry !== BerryType.None && p.stage() >= PlotStage.Berry && this.plots().includes(i));
-            if (readyPlotIndex >= 0 && workTimes > 0) {
-                const berry = App.game.farming.plotList[readyPlotIndex].berry;
-                App.game.farming.harvest(readyPlotIndex);
-                workTimes--;
-                worked = true;
-                if (this.focus() == FarmHandBerryTypes.Replant) {
-                    App.game.farming.plant(readyPlotIndex, berry);
+        if (this.shouldHarvest()) {
+            let readyPlotIndex;
+            do {
+                readyPlotIndex = App.game.farming.plotList.findIndex((p, i) => p.isUnlocked && p.berry !== BerryType.None && p.stage() >= PlotStage.Berry && this.plots().includes(i));
+                if (readyPlotIndex >= 0 && workTimes > 0) {
+                    const berry = App.game.farming.plotList[readyPlotIndex].berry;
+                    App.game.farming.harvest(readyPlotIndex);
+                    workTimes--;
+                    worked = true;
+                    if (this.focus() == FarmHandBerryTypes.Replant) {
+                        App.game.farming.plant(readyPlotIndex, berry);
+                        workTimes--;
+                        worked = true;
+                    }
+                }
+            } while (readyPlotIndex >= 0 && workTimes > 0);
+        }
+
+        // Planting berries
+        if (this.focus() != FarmHandBerryTypes.None && this.focus() != FarmHandBerryTypes.Replant) {
+            let emptyPlotIndex;
+            do {
+                // Plant the expected berry, or a random berry
+                let berry = this.focus() != FarmHandBerryTypes.Random ? this.focus() : Rand.fromArray(App.game.farming.farmHands.availableBerries().filter(b => b >= 0));
+                berry = berry < 0 ? BerryType.Cheri : berry;
+                // Find empty plots
+                emptyPlotIndex = App.game.farming.plotList.findIndex((p, i) => p.isUnlocked && p.berry == BerryType.None && this.plots().includes(i));
+                // Plant the berry
+                if (emptyPlotIndex >= 0 && workTimes > 0) {
+                    App.game.farming.plant(emptyPlotIndex, berry as BerryType);
                     workTimes--;
                     worked = true;
                 }
-            }
-        } while (readyPlotIndex >= 0 && workTimes > 0);
-
-        // Planting berries
-        let emptyPlotIndex;
-        do {
-            // If they don't want to plant berries, don't do anything here
-            if (this.focus() == FarmHandBerryTypes.None || this.focus() == FarmHandBerryTypes.Replant) {
-                break;
-            }
-            // Plant the expected berry, or a random berry
-            let berry = this.focus() != FarmHandBerryTypes.Random ? this.focus() : Rand.fromEnum(BerryType);
-            berry = berry < 0 ? BerryType.Cheri : berry;
-            // Find empty plots
-            emptyPlotIndex = App.game.farming.plotList.findIndex((p, i) => p.isUnlocked && p.berry == BerryType.None && this.plots().includes(i));
-            // Plant the berry
-            if (emptyPlotIndex >= 0 && workTimes > 0) {
-                App.game.farming.plant(emptyPlotIndex, berry as BerryType);
-                workTimes--;
-                worked = true;
-            }
-        } while (emptyPlotIndex >= 0 && workTimes > 0);
+            } while (emptyPlotIndex >= 0 && workTimes > 0);
+        }
 
         if (!worked) {
             this.addEnergy();
@@ -309,6 +309,7 @@ class FarmHands {
     }
 }
 
+// Note: Gender-neutral names used as the trainer sprite is (seeded) randomly generated
 FarmHands.add(new FarmHand('Alex', 10, 1, FarmHandSpeeds.Lazy, 1, 1, new BerriesUnlockedRequirement(8)));
 FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slower, 2, 3, new BerriesUnlockedRequirement(16)));
 FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.Average, 7, 6, new BerriesUnlockedRequirement(24)));

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -41,6 +41,7 @@ class FarmHand {
     public level: number;
     public experience: number;
     public energy = 0;
+    public hired = false;
 
     constructor(
         public name: string,
@@ -73,6 +74,9 @@ class FarmHand {
     }
 
     tick(): void {
+        if (!this.hired) {
+            return;
+        }
         // Work when work ticks reached
         this.workTicks += GameConstants.TICK_TIME;
         if (this.workTicks % this.workTick < GameConstants.TICK_TIME) {
@@ -122,8 +126,30 @@ class FarmHand {
     }
 }
 
-const FarmHands: FarmHand[] = [
-    new FarmHand('Jake', 10, 1, FarmHandSpeeds.SnailPaced, 1, 1),
-    new FarmHand('Paul', 15, 3, FarmHandSpeeds.Slowest, 1, 3),
-    new FarmHand('Fred', 100, 10, FarmHandSpeeds.Fastest, 10, 10),
-];
+class FarmHands {
+    public static list: FarmHand[] = [];
+
+    public static add(farmHand: FarmHand) {
+        this.list.push(farmHand);
+    }
+
+    public hired: string[] = [];
+    public available: KnockoutComputed<FarmHand[]>;
+
+    constructor() {
+        this.available = ko.pureComputed(() => FarmHands.list.filter(f => f.isUnlocked()));
+    }
+
+    public isUnlocked() {
+        return player.highestRegion() >= GameConstants.Region.hoenn;
+    }
+
+    public tick() {
+        // run game tick for all hired farmhands
+        FarmHands.list.forEach(f => f.hired && f.tick());
+    }
+}
+
+FarmHands.add(new FarmHand('Jake', 10, 1, FarmHandSpeeds.SnailPaced, 1, 1));
+FarmHands.add(new FarmHand('Paul', 15, 3, FarmHandSpeeds.Slowest, 1, 3));
+FarmHands.add(new FarmHand('Fred', 100, 10, FarmHandSpeeds.Fastest, 10, 10));

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -147,7 +147,7 @@ class FarmHand {
     work(): void {
         // Out of energy cannot work right now..
         if (!this.energy()) {
-            GameHelper.incrementObservable(this.energy, 1);
+            this.addEnergy();
             return;
         }
 
@@ -193,10 +193,20 @@ class FarmHand {
         } while (emptyPlotIndex >= 0 && workTimes > 0);
 
         if (!worked) {
-            GameHelper.incrementObservable(this.energy, 1);
+            this.addEnergy();
         } else {
-            GameHelper.incrementObservable(this.energy, -1);
+            this.useEnergy();
         }
+    }
+
+    addEnergy(): void {
+        // Only allow up to maximum value
+        this.energy(Math.min(this.maxEnergy, this.energy() + 1));
+    }
+
+    useEnergy(): void {
+        // Only allow to go down to 0
+        this.energy(Math.max(0, this.energy() - 1));
     }
 
     charge(): void {
@@ -281,4 +291,5 @@ class FarmHands {
 
 FarmHands.add(new FarmHand('Jake', 10, 1, FarmHandSpeeds.SnailPaced, 1, 1));
 FarmHands.add(new FarmHand('Paul', 15, 3, FarmHandSpeeds.Slowest, 1, 3));
+FarmHands.add(new FarmHand('Justin', 30, 10, FarmHandSpeeds.Average, 1, 6));
 FarmHands.add(new FarmHand('Fred', 100, 50, FarmHandSpeeds.Fastest, 10, 12));

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -184,14 +184,25 @@ class FarmHand {
         }
 
         // Planting berries
-        if (this.focus() != FarmHandBerryTypes.None && this.focus() != FarmHandBerryTypes.Replant) {
+        if (this.focus() != FarmHandBerryTypes.None) {
             let emptyPlotIndex;
             do {
-                // Plant the expected berry, or a random berry
-                let berry = this.focus() != FarmHandBerryTypes.Random ? this.focus() : Rand.fromArray(App.game.farming.farmHands.availableBerries().filter(b => b >= 0));
-                berry = berry < 0 ? BerryType.Cheri : berry;
                 // Find empty plots
                 emptyPlotIndex = App.game.farming.plotList.findIndex((p, i) => p.isUnlocked && p.berry == BerryType.None && this.plots().includes(i));
+                // Plant the expected berry
+                let berry;
+                switch (this.focus()) {
+                    case FarmHandBerryTypes.Replant: // Re-plant last berry used
+                        berry = App.game.farming.plotList[emptyPlotIndex].lastPlanted;
+                        break;
+                    case FarmHandBerryTypes.Random: // Plant a random berry
+                        berry = Rand.fromArray(App.game.farming.farmHands.availableBerries().filter(b => b >= 0));
+                        break;
+                    default:
+                        berry = this.focus();
+                }
+                // If we somehow didn't find a berry to use, just plant a Cheri..
+                berry = berry < 0 ? BerryType.Cheri : berry;
                 // Plant the berry
                 if (emptyPlotIndex >= 0 && workTimes > 0) {
                     App.game.farming.plant(emptyPlotIndex, berry as BerryType);

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -325,8 +325,8 @@ class FarmHands {
 
 // Note: Gender-neutral names used as the trainer sprite is (seeded) randomly generated
 FarmHands.add(new FarmHand('Alex', 10, 1, FarmHandSpeeds.Lazy, 1, 1, new BerriesUnlockedRequirement(8)));
-FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slower, 2, 4, new BerriesUnlockedRequirement(16)));
-FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.Average, 7, 6, new BerriesUnlockedRequirement(24)));
-FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8, new BerriesUnlockedRequirement(30)));
-FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10, new BerriesUnlockedRequirement(36)));
-FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12, new BerriesUnlockedRequirement(42)));
+FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slower, 2, 4, new BerriesUnlockedRequirement(22)));
+FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.Average, 7, 6, new BerriesUnlockedRequirement(30)));
+FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8, new ItemOwnedRequirement('FarmHandKerry')));
+FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10, new ItemOwnedRequirement('FarmHandRiley')));
+FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12, new ItemOwnedRequirement('FarmHandJessie')));

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -27,21 +27,35 @@ Ability to hire multiple people?
 Use accuracy to decide if they plant the right berry or plant a berry at all (still use up energy?)
 Use accuracy to decide if they harvest a berry by accident? (still use up energy?)
 */
+enum FarmHandBerryType {
+    'Random' = -3,
+    'Replant' = -2,
+}
+
+const FarmHandBerryTypes = {
+    ...FarmHandBerryType,
+    ...BerryType,
+};
+type FarmHandBerryTypes = (typeof FarmHandBerryTypes)[keyof typeof FarmHandBerryTypes];
+
 class FarmHand {
-    private maxEfficiency = 10;
+    // Maximum Efficiency value
+    public maxEfficiency = 50;
     // Negative value so they are charged on the first tick and work on the first tick
     public workTicks = -GameConstants.TICK_TIME;
     public costTicks = -GameConstants.TICK_TIME;
-    // When to charge the player whatever the cost is
+    // When to charge the player whatever the cost is, when to work
     public workTick;
     public costTick = GameConstants.HOUR;
 
-    public focus: KnockoutObservable<BerryType> = ko.observable(BerryType.Cheri);
-    public shouldHarvest: KnockoutObservable<boolean> = ko.observable(true).extend({ boolean: null });
-    public level: number;
-    public experience: number;
-    public energy = 0;
-    public hired = false;
+    public cost = new Amount(+0, GameConstants.Currency.farmPoint);
+    public trainerSprite = 0;
+    public focus: KnockoutObservable<FarmHandBerryTypes> = ko.observable(BerryType.None);
+    public shouldHarvest: KnockoutObservable<boolean> = ko.observable(false).extend({ boolean: null });
+    public energy: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 0 });
+    public hired: KnockoutObservable<boolean> = ko.observable(false).extend({ boolean: null });
+    // public level: number;
+    // public experience: number;
 
     constructor(
         public name: string,
@@ -49,15 +63,18 @@ class FarmHand {
         public efficiency: number, // 1 - 50?
         public speed: FarmHandSpeeds,
         public accuracy: number, // 0 - 10 (80% - 100%)
-        public cost: number, // 0 - 10
+        cost: number, // 0 - 10? (can go higher if needed)
         public unlockRequirement?: Requirement | MultiRequirement | OneFromManyRequirement
     ) {
+        SeededRand.seed(parseInt(this.name, 36));
+        this.trainerSprite = SeededRand.intBetween(0, Profile.MAX_TRAINER - 1);
+        // Negative value so they are charged on the first tick and work on the first tick
         this.workTicks = -GameConstants.TICK_TIME;
         this.costTicks = -GameConstants.TICK_TIME;
         // Set initial energy to maximum energy
-        this.energy = this.maxEnergy;
+        this.energy(this.maxEnergy);
         // Calculate how much to charge the player in farm points
-        this.cost = +Math.pow(100, 1 + this.cost * 0.08).toPrecision(2);
+        this.cost = new Amount(+Math.pow(100, 1 + cost * 0.08).toPrecision(2), GameConstants.Currency.farmPoint);
         // Calculate how often they work
         this.workTick = this.calcWorkTick(this.speed);
     }
@@ -73,56 +90,151 @@ class FarmHand {
         return this.unlockRequirement?.isCompleted() ?? true;
     }
 
-    tick(): void {
-        if (!this.hired) {
+    hire(): void {
+        // Negative value so they are charged on the first tick and work on the first tick
+        this.workTicks = -GameConstants.TICK_TIME;
+        this.costTicks = -GameConstants.TICK_TIME;
+
+        // Check the player has enough Farm Points to hire this Farm Hand
+        if (!App.game.wallet.hasAmount(this.cost)) {
+            Notifier.notify({
+                title: `Farm Hand ${this.name}`,
+                message: `You don't have enough Farm Points to hire me..\nCost: ${this.cost.amount}`,
+                type: NotificationConstants.NotificationOption.warning,
+                timeout: 30 * GameConstants.SECOND,
+            });
             return;
         }
-        // Work when work ticks reached
-        this.workTicks += GameConstants.TICK_TIME;
-        if (this.workTicks % this.workTick < GameConstants.TICK_TIME) {
-            this.work();
+        // Farm hand is hired
+        this.hired(true);
+        Notifier.notify({
+            title: `Farm Hand ${this.name}`,
+            message: 'Thanks for hiring me,\nI won\'t let you down!',
+            type: NotificationConstants.NotificationOption.success,
+            timeout: 30 * GameConstants.SECOND,
+        });
+    }
+
+    fire(): void {
+        Notifier.notify({
+            title: `Farm Hand ${this.name}`,
+            message: 'Thanks for the work,\nLet me know when you\'re hiring again!',
+            type: NotificationConstants.NotificationOption.info,
+            timeout: 30 * GameConstants.SECOND,
+        });
+        this.hired(false);
+        return;
+    }
+
+    tick(): void {
+        if (!this.hired()) {
+            return;
         }
         // Charge player when cost tick reached
         this.costTicks += GameConstants.TICK_TIME;
-        if (this.costTicks % this.costTick < GameConstants.TICK_TIME) {
+        if (this.costTicks % this.costTick < GameConstants.TICK_TIME && this.hired()) {
             this.costTicks = 0;
+            this.charge();
+        }
+        // Work when work ticks reached
+        this.workTicks += GameConstants.TICK_TIME;
+        if (this.workTicks % this.workTick < GameConstants.TICK_TIME && this.hired()) {
+            this.workTicks = 0;
+            this.work();
         }
     }
 
     work(): void {
         // Out of energy cannot work right now..
-        if (!this.energy) {
-            this.energy++;
+        if (!this.energy()) {
+            GameHelper.incrementObservable(this.energy, 1);
             return;
         }
 
-        // flip this is they worked, otherwise restore energy points
+        // flip this if they worked, otherwise restore energy points
         let worked = false;
         let workTimes = this.efficiency;
+
+        // Harvesting berries
         let readyPlotIndex;
         do {
             readyPlotIndex = App.game.farming.plotList.findIndex(p => p.isUnlocked && p.berry !== BerryType.None && p.stage() >= PlotStage.Berry);
-            if (readyPlotIndex >= 0 && workTimes) {
+            if (readyPlotIndex >= 0 && workTimes > 0) {
+                const berry = App.game.farming.plotList[readyPlotIndex].berry;
                 App.game.farming.harvest(readyPlotIndex);
                 workTimes--;
                 worked = true;
+                if (this.focus() == FarmHandBerryTypes.Replant) {
+                    App.game.farming.plant(readyPlotIndex, berry);
+                    workTimes--;
+                    worked = true;
+                }
             }
-        } while (readyPlotIndex >= 0 && workTimes);
+        } while (readyPlotIndex >= 0 && workTimes > 0);
+
+        // Planting berries
         let emptyPlotIndex;
         do {
+            // If they don't want to plant berries, don't do anything here
+            if (this.focus() == FarmHandBerryTypes.None || this.focus() == FarmHandBerryTypes.Replant) {
+                break;
+            }
+            // Plant the expected berry, or a random berry
+            let berry = this.focus() != FarmHandBerryTypes.Random ? this.focus() : Rand.fromEnum(BerryType);
+            berry = berry < 0 ? BerryType.Cheri : berry;
+            // Find empty plots
             emptyPlotIndex = App.game.farming.plotList.findIndex(p => p.isUnlocked && p.berry == BerryType.None);
-            if (emptyPlotIndex && workTimes) {
-                App.game.farming.plant(emptyPlotIndex, this.focus());
+            // Plant the berry
+            if (emptyPlotIndex >= 0 && workTimes > 0) {
+                App.game.farming.plant(emptyPlotIndex, berry as BerryType);
                 workTimes--;
                 worked = true;
             }
-        } while (emptyPlotIndex >= 0 && workTimes);
+        } while (emptyPlotIndex >= 0 && workTimes > 0);
 
         if (!worked) {
-            this.energy++;
+            GameHelper.incrementObservable(this.energy, 1);
         } else {
-            this.energy--;
+            GameHelper.incrementObservable(this.energy, -1);
         }
+    }
+
+    charge(): void {
+        // Player cannot afford to pay for this hour
+        if (!App.game.wallet.hasAmount(this.cost)) {
+            Notifier.notify({
+                title: `Farm Hand ${this.name}`,
+                message: `It looks like you are a little short on Farm Points right now..\nLet me know when you're hiring again!\nCost: ${this.cost.amount}`,
+                type: NotificationConstants.NotificationOption.danger,
+                timeout: GameConstants.MINUTE,
+            });
+            this.hired(false);
+            return;
+        }
+        // Charge the player for the hour
+        Notifier.notify({
+            title: `Farm Hand ${this.name}`,
+            message: `Here's your bill for the hour!\nCost: ${this.cost.amount}`,
+            type: NotificationConstants.NotificationOption.info,
+            timeout: 30 * GameConstants.SECOND,
+        });
+        App.game.wallet.loseAmount(this.cost);
+    }
+
+    toJSON(): Record<string, any> {
+        return ko.toJS(this);
+    }
+
+    fromJSON(json: Record<string, any>): void {
+        if (!json) {
+            return;
+        }
+        this.focus(json.focus);
+        this.shouldHarvest(json.shouldHarvest);
+        this.workTicks = json.workTicks;
+        this.costTicks = json.costTicks;
+        this.energy(json.energy);
+        this.hired(json.hired);
     }
 }
 
@@ -146,10 +258,27 @@ class FarmHands {
 
     public tick() {
         // run game tick for all hired farmhands
-        FarmHands.list.forEach(f => f.hired && f.tick());
+        FarmHands.list.forEach(f => f.hired() && f.tick());
+    }
+
+    public toJSON(): Record<string, any>[] {
+        return FarmHands.list.map(f => f.toJSON());
+    }
+
+    public fromJSON(json: Array<any>): void {
+        if (!json || !json.length) {
+            return;
+        }
+
+        FarmHands.list.forEach(f => {
+            const data = json?.find(_f => _f.name == f.name);
+            if (data) {
+                f.fromJSON(data);
+            }
+        });
     }
 }
 
 FarmHands.add(new FarmHand('Jake', 10, 1, FarmHandSpeeds.SnailPaced, 1, 1));
 FarmHands.add(new FarmHand('Paul', 15, 3, FarmHandSpeeds.Slowest, 1, 3));
-FarmHands.add(new FarmHand('Fred', 100, 10, FarmHandSpeeds.Fastest, 10, 10));
+FarmHands.add(new FarmHand('Fred', 100, 50, FarmHandSpeeds.Fastest, 10, 12));

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -98,8 +98,8 @@ class FarmHand {
         // Check the player has enough Farm Points to hire this Farm Hand
         if (!App.game.wallet.hasAmount(this.cost)) {
             Notifier.notify({
-                title: `Farm Hand ${this.name}`,
-                message: `You don't have enough Farm Points to hire me..\nCost: ${this.cost.amount}`,
+                title: `[FARM HAND] <img src="assets/images/profile/trainer-${this.trainerSprite}.png" height="24px" class="pixelated"/> ${this.name}`,
+                message: `You don't have enough Farm Points to hire me..\nCost: <img src="./assets/images/currency/farmPoint.svg" height="24px"/> ${this.cost.amount.toLocaleString('en-US')}`,
                 type: NotificationConstants.NotificationOption.warning,
                 timeout: 30 * GameConstants.SECOND,
             });
@@ -108,7 +108,7 @@ class FarmHand {
         // Farm hand is hired
         this.hired(true);
         Notifier.notify({
-            title: `Farm Hand ${this.name}`,
+            title: `[FARM HAND] <img src="assets/images/profile/trainer-${this.trainerSprite}.png" height="24px" class="pixelated"/> ${this.name}`,
             message: 'Thanks for hiring me,\nI won\'t let you down!',
             type: NotificationConstants.NotificationOption.success,
             timeout: 30 * GameConstants.SECOND,
@@ -117,7 +117,7 @@ class FarmHand {
 
     fire(): void {
         Notifier.notify({
-            title: `Farm Hand ${this.name}`,
+            title: `[FARM HAND] <img src="assets/images/profile/trainer-${this.trainerSprite}.png" height="24px" class="pixelated"/> ${this.name}`,
             message: 'Thanks for the work,\nLet me know when you\'re hiring again!',
             type: NotificationConstants.NotificationOption.info,
             timeout: 30 * GameConstants.SECOND,
@@ -213,22 +213,28 @@ class FarmHand {
         // Player cannot afford to pay for this hour
         if (!App.game.wallet.hasAmount(this.cost)) {
             Notifier.notify({
-                title: `Farm Hand ${this.name}`,
-                message: `It looks like you are a little short on Farm Points right now..\nLet me know when you're hiring again!\nCost: ${this.cost.amount}`,
+                title: `[FARM HAND] <img src="assets/images/profile/trainer-${this.trainerSprite}.png" height="24px" class="pixelated"/> ${this.name}`,
+                message: `It looks like you are a little short on Farm Points right now..\nLet me know when you're hiring again!\nCost: <img src="./assets/images/currency/farmPoint.svg" height="24px"/> ${this.cost.amount.toLocaleString('en-US')}`,
                 type: NotificationConstants.NotificationOption.danger,
-                timeout: GameConstants.MINUTE,
+                timeout: 30 * GameConstants.MINUTE,
             });
             this.hired(false);
             return;
         }
         // Charge the player for the hour
         Notifier.notify({
-            title: `Farm Hand ${this.name}`,
-            message: `Here's your bill for the hour!\nCost: ${this.cost.amount}`,
+            title: `[FARM HAND] <img src="assets/images/profile/trainer-${this.trainerSprite}.png" height="24px" class="pixelated"/> ${this.name}`,
+            message: `Here's your bill for the hour!\nCost: <img src="./assets/images/currency/farmPoint.svg" height="24px"/> ${this.cost.amount.toLocaleString('en-US')}`,
             type: NotificationConstants.NotificationOption.info,
             timeout: 30 * GameConstants.SECOND,
         });
         App.game.wallet.loseAmount(this.cost);
+    }
+
+    tooltip(): KnockoutComputed<string> {
+        return ko.pureComputed(() => `<strong>${this.name}</strong><br/>
+            Energy: ${this.energy()}/${this.maxEnergy}`
+        );
     }
 
     toJSON(): Record<string, any> {
@@ -255,11 +261,14 @@ class FarmHands {
         this.list.push(farmHand);
     }
 
-    public hired: string[] = [];
     public available: KnockoutComputed<FarmHand[]>;
+    public hired: KnockoutComputed<FarmHand[]>;
+    public availableBerries: KnockoutComputed<FarmHandBerryTypes[]>;
 
     constructor() {
         this.available = ko.pureComputed(() => FarmHands.list.filter(f => f.isUnlocked()));
+        this.hired = ko.pureComputed(() => FarmHands.list.filter(f => f.hired()));
+        this.availableBerries = ko.pureComputed(() => GameHelper.enumNumbers(FarmHandBerryTypes).filter(b => App.game.farming.unlockedBerries[b]?.() || b < 0).sort((a, b) => a - b));
     }
 
     public isUnlocked() {
@@ -289,7 +298,9 @@ class FarmHands {
     }
 }
 
-FarmHands.add(new FarmHand('Jake', 10, 1, FarmHandSpeeds.SnailPaced, 1, 1));
-FarmHands.add(new FarmHand('Paul', 15, 3, FarmHandSpeeds.Slowest, 1, 3));
-FarmHands.add(new FarmHand('Justin', 30, 10, FarmHandSpeeds.Average, 1, 6));
-FarmHands.add(new FarmHand('Fred', 100, 50, FarmHandSpeeds.Fastest, 10, 12));
+FarmHands.add(new FarmHand('Alex', 10, 1, FarmHandSpeeds.Lazy, 1, 1));
+FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slower, 2, 3));
+FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.Average, 7, 6));
+FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8));
+FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10));
+FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12));

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -7,6 +7,7 @@ class Farming implements Feature {
 
     berryData: Berry[] = [];
     mutations: Mutation[] = [];
+    farmHand: FarmHand;
 
     externalAuras: KnockoutObservable<number>[];
 
@@ -940,6 +941,8 @@ class Farming implements Feature {
         if (notifications.size) {
             notifications.forEach((n) => this.handleNotification(n, wanderPokemon));
         }
+
+        this.farmHand?.tick();
     }
 
     handleNotification(farmNotiType: FarmNotificationType, wander?: any): void {

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -7,7 +7,7 @@ class Farming implements Feature {
 
     berryData: Berry[] = [];
     mutations: Mutation[] = [];
-    farmHand: FarmHand;
+    farmHands = FarmHands;
 
     externalAuras: KnockoutObservable<number>[];
 
@@ -942,7 +942,7 @@ class Farming implements Feature {
             notifications.forEach((n) => this.handleNotification(n, wanderPokemon));
         }
 
-        this.farmHand?.tick();
+        this.farmHands.tick();
     }
 
     handleNotification(farmNotiType: FarmNotificationType, wander?: any): void {

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1262,6 +1262,7 @@ class Farming implements Feature {
             plotList: this.plotList.map(plot => plot.toJSON()),
             shovelAmt: this.shovelAmt(),
             mutations: this.mutations.map(mutation => mutation.toJSON()),
+            farmHands: this.farmHands.toJSON(),
         };
     }
 
@@ -1321,6 +1322,8 @@ class Farming implements Feature {
         } else {
             this.mutations.forEach((mutation, i) => mutation.fromJSON(mutations[i]));
         }
+
+        this.farmHands.fromJSON(json.farmHands);
     }
 
     public static genBounds = [8, 20, 35, 53, Infinity];

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -7,7 +7,7 @@ class Farming implements Feature {
 
     berryData: Berry[] = [];
     mutations: Mutation[] = [];
-    farmHands = FarmHands;
+    farmHands = new FarmHands();
 
     externalAuras: KnockoutObservable<number>[];
 

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -21,15 +21,12 @@ class Farming implements Feature {
     // Queueing an aura reset in later ticks fixes this issue, and is barely noticable to the player.
     queuedAuraReset = -1;
 
-    static readonly PLOT_WIDTH = 5;
-    static readonly PLOT_HEIGHT = 5;
-
     defaults = {
         berryList: Array<number>(GameHelper.enumLength(BerryType) - 1).fill(0),
         unlockedBerries: Array<boolean>(GameHelper.enumLength(BerryType) - 1).fill(false),
         mulchList: Array<number>(GameHelper.enumLength(MulchType)).fill(0),
-        plotList: new Array(Farming.PLOT_WIDTH * Farming.PLOT_HEIGHT).fill(null).map((value, index) => {
-            const middle = Math.floor(Farming.PLOT_HEIGHT / 2) * Farming.PLOT_WIDTH + Math.floor(Farming.PLOT_WIDTH / 2);
+        plotList: new Array(GameConstants.FARM_PLOT_WIDTH * GameConstants.FARM_PLOT_HEIGHT).fill(null).map((value, index) => {
+            const middle = Math.floor(GameConstants.FARM_PLOT_HEIGHT / 2) * GameConstants.FARM_PLOT_WIDTH + Math.floor(GameConstants.FARM_PLOT_WIDTH / 2);
             return new Plot(index === middle, BerryType.None, 0, MulchType.None, 0);
         }),
         shovelAmt: 0,

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -10,6 +10,7 @@ class Plot implements Saveable {
 
     _isUnlocked: KnockoutObservable<boolean>;
     _berry: KnockoutObservable<BerryType>;
+    _lastPlanted: KnockoutObservable<BerryType>;
     _age: KnockoutObservable<number>;
 
     _mulch: KnockoutObservable<MulchType>;
@@ -40,6 +41,7 @@ class Plot implements Saveable {
     constructor(isUnlocked: boolean, berry: BerryType, age: number, mulch: MulchType, mulchTimeLeft: number) {
         this._isUnlocked = ko.observable(isUnlocked);
         this._berry = ko.observable(berry).extend({ numeric: 0 });
+        this._lastPlanted = ko.observable(berry).extend({ numeric: 0 });
         this._age = ko.observable(age).extend({ numeric: 3 });
         this._mulch = ko.observable(mulch).extend({ numeric: 0 });
         this._mulchTimeLeft = ko.observable(mulchTimeLeft).extend({ numeric: 3 });
@@ -285,6 +287,7 @@ class Plot implements Saveable {
      */
     plant(berry: BerryType): void {
         this.berry = berry;
+        this.lastPlanted = berry;
         this.age = 0;
         this.notifications = [];
         this._hasWarnedAboutToWither = false;
@@ -494,12 +497,14 @@ class Plot implements Saveable {
         this.age = json['age'] ?? this.defaults.age;
         this.mulch = json['mulch'] ?? this.defaults.mulch;
         this.mulchTimeLeft = json['mulchTimeLeft'] ?? this.defaults.mulchTimeLeft;
+        this.lastPlanted = json['lastPlanted'] ?? json['berry'] ?? this.defaults.berry;
     }
 
     toJSON(): Record<string, any> {
         return {
             isUnlocked: this.isUnlocked,
             berry: this.berry,
+            lastPlanted: this.lastPlanted,
             age: this.age,
             mulch: this.mulch,
             mulchTimeLeft: this.mulchTimeLeft,
@@ -566,6 +571,14 @@ class Plot implements Saveable {
 
     set berry(berry: BerryType) {
         this._berry(berry);
+    }
+
+    get lastPlanted(): BerryType {
+        return this._lastPlanted();
+    }
+
+    set lastPlanted(berry: BerryType) {
+        this._lastPlanted(berry);
     }
 
     get age(): number {

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -513,18 +513,18 @@ class Plot implements Saveable {
     public static findNearPlots(index: number): number[] {
         const plots = [];
 
-        const posX = index % Farming.PLOT_WIDTH;
-        const posY = (index - posX) / Farming.PLOT_HEIGHT;
+        const posX = index % GameConstants.FARM_PLOT_WIDTH;
+        const posY = (index - posX) / GameConstants.FARM_PLOT_HEIGHT;
 
         for (let y = posY - 1; y <= posY + 1; y++) {
             for (let x = posX - 1; x <= posX + 1; x++) {
-                if (y < 0 || y > Farming.PLOT_HEIGHT - 1 || x < 0 || x >  Farming.PLOT_WIDTH - 1) {
+                if (y < 0 || y > GameConstants.FARM_PLOT_HEIGHT - 1 || x < 0 || x >  GameConstants.FARM_PLOT_WIDTH - 1) {
                     continue;
                 }
                 if (y === posY && x === posX) {
                     continue;
                 }
-                const id = y * Farming.PLOT_HEIGHT + x;
+                const id = y * GameConstants.FARM_PLOT_HEIGHT + x;
                 plots.push(id);
             }
         }
@@ -537,14 +537,14 @@ class Plot implements Saveable {
      * @param index The plot index
      */
     public static findPlusPlots(index: number, filter?: (n: number) => boolean): number[] {
-        const posX = index % Farming.PLOT_WIDTH;
-        const posY = (index - posX) / Farming.PLOT_HEIGHT;
+        const posX = index % GameConstants.FARM_PLOT_WIDTH;
+        const posY = (index - posX) / GameConstants.FARM_PLOT_HEIGHT;
 
         const possiblePlots = [[posY - 1, posX], [posY, posX - 1], [posY, posX + 1], [posY + 1, posX]];
 
         return possiblePlots.filter(([y, x]) => {
-            return y >= 0 && y < Farming.PLOT_HEIGHT && x >= 0 && x < Farming.PLOT_WIDTH;
-        }).map(([y, x]) => y * Farming.PLOT_HEIGHT + x);
+            return y >= 0 && y < GameConstants.FARM_PLOT_HEIGHT && x >= 0 && x < GameConstants.FARM_PLOT_WIDTH;
+        }).map(([y, x]) => y * GameConstants.FARM_PLOT_HEIGHT + x);
     }
 
     get berryData(): Berry {

--- a/src/scripts/items/FarmHandItem.ts
+++ b/src/scripts/items/FarmHandItem.ts
@@ -29,7 +29,10 @@ class FarmHandItem extends Item {
     }
 }
 
+// Berry Masters
+ItemList['FarmHandBailey']   = new FarmHandItem('Bailey', 50000, GameConstants.Currency.farmPoint); // Johto (50k)
+ItemList['FarmHandKerry']   = new FarmHandItem('Kerry', 100000, GameConstants.Currency.farmPoint); // Hoenn (100k)
+ItemList['FarmHandRiley']   = new FarmHandItem('Riley', 200000, GameConstants.Currency.farmPoint); // Sinnoh (200k)
+//ItemList['FarmHandJessie']   = new FarmHandItem('Jessie', 500000, GameConstants.Currency.farmPoint); // Alola (500k) (not implemented)
 // Battle Frontier
-ItemList['FarmHandKerry']   = new FarmHandItem('Kerry', 50000, GameConstants.Currency.farmPoint);
-ItemList['FarmHandRiley']   = new FarmHandItem('Riley', 100000, GameConstants.Currency.farmPoint);
-ItemList['FarmHandJessie']   = new FarmHandItem('Jessie', 20000, GameConstants.Currency.battlePoint);
+ItemList['FarmHandJamie']   = new FarmHandItem('Jamie', 20000, GameConstants.Currency.battlePoint);

--- a/src/scripts/items/FarmHandItem.ts
+++ b/src/scripts/items/FarmHandItem.ts
@@ -1,0 +1,35 @@
+///<reference path="Item.ts"/>
+
+class FarmHandItem extends Item {
+
+    constructor(public farmHandName: string, basePrice: number, currency = GameConstants.Currency.farmPoint) {
+        super(`FarmHand${farmHandName}`, basePrice, currency, { maxAmount: 1 }, `Farm Hand ${farmHandName}`);
+    }
+
+    get farmHand(): FarmHand {
+        return FarmHands.list.find(f => f.name == this.farmHandName);
+    }
+
+    get description(): string {
+        const farmHand = this.farmHand;
+        return `Cost: <img alt="Farm Points" src="assets/images/currency/farmPoint.svg" width="20px">&nbsp;${(farmHand?.cost?.amount ?? 0).toLocaleString('en-US')}/hour<br/>
+        Work Speed: ${GameConstants.formatTimeFullLetters((farmHand?.workTick ?? GameConstants.MINUTE) / 1000)}<br/>
+        Efficiency: ${(farmHand?.efficiency ?? 0).toLocaleString('en-US')}<br/>
+        Max Energy: ${(farmHand?.maxEnergy ?? 0).toLocaleString('en-US')}`;
+    }
+
+    isAvailable(): boolean {
+        const purchased = this.farmHand?.isUnlocked() ?? true;
+        return super.isAvailable() && !purchased;
+    }
+
+    get image() {
+        const trainerID = this.farmHand?.trainerSprite || 0;
+        return `assets/images/profile/trainer-${trainerID}.png`;
+    }
+}
+
+// Battle Frontier
+ItemList['FarmHandKerry']   = new FarmHandItem('Kerry', 50000, GameConstants.Currency.farmPoint);
+ItemList['FarmHandRiley']   = new FarmHandItem('Riley', 100000, GameConstants.Currency.farmPoint);
+ItemList['FarmHandJessie']   = new FarmHandItem('Jessie', 20000, GameConstants.Currency.battlePoint);

--- a/src/scripts/items/Item.ts
+++ b/src/scripts/items/Item.ts
@@ -30,7 +30,7 @@ class Item {
     multiplierDecreaser: MultiplierDecreaser;
 
     maxAmount: number;
-    description?: string;
+    _description?: string;
     _displayName: string;
     imageDirectory?: string;
 
@@ -62,7 +62,7 @@ class Item {
         }
 
         this._displayName = displayName ?? name;
-        this.description = description;
+        this._description = description;
         this.imageDirectory = imageDirectory;
     }
 
@@ -160,6 +160,10 @@ class Item {
         }
         player.itemMultipliers[this.saveName] = Math.max(1, (player.itemMultipliers[this.saveName] || 1) / Math.pow(this.multiplier, amount));
         this.price(Math.round(this.basePrice * player.itemMultipliers[this.saveName]));
+    }
+
+    get description() {
+        return this._description;
     }
 
     get displayName() {

--- a/src/scripts/items/Vitamin.ts
+++ b/src/scripts/items/Vitamin.ts
@@ -1,8 +1,8 @@
 class Vitamin extends Item {
     type: GameConstants.VitaminType;
 
-    constructor(type: GameConstants.VitaminType, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.money, options?: ShopOptions, displayName?: string) {
-        super(GameConstants.VitaminType[type], basePrice, currency, options, displayName);
+    constructor(type: GameConstants.VitaminType, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.money, options?: ShopOptions, displayName?: string, description?: string) {
+        super(GameConstants.VitaminType[type], basePrice, currency, options, displayName, description);
         this.type = type;
     }
 
@@ -11,7 +11,5 @@ class Vitamin extends Item {
     }
 }
 
-ItemList.RareCandy = new Vitamin(GameConstants.VitaminType.RareCandy, Infinity, undefined, undefined, 'Rare Candy');
-ItemList.RareCandy.description = 'A rare to find candy that currently has no use.';
-ItemList.Protein   = new Vitamin(GameConstants.VitaminType.Protein, 1e4, GameConstants.Currency.money, { multiplier: 1.1, multiplierDecrease: false, saveName: `${GameConstants.VitaminType[GameConstants.VitaminType.Protein]}|${GameConstants.Currency[GameConstants.Currency.money]}` });
-ItemList.Protein.description = 'Increases Pokemon attack bonus<br/><i>(attack gained per breeding cycle)</i>';
+ItemList.RareCandy = new Vitamin(GameConstants.VitaminType.RareCandy, Infinity, undefined, undefined, 'Rare Candy', 'A rare to find candy that currently has no use.');
+ItemList.Protein   = new Vitamin(GameConstants.VitaminType.Protein, 1e4, GameConstants.Currency.money, { multiplier: 1.1, multiplierDecrease: false, saveName: `${GameConstants.VitaminType[GameConstants.VitaminType.Protein]}|${GameConstants.Currency[GameConstants.Currency.money]}` }, undefined, 'Increases Pokemon attack bonus<br/><i>(attack gained per breeding cycle)</i>');

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -398,6 +398,7 @@ const JohtoBerryMaster = new Shop([
     ItemList['Amaze_Mulch'],
     ItemList['Berry_Shovel'],
     ItemList['Squirtbottle'],
+    ItemList['FarmHandKerry'],
 ]);
 
 const NewBarkTechnologyEnthusiast = new NPC('Tech Enthusiast', [
@@ -670,6 +671,7 @@ const BattleFrontierShop = new Shop([
     new EnergyRestore(GameConstants.EnergyRestoreSize.SmallRestore, 10, GameConstants.Currency.battlePoint),
     new EnergyRestore(GameConstants.EnergyRestoreSize.MediumRestore, 20, GameConstants.Currency.battlePoint),
     new EnergyRestore(GameConstants.EnergyRestoreSize.LargeRestore, 40, GameConstants.Currency.battlePoint),
+    ItemList['FarmHandJessie'],
 ]);
 
 //Hoenn Berry Master
@@ -680,6 +682,7 @@ const HoennBerryMaster = new Shop([
     ItemList['Amaze_Mulch'],
     ItemList['Berry_Shovel'],
     ItemList['Sprinklotad'],
+    ItemList['FarmHandRiley'],
 ]);
 
 //Hoenn NPCs

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -398,7 +398,7 @@ const JohtoBerryMaster = new Shop([
     ItemList['Amaze_Mulch'],
     ItemList['Berry_Shovel'],
     ItemList['Squirtbottle'],
-    ItemList['FarmHandKerry'],
+    ItemList['FarmHandBailey'],
 ]);
 
 const NewBarkTechnologyEnthusiast = new NPC('Tech Enthusiast', [
@@ -671,7 +671,7 @@ const BattleFrontierShop = new Shop([
     new EnergyRestore(GameConstants.EnergyRestoreSize.SmallRestore, 10, GameConstants.Currency.battlePoint),
     new EnergyRestore(GameConstants.EnergyRestoreSize.MediumRestore, 20, GameConstants.Currency.battlePoint),
     new EnergyRestore(GameConstants.EnergyRestoreSize.LargeRestore, 40, GameConstants.Currency.battlePoint),
-    ItemList['FarmHandJessie'],
+    ItemList['FarmHandJamie'],
 ]);
 
 //Hoenn Berry Master
@@ -682,7 +682,7 @@ const HoennBerryMaster = new Shop([
     ItemList['Amaze_Mulch'],
     ItemList['Berry_Shovel'],
     ItemList['Sprinklotad'],
-    ItemList['FarmHandRiley'],
+    ItemList['FarmHandKerry'],
 ]);
 
 //Hoenn NPCs
@@ -1060,6 +1060,7 @@ const SinnohBerryMaster = new Shop([
     ItemList['Surprise_Mulch'],
     ItemList['Amaze_Mulch'],
     ItemList['Berry_Shovel'],
+    ItemList['FarmHandRiley'],
 ]);
 
 //Sinnoh NPCs

--- a/src/styles/farm.less
+++ b/src/styles/farm.less
@@ -98,3 +98,17 @@
     position: absolute;
   }
 }
+
+#farmHandsView {
+  .plot:hover {
+    cursor: pointer;
+  }
+
+  .plotEnabled {
+    filter: hue-rotate(90deg);
+  }
+
+  .plotDisabled {
+    filter: brightness(50%) opacity(90%);
+  }
+}

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -89,6 +89,10 @@
 	animation: flash linear 0.5s infinite;
 }
 
+img.pixelated {
+  image-rendering: pixelated;
+}
+
 @-webkit-keyframes flash {
 	0% { opacity: 1; }
 	50% { opacity: 0.1; }


### PR DESCRIPTION
Add Farm Hands to the farm.

Unlocks once you have 8 unique berries unlocked,
More Farm Hands will unlock as you obtain more unique berries or purchase them in some shops.

Will perform basic duties such as Harvesting or Planting.
Up to 3 can be hired at one time.
All will have different stats (Efficiency, Work Speed, Energy, Cost, Accuracy (not implemented)).
Will be able to gain experience/levels to increase their stats (not implemented).

Work Speed: How often they perform a work cycle.
Efficiency: How many actions they perform per work cycle.
Energy: Each work cycle will decrease or increase based on if they worked, They wont work if it's empty.
Cost: Farm Points.

_Will implement as a Beta feature for now, may be removed/reworked in future._

![image](https://user-images.githubusercontent.com/7288322/131360540-71e1f7b7-bf57-4096-9129-671a15b5ff77.png)
![image](https://user-images.githubusercontent.com/7288322/131365022-f8cad8e8-26c4-43fe-9a65-12211680130a.png)
![image](https://user-images.githubusercontent.com/7288322/131365266-bda6b5d7-f7b0-476f-a9e3-2a139a54ab98.png)
