### PR TITLE
Only allow players to move to tiles adjacent to tiles that have been visited

### DIFF
--- a/src/components/templates/currencyTemplate.html
+++ b/src/components/templates/currencyTemplate.html
@@ -19,7 +19,7 @@
         <img alt="Battle Points" src="assets/images/currency/battlePoint.svg" data-bind="style: {height: $data.height || '24px', width: $data.width || $data.height || '24px'}"/>
         <!-- /ko -->
 
-        <span data-bind="text: ($data.reduced || ($data.amount > $data.reducedThreshold)) ? GameConstants.formatNumber($data.amount) : $data.amount.toLocaleString('en-US')">0</span>
+        <span data-bind="text: ($data.reduced || ($data.amount > $data.reducedThreshold) || !$data.amount) ? GameConstants.formatNumber($data.amount) : $data.amount.toLocaleString('en-US')">0</span>
     </span>
 </script>
 

--- a/src/scripts/dungeons/DungeonTile.ts
+++ b/src/scripts/dungeons/DungeonTile.ts
@@ -1,11 +1,13 @@
 class DungeonTile {
     isVisible: boolean;
+    isVisited: boolean;
     hasPlayer: boolean;
     type: KnockoutObservable<GameConstants.DungeonTile>;
     cssClass: KnockoutObservable<string>;
 
     constructor(type: GameConstants.DungeonTile) {
         this.isVisible = false;
+        this.isVisited = false;
         this.hasPlayer = false;
         this.type = ko.observable(type);
         this.cssClass = ko.observable('');
@@ -21,6 +23,15 @@ class DungeonTile {
             this.cssClass('tile tile-player');
             return;
         }
-        this.cssClass(`tile tile-${GameConstants.DungeonTile[this.type()]}`);
+        // Base tile class
+        const css = ['tile'];
+        // If player visited tile add the class
+        if (this.isVisited) {
+            css.push('tile-visited');
+        }
+        // Add the tile type class
+        css .push(`tile-${GameConstants.DungeonTile[this.type()]}`);
+        // Join all the classes
+        this.cssClass(css.join(' '));
     }
 }

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -11,7 +11,7 @@ class PokemonFactory {
      */
     public static generateWildPokemon(route: number, region: GameConstants.Region): BattlePokemon {
         if (!MapHelper.validRoute(route, region)) {
-            return new BattlePokemon('Rattata', 19, PokemonType.Psychic, PokemonType.None, 10000, 1, 0, 0, new Amount(0, GameConstants.Currency.money), false, 1);
+            return new BattlePokemon('MissingNo.', 0, PokemonType.None, PokemonType.None, 0, 0, 0, 0, new Amount(0, GameConstants.Currency.money), false, 0);
         }
         let name: PokemonNameType;
 

--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -1,4 +1,5 @@
 .tile {
+  position: relative;
   height: 45px;
   border: 1px solid black;
   margin: 1px;
@@ -6,10 +7,14 @@
   &:hover {
     opacity: 0.8;
   }
+
+  &:not(.tile-visited, .tile-invisible, .tile-player) {
+    filter: brightness(50%);
+  }
 }
 
 .tile-invisible {
-  background-color: #505050;
+  background-color: #333;
 }
 
 .tile-player {
@@ -41,10 +46,30 @@
 
 .tile-chest {
   background-color: #f1c40f;
+  &::after {
+    position: absolute;
+    top: 15%;
+    left: 15%;
+    content: '';
+    display: block;
+    height: 70%;
+    width: 70%;
+    background: center / contain no-repeat url('../assets/images/dungeons/chest.png');
+  }
 }
 
 .tile-boss {
   background-color: #9b59b6;
+  &::after {
+    position: absolute;
+    top: 15%;
+    left: 15%;
+    content: '';
+    display: block;
+    height: 70%;
+    width: 70%;
+    background: center / contain no-repeat url('../assets/images/dungeons/boss.svg');
+  }
 }
 
 .healthbar-boss {


### PR DESCRIPTION
Player can now only move to tiles next to **visited** tiles.
_(could previously move to any tile next to a **visible** tile)_
Add chest image to chest tiles.
Add boss image to boss tiles.
Darkened hidden tiles.
Unvisited tiles will be darker than normal too.
![image](https://user-images.githubusercontent.com/7288322/131599192-294b01e7-d706-4257-b329-2ced5cd8b541.png)
![image](https://user-images.githubusercontent.com/7288322/131599198-26d24286-7711-4196-bea6-c736ff281666.png)
![image](https://user-images.githubusercontent.com/7288322/131599263-83debd97-a5cd-4ff6-9d73-95c423f7d52c.png)

Previously in the below example you would be able to move to any tile (except top right) as they are next to a visible tile, now you would not be able to move to any of the tiles on the far right side.
![image](https://user-images.githubusercontent.com/7288322/131599192-294b01e7-d706-4257-b329-2ced5cd8b541.png)

Fixed up that a Rattata would be the first Pokémon you encounter immediately when entering a dungeon if you had loaded into a game that saved on a dungeon.