### PR TITLE
fix (lag): Make Achievements use a single attack observable for common parameters

### DIFF
--- a/src/scripts/achievements/AttackRequirement.ts
+++ b/src/scripts/achievements/AttackRequirement.ts
@@ -1,13 +1,17 @@
 ///<reference path="AchievementRequirement.ts"/>
 
 class AttackRequirement extends AchievementRequirement {
+    private static attack = ko.pureComputed(() => {
+        return App.game.party.calculatePokemonAttack(PokemonType.None, PokemonType.None, true);
+    }).extend({ rateLimit: 500 })
+
     constructor(value: number, option: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
         super(value, option, GameConstants.AchievementType['Attack']);
     }
 
     public getProgress() {
         // Calculate real total attack regardless of current region
-        const currentAttack = App.game.party.calculatePokemonAttack(PokemonType.None, PokemonType.None, true);
+        const currentAttack = AttackRequirement.attack();
         return Math.min(currentAttack, this.requiredValue);
     }
 

--- a/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
@@ -26,7 +26,7 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
     }
 
     private static calcReward(amount: number, dungeon: string): number {
-        const playerDamage = App.game.party.calculateClickAttack() + (App.game.party.calculatePokemonAttack() / GameConstants.QUEST_CLICKS_PER_SECOND);
+        const playerDamage = App.game.party.calculateClickAttack() + (App.game.party.pokemonAttackObservable() / GameConstants.QUEST_CLICKS_PER_SECOND);
         const attacksToDefeatPokemon = Math.ceil(Math.min(4, dungeonList[dungeon].baseHealth / playerDamage));
         const averageTilesToBoss = 13;
         const attacksToCompleteDungeon = attacksToDefeatPokemon * averageTilesToBoss;

--- a/src/scripts/quests/questTypes/DefeatGymQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatGymQuest.ts
@@ -29,7 +29,7 @@ class DefeatGymQuest extends Quest implements QuestInterface {
         if (gym instanceof Champion) {
             gym.setPokemon(player.starter());
         }
-        const playerDamage = App.game.party.calculatePokemonAttack();
+        const playerDamage = App.game.party.pokemonAttackObservable();
         let attacksToWin = 0;
         for (const pokemon of gym.pokemons) {
             attacksToWin += Math.ceil( Math.min( 4, pokemon.maxHealth / Math.max(1, playerDamage) ) );

--- a/src/scripts/quests/questTypes/DefeatPokemonsQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatPokemonsQuest.ts
@@ -24,7 +24,7 @@ class DefeatPokemonsQuest extends Quest implements QuestInterface {
     }
 
     private static calcReward(killsNeeded: number, route: number, region: number): number {
-        const attacksPerPokemon = Math.ceil(Math.min(4, PokemonFactory.routeHealth(route, region) / Math.max(1, App.game.party.calculatePokemonAttack())));
+        const attacksPerPokemon = Math.ceil(Math.min(4, PokemonFactory.routeHealth(route, region) / Math.max(1, App.game.party.pokemonAttackObservable())));
         const reward = Math.ceil(GameConstants.DEFEAT_POKEMONS_BASE_REWARD * attacksPerPokemon * killsNeeded);
         return super.randomizeReward(reward);
     }


### PR DESCRIPTION
Part 2 of #1605

A few achievements are creating identical observables that all want to run calculatePokemonAttack with the same parameters. This makes them use a single common observable instead.

According to firefox performance analysis there are still some lag spikes when putting pokemon in eggs, but I can't decipher where the remaining lag is coming from with the information it gives me.

With these two PRs, I'm not noticing any breeding modal lag while auto-defeating every 200ms and sorting by attack.

Leaving them as separate PRs because they each have a noticeable lag improvement on their own and I don't want to prevent one because of issues in the other.