### PR TITLE
Underground net worth indicator added

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -199,6 +199,18 @@
             </div>
 
             <div class="modal-footer">
+
+                <button type="button" class="btn mr-auto"
+                    data-bind="visible: Underground.getDiamondNetWorth() > 0,
+                    tooltip: {
+                        title: Underground.netWorthTooltip(),
+                        trigger: 'hover',
+                        placement:'top',
+                        html: true,
+                    }">
+                    <span>Total net worth: <b><span data-bind="text: Underground.getDiamondNetWorth()">-</span></b></span>
+                    <img src='assets/images/underground/diamond.svg' width="20px'">
+                </button>
                 <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
             </div>
         </div>

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -196,7 +196,9 @@ class Underground implements Feature {
     public static getDiamondNetWorth(): number {
         let diamondNetWorth = 0;
         player.mineInventory().forEach(mineItem => {
-            if (mineItem.valueType == 'Diamond') diamondNetWorth += mineItem.value * mineItem.amount();
+            if (mineItem.valueType == 'Diamond') {
+                diamondNetWorth += mineItem.value * mineItem.amount();
+            }
         });
 
         return diamondNetWorth + App.game.wallet.currencies[GameConstants.Currency.diamond]();
@@ -207,12 +209,18 @@ class Underground implements Feature {
         let nFossils = 0;
         let nPlates = 0;
         player.mineInventory().forEach(mineItem => {
-            if (mineItem.valueType == 'Diamond') nMineItems += mineItem.amount();
-            else if (mineItem.valueType == 'Mine Egg') nFossils += mineItem.amount();
-            else nPlates += mineItem.amount();
+            if (mineItem.valueType == 'Diamond') {
+                nMineItems += mineItem.amount();
+            }
+            else if (mineItem.valueType == 'Mine Egg') {
+                nFossils += mineItem.amount();
+            }
+            else {
+                nPlates += mineItem.amount();
+            }
         });
 
-        return '<u>Owned:</u><br>Mine items: ' + nMineItems + '<br>Fossils: ' + nFossils + '<br>Plates: ' + nPlates;
+        return `<u>Owned:</u><br>Mine items: ${nMineItems}<br>Fossils: ${nFossils}<br>Plates: ${nPlates}`;
     });
 
     public static getMineItemByName(name: string): UndergroundItem {

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -193,6 +193,28 @@ class Underground implements Feature {
         }
     }
 
+    public static getDiamondNetWorth(): number {
+        let diamondNetWorth = 0;
+        player.mineInventory().forEach(mineItem => {
+            if (mineItem.valueType == 'Diamond') diamondNetWorth += mineItem.value * mineItem.amount();
+        });
+
+        return diamondNetWorth + App.game.wallet.currencies[GameConstants.Currency.diamond]();
+    }
+
+    public static netWorthTooltip: KnockoutComputed<string> = ko.pureComputed(() => {
+        let nMineItems = 0;
+        let nFossils = 0;
+        let nPlates = 0;
+        player.mineInventory().forEach(mineItem => {
+            if (mineItem.valueType == 'Diamond') nMineItems += mineItem.amount();
+            else if (mineItem.valueType == 'Mine Egg') nFossils += mineItem.amount();
+            else nPlates += mineItem.amount();
+        });
+
+        return '<u>Owned:</u><br>Mine items: ' + nMineItems + '<br>Fossils: ' + nFossils + '<br>Plates: ' + nPlates;
+    });
+
     public static getMineItemByName(name: string): UndergroundItem {
         return UndergroundItem.list.find(i => i.name == name);
     }

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -211,11 +211,9 @@ class Underground implements Feature {
         player.mineInventory().forEach(mineItem => {
             if (mineItem.valueType == 'Diamond') {
                 nMineItems += mineItem.amount();
-            }
-            else if (mineItem.valueType == 'Mine Egg') {
+            } else if (mineItem.valueType == 'Mine Egg') {
                 nFossils += mineItem.amount();
-            }
-            else {
+            } else {
                 nPlates += mineItem.amount();
             }
         });


### PR DESCRIPTION
It's in the footer of the underground modal for now but location can be changed later. Hover tooltip shows item types (Mine, Fossil, Plate) and number owned
fixes #1529