### PR TITLE
fix (lag): Prevent knockout updating damage calculator when the modal is hidden

### DIFF
--- a/src/components/damageCalculatorModal.html
+++ b/src/components/damageCalculatorModal.html
@@ -15,6 +15,7 @@
 aria-labelledby="damageCalculatorModalLabel" aria-hidden="true">
 <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">
     <div class="modal-content">
+        <!-- ko if: modalUtils.observableState['damageCalculatorModal'] === 'show' -->
         <div class="modal-header">
             <h5 class="modal-title" id="damageCalculatorModalLabel">Damage Calculator</h5>
             <button type="button" class="btn btn-info"
@@ -108,6 +109,7 @@ aria-labelledby="damageCalculatorModalLabel" aria-hidden="true">
        <div class="modal-footer">
             <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
        </div>
+       <!-- /ko -->
    </div>
 </div>
 </div>

--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -35,6 +35,7 @@ import LevelType, { levelRequirements } from './party/LevelType';
 import WalletClasses from './wallet/inject';
 import GenericProxy from './utilities/GenericProxy';
 import { SpriteCredits, CodeCredits } from './Credits';
+import * as modalUtils from './utilities/Modal';
 
 Object.assign(<any>window, {
     SaveSelector,
@@ -76,4 +77,5 @@ Object.assign(<any>window, {
     GenericProxy,
     SpriteCredits,
     CodeCredits,
+    modalUtils,
 });

--- a/src/modules/utilities/Modal.ts
+++ b/src/modules/utilities/Modal.ts
@@ -1,0 +1,37 @@
+import type { Observable } from 'knockout';
+
+enum ModalState {
+    'hidden' = 'hidden',
+    'hide' = 'hide',
+    'show' = 'show',
+}
+
+function createStateObservable(modalID: string): Observable<ModalState> {
+    const obs = ko.observable(ModalState.hidden);
+
+    $(document).ready(() => {
+        const $modal = $(`#${modalID}`);
+        if (!$modal.length) {
+            console.error(`Modal ${modalID} not found; cannot create state observable`);
+        } else {
+            obs(ModalState[$modal.hasClass('show') ? 'show' : 'hidden']);
+            Object.values(ModalState).forEach((st) => {
+                $modal.on(`${st}.bs.modal`, () => obs(st));
+            });
+        }
+    });
+
+    return obs;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const observableState: Record<string, ModalState> = new Proxy({}, {
+    get(target, modalID: string) {
+        if (!target[modalID]) {
+            // eslint-disable-next-line no-param-reassign
+            target[modalID] = createStateObservable(modalID);
+        }
+
+        return target[modalID]();
+    },
+});


### PR DESCRIPTION
When putting pokemon into eggs/queue, there seem to be two main causes of lag:
1. DamageCalculator updating things
2. Achievements for total damage updating their progress

This deals with the first case, and will be fairly easy to use for other modals if they need it.