### PR TITLE
Shop amount reset setting

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -30,6 +30,7 @@
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('backgroundImage')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('breedingDisplay')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('shopButtons')}"></tr>
+                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('resetShopAmountOnPurchase')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('eggAnimation')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('hideHatchery')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('farmDisplay')}"></tr>
@@ -68,7 +69,6 @@
                             <tbody>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('disableAutoDownloadBackupSaveOnUpdate')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('useWebWorkerForGameTicks')}"></tr>
-                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('resetShopAmountOnPurchase')}"></tr>
                             </tbody>
                         </table>
                         <div class="btn-group btn-block">
@@ -99,7 +99,7 @@
 
 <script type="text/html" id="BooleanSettingTemplate">
     <td class="p-2">
-        <label class="m-0" data-bind="attr: { for: 'checkbox-' + $data.name }, text: $data.displayName">
+        <label class="m-0" data-bind="attr: { for: 'checkbox-' + $data.name }, text: `${$data.displayName}:`">
             setting name
         </label>
     </td>
@@ -120,7 +120,7 @@
 
 
 <script type="text/html" id="ColorChoiceSettingTemplate">
-    <td class="p-2" data-bind="text: $data.displayName">setting name</td>
+    <td class="p-2" data-bind="text: `${$data.displayName}:`">setting name</td>
     <td class="p-0" data-bind="style: { background: $data.observableValue },
     tooltip: {
         title: 'Set to white for transparent',

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -68,6 +68,7 @@
                             <tbody>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('disableAutoDownloadBackupSaveOnUpdate')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('useWebWorkerForGameTicks')}"></tr>
+                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('resetShopAmountOnPurchase')}"></tr>
                             </tbody>
                         </table>
                         <div class="btn-group btn-block">

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -99,6 +99,7 @@ Settings.add(new CssVariableSetting('completed', 'Map Color Completed Location',
 // Other settings
 Settings.add(new BooleanSetting('disableAutoDownloadBackupSaveOnUpdate', 'Disable automatic backup save downloading when game updates', false));
 Settings.add(new BooleanSetting('useWebWorkerForGameTicks', 'Make use of web workers for game ticks (more consistent game speed)', true));
+Settings.add(new BooleanSetting('resetShopAmountOnPurchase', 'Reset buy quantity after each purchase', true));
 
 // Sound settings
 Object.values(NotificationConstants.NotificationSound).forEach((sound) => {

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -57,6 +57,7 @@ Settings.add(new Setting<string>('shopButtons', 'Shop amount buttons:',
         new SettingOption('×10, ÷10', 'multiplication'),
     ],
     'original'));
+Settings.add(new BooleanSetting('resetShopAmountOnPurchase', 'Reset buy quantity after each purchase', true));
 Settings.add(new BooleanSetting('showCurrencyGainedAnimation', 'Show currency gained animation', true));
 Settings.add(new BooleanSetting('hideChallengeRelatedModules', 'Hide challenge related modules', false));
 Settings.add(new Setting<string>('backgroundImage', 'Background image:',
@@ -99,7 +100,6 @@ Settings.add(new CssVariableSetting('completed', 'Map Color Completed Location',
 // Other settings
 Settings.add(new BooleanSetting('disableAutoDownloadBackupSaveOnUpdate', 'Disable automatic backup save downloading when game updates', false));
 Settings.add(new BooleanSetting('useWebWorkerForGameTicks', 'Make use of web workers for game ticks (more consistent game speed)', true));
-Settings.add(new BooleanSetting('resetShopAmountOnPurchase', 'Reset buy quantity after each purchase', true));
 
 // Sound settings
 Object.values(NotificationConstants.NotificationSound).forEach((sound) => {

--- a/src/scripts/shop/ShopHandler.ts
+++ b/src/scripts/shop/ShopHandler.ts
@@ -23,7 +23,10 @@ class ShopHandler {
     public static buyItem() {
         const item: Item = this.shopObservable().items[ShopHandler.selected()];
         item.buy(this.amount());
-        ShopHandler.resetAmount();
+
+        if (Settings.getSetting('resetShopAmountOnPurchase').observableValue()) {
+            ShopHandler.resetAmount();
+        }
     }
 
     public static resetAmount() {


### PR DESCRIPTION
Adds a setting to not reset the shop amount after a purchase.
Default behaviour stays the same as is (reset on purchase)