### PR TITLE
fix (lag): Use a copy of caughtPokemon for sorting

### DIFF
--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -75,9 +75,6 @@ class Party implements Feature {
 
         App.game.logbook.newLog(LogBookTypes.CAUGHT, `You have captured ${GameHelper.anOrA(pokemon.name)} ${pokemon.name}!`);
         this._caughtPokemon.push(pokemon);
-
-        // Trigger sorting update of PokemonList UI
-        PartyController.sortList();
     }
 
     public gainExp(exp = 0, level = 1, trainer = false) {

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -39,12 +39,9 @@ class PartyController {
     }
 
     static getSortedList = ko.pureComputed(() => {
-        return App.game.party._caughtPokemon.sort(PartyController.compareBy(Settings.getSetting('partySort').observableValue(), Settings.getSetting('partySortDirection').observableValue()));
+        const list = [...App.game.party.caughtPokemon];
+        return list.sort(PartyController.compareBy(Settings.getSetting('partySort').observableValue(), Settings.getSetting('partySortDirection').observableValue()));
     }).extend({ rateLimit: 500 });
-
-    static sortList() {
-        App.game.party._caughtPokemon.sort(PartyController.compareBy(Settings.getSetting('partySort').observableValue(), Settings.getSetting('partySortDirection').observableValue()));
-    }
 
     public static compareBy(option: SortOptions, direction: boolean): (a: PartyPokemon, b: PartyPokemon) => number {
         return function (a, b) {


### PR DESCRIPTION
This change makes things run smoother for me while sorting by attack, could do with testing from other people though.

The difference isn't coming through in gifs very well, but here is a comparison with some auto defeat hacks
```js
setInterval(() => {if (Battle.enemyPokemon()?.isAlive()) Battle.defeatPokemon()}, 10)
```
[Before](https://imgur.com/FUz4rNy)

[After](https://imgur.com/ILvS3jS)