### PR TITLE
Prevent shoveling fully grown crops

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1129,6 +1129,10 @@ class Farming implements Feature {
         if (plot.isEmpty()) {
             return;
         }
+        if (plot.stage() == PlotStage.Berry){
+            this.harvest(index);
+            return;
+        }
         if (this.shovelAmt() <= 0) {
             return;
         }

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1129,7 +1129,7 @@ class Farming implements Feature {
         if (plot.isEmpty()) {
             return;
         }
-        if (plot.stage() == PlotStage.Berry){
+        if (plot.stage() == PlotStage.Berry) {
             this.harvest(index);
             return;
         }


### PR DESCRIPTION
Fully grown crops are instead harvested as if the shovel were not selected.