### PR TITLE
Updating Gym Display Names for Johto

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -760,7 +760,7 @@ export const JohtoGyms = [
     'Blackthorn City',
     'Elite Will',
     'Elite Koga',
-    'Elite Bruno2',
+    'Elite Bruno (Johto)',
     'Elite Karen',
     'Champion Lance',
 ];

--- a/src/scripts/gym/Gym.ts
+++ b/src/scripts/gym/Gym.ts
@@ -367,7 +367,7 @@ gymList['Elite Will'] = new Gym(
     [new GymBadgeRequirement(BadgeEnums.Rising)]
 );
 gymList['Elite Koga'] = new Gym(
-    'Koga2',
+    'Koga (Johto)',
     'Elite Koga',
     [
         new GymPokemon('Ariados', 245330, 40),
@@ -381,9 +381,9 @@ gymList['Elite Koga'] = new Gym(
     'I subjected you to everything I could muster. But my efforts failed. I must hone my skills. Go on to the next room, and put your abilities to the test!',
     [new GymBadgeRequirement(BadgeEnums.Elite_Will)]
 );
-gymList['Elite Bruno2'] = new Gym(
-    'Bruno2',
-    'Elite Bruno2',
+gymList['Elite Bruno (Johto)'] = new Gym(
+    'Bruno (Johto)',
+    'Elite Bruno (Johto)',
     [
         new GymPokemon('Hitmontop', 245330, 42),
         new GymPokemon('Hitmonlee', 248300, 42),
@@ -412,7 +412,7 @@ gymList['Elite Karen'] = new Gym(
     [new GymBadgeRequirement(BadgeEnums.Elite_Bruno2)]
 );
 gymList['Champion Lance'] = new Gym(
-    'Lance2',
+    'Lance (Johto)',
     'Champion Lance',
     [
         new GymPokemon('Gyarados', 258300, 44),

--- a/src/scripts/towns/PokemonLeague.ts
+++ b/src/scripts/towns/PokemonLeague.ts
@@ -47,7 +47,7 @@ TownList['Indigo Plateau Johto'] = new PokemonLeague(
     GameConstants.Region.johto,
     [new RouteKillRequirement(10, GameConstants.Region.johto, 27)],
     [indigoPlateauShop],
-    ['Elite Will', 'Elite Koga', 'Elite Bruno2', 'Elite Karen', 'Champion Lance']
+    ['Elite Will', 'Elite Koga', 'Elite Bruno (Johto)', 'Elite Karen', 'Champion Lance']
 );
 (<PokemonLeague>TownList['Indigo Plateau Johto']).setupGymTowns();
 


### PR DESCRIPTION
Fixed display/identification issue for Johto League to prevent "Bruno2", "Koga2", and "Lance2" from being reported as bugs.