### PR TITLE
Limit to +32 queue slots per new region

### DIFF
--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -389,7 +389,7 @@ class Breeding implements Feature {
     }
 
     public queueSlotsGainedFromRegion(region: GameConstants.Region): number {
-        return Math.max(4, 4 * Math.pow(2, region - 1));
+        return Math.min(32, Math.max(4, 4 * Math.pow(2, region - 1)));
     }
 
     get eggList(): Array<KnockoutObservable<Egg>> {

--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -389,6 +389,7 @@ class Breeding implements Feature {
     }
 
     public queueSlotsGainedFromRegion(region: GameConstants.Region): number {
+        // bewtween 4 → 32 queue slots gained when completing a region
         return Math.min(32, Math.max(4, 4 * Math.pow(2, region - 1)));
     }
 


### PR DESCRIPTION
Give a maximum of 32 extra queue slots when travelling to a new region instead of the current doubling each region.