### PR TITLE
Fix hatchery sorting, Separate hatchery sort from party sorting

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -91,7 +91,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                             </div>
                         </div>
                         <div class="form-row collapse" id="breeding-sort">
-                            <div class="form-group col" data-bind="with: Settings.getSetting('partySort')">
+                            <div class="form-group col" data-bind="with: Settings.getSetting('hatcherySort')">
                                 <label>Sort</label>
                                 <div class="input-group">
                                     <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])"
@@ -99,10 +99,10 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                         <option data-bind="text: $data.text, value: $data.value"></option>
                                     </select>
                                     <div class="input-group-append bg-primary text-light">
-                                        <label for="hatcheryPartySortDirection" class="clickable m-0 pl-2 pr-2" style="font-size: 22px;" data-bind="text: Settings.getSetting('partySortDirection').observableValue() ? '⥄' : '⥂'">⥂</label>
-                                        <input id="hatcheryPartySortDirection" style="vertical-align: middle" class="hidden" type='checkbox'
-                                            data-bind="checked: Settings.getSetting('partySortDirection').observableValue()"
-                                            onchange="Settings.setSettingByName('partySortDirection', this.checked)"/>
+                                        <label for="hatcherySortDirection" class="clickable m-0 pl-2 pr-2" style="font-size: 22px;" data-bind="text: Settings.getSetting('hatcherySortDirection').observableValue() ? '⥄' : '⥂'">⥂</label>
+                                        <input id="hatcherySortDirection" style="vertical-align: middle" class="hidden" type='checkbox'
+                                            data-bind="checked: Settings.getSetting('hatcherySortDirection').observableValue()"
+                                            onchange="Settings.setSettingByName('hatcherySortDirection', this.checked)"/>
                                     </div>
                                 </div>
                             </div>
@@ -114,7 +114,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                             Unfortunately, you don't have any Pokémon of level 100 to breed.
                         </p>
                         <!-- ko if: App.game.party.hasMaxLevelPokemon() -->
-                        <ul class="row justify-content-center p-0" data-bind="foreach: App.game.party.caughtPokemon">
+                        <ul class="row justify-content-center p-0" data-bind="foreach: PartyController.getHatcherySortedList()">
                             <li class="eggSlot col-sm-4 col-md-3 col-lg-2 pokedexEntry text-nowrap" data-bind="visible: BreedingController.visible($data), style:{background: PokedexHelper.getBackgroundColors($data.name)}, class: App.game.breeding.hasFreeEggSlot() || App.game.breeding.hasFreeQueueSlot() ? '' : 'disabled'">
                                 <span style="top: 0; border-top-left-radius: 6px; border-top-right-radius: 6px;" data-bind="text: $data.name">name</span>
                                 <div data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)" style="position: absolute;right: 0px;top: 0px;">✨</div>

--- a/src/components/pokemonSelectorModal.html
+++ b/src/components/pokemonSelectorModal.html
@@ -1,6 +1,7 @@
 <div class="modal noselect fade" id="pokemonSelectorModal" tabindex="-1" role="dialog" aria-labelledby="pokemonSelectorModal">
     <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-sm" role="document">
         <div class="modal-content">
+            <!-- ko if: modalUtils.observableState['pokemonSelectorModal'] === 'show' -->
             <div class="modal-header bg-dark text-light" style='justify-content: space-around;'>
                 <h5 class="modal-title text-light">Select a Pokémon</h5>&nbsp;
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -30,16 +31,16 @@
                       data-trigger="hover">
                     </button>
                   </div>
-                  <div class="input-group" data-bind="with: Settings.getSetting('partySort')">
+                  <div class="input-group" data-bind="with: Settings.getSetting('proteinSort')">
                       <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])"
                           data-bind="foreach: $data.options, attr: {name}, selectedOptions: [$data.observableValue()]">
                           <option data-bind="text: $data.text, value: $data.value"></option>
                       </select>
                       <div class="input-group-append bg-primary text-light">
-                          <label for="hatcheryPartySortDirection" class="clickable m-0 pl-2 pr-2" style="font-size: 22px;" data-bind="text: Settings.getSetting('partySortDirection').observableValue() ? '⥄' : '⥂'">⥂</label>
-                          <input id="hatcheryPartySortDirection" style="vertical-align: middle" class="hidden" type='checkbox'
-                              data-bind="checked: Settings.getSetting('partySortDirection').observableValue()"
-                              onchange="Settings.setSettingByName('partySortDirection', this.checked)"/>
+                          <label for="proteinSortDirection" class="clickable m-0 pl-2 pr-2" style="font-size: 22px;" data-bind="text: Settings.getSetting('proteinSortDirection').observableValue() ? '⥄' : '⥂'">⥂</label>
+                          <input id="proteinSortDirection" style="vertical-align: middle" class="hidden" type='checkbox'
+                              data-bind="checked: Settings.getSetting('proteinSortDirection').observableValue()"
+                              onchange="Settings.setSettingByName('proteinSortDirection', this.checked)"/>
                       </div>
                   </div>
                 </div>
@@ -51,7 +52,7 @@
                       <th class="text-center bg-dark align-middle">Attack Bonus</th>
                     </tr>
                   </thead>
-                  <tbody data-bind="foreach: App.game.party.caughtPokemon">
+                  <tbody data-bind="foreach: PartyController.getProteinSortedList()">
                     <tr class="clickable" data-bind="click: () => $data.useProtein(VitaminController.getMultiplier()), hidden: $data.breeding">
                       <td class="text-left"><knockout data-bind="text: $data.name"></knockout><sup data-bind="visible: $data.shiny">✨</sup></td>
                       <td class="text-center tight" data-bind="text: $data.proteinsUsed().toLocaleString('en-US')">-</td>
@@ -60,6 +61,7 @@
                   </tbody>
                 </table>
             </div>
+            <!-- /ko -->
         </div>
     </div>
 </div>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -130,6 +130,13 @@ const hatcherySortSettings = Object.keys(SortOptionConfigs).map((opt) => (
 Settings.add(new Setting<number>('hatcherySort', 'Sort:', hatcherySortSettings, SortOptions.id));
 Settings.add(new BooleanSetting('hatcherySortDirection', 'reverse', false));
 
+// Protein Sorting
+const proteinSortSettings = Object.keys(SortOptionConfigs).map((opt) => (
+    new SettingOption<number>(SortOptionConfigs[opt].text, parseInt(opt, 10))
+));
+Settings.add(new Setting<number>('proteinSort', 'Sort:', proteinSortSettings, SortOptions.id));
+Settings.add(new BooleanSetting('proteinSortDirection', 'reverse', false));
+
 // Breeding Filters
 Settings.add(new Setting<string>('breedingCategoryFilter', 'breedingCategoryFilter',
     [],

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -117,13 +117,18 @@ Object.values(NotificationConstants.NotificationSetting).forEach((setting) => {
  */
 
 // Party Sorting
-const sortsettings = Object.keys(SortOptionConfigs).map((opt) => (
+const partySortSettings = Object.keys(SortOptionConfigs).map((opt) => (
     new SettingOption<number>(SortOptionConfigs[opt].text, parseInt(opt, 10))
 ));
-Settings.add(new Setting<number>('partySort', 'Sort:',
-    sortsettings,
-    SortOptions.id));
+Settings.add(new Setting<number>('partySort', 'Sort:', partySortSettings, SortOptions.id));
 Settings.add(new BooleanSetting('partySortDirection', 'reverse', false));
+
+// Hatchery Sorting
+const hatcherySortSettings = Object.keys(SortOptionConfigs).map((opt) => (
+    new SettingOption<number>(SortOptionConfigs[opt].text, parseInt(opt, 10))
+));
+Settings.add(new Setting<number>('hatcherySort', 'Sort:', hatcherySortSettings, SortOptions.id));
+Settings.add(new BooleanSetting('hatcherySortDirection', 'reverse', false));
 
 // Breeding Filters
 Settings.add(new Setting<string>('breedingCategoryFilter', 'breedingCategoryFilter',

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -49,10 +49,10 @@ class PartyController {
     static getHatcherySortedList = ko.pureComputed(() => {
         // If the breeding modal is open, we should sort it.
         if (modalUtils.observableState['breedingModal'] === 'show') {
-            this.hatcherySortedList = [...App.game.party.caughtPokemon];
-            return this.hatcherySortedList.sort(PartyController.compareBy(Settings.getSetting('hatcherySort').observableValue(), Settings.getSetting('hatcherySortDirection').observableValue()));
+            PartyController.hatcherySortedList = [...App.game.party.caughtPokemon];
+            return PartyController.hatcherySortedList.sort(PartyController.compareBy(Settings.getSetting('hatcherySort').observableValue(), Settings.getSetting('hatcherySortDirection').observableValue()));
         }
-        return this.hatcherySortedList;
+        return PartyController.hatcherySortedList;
     }).extend({ rateLimit: 500 });
 
     static getProteinSortedList = ko.pureComputed(() => {

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -55,9 +55,15 @@ class PartyController {
         return PartyController.hatcherySortedList;
     }).extend({ rateLimit: 500 });
 
+
+    private static proteinSortedList = [];
     static getProteinSortedList = ko.pureComputed(() => {
-        const list = [...App.game.party.caughtPokemon];
-        return list.sort(PartyController.compareBy(Settings.getSetting('proteinSort').observableValue(), Settings.getSetting('proteinSortDirection').observableValue()));
+        // If the protein modal is open, we should sort it.
+        if (modalUtils.observableState['pokemonSelectorModal'] === 'show') {
+            PartyController.proteinSortedList = [...App.game.party.caughtPokemon];
+            return PartyController.proteinSortedList.sort(PartyController.compareBy(Settings.getSetting('proteinSort').observableValue(), Settings.getSetting('proteinSortDirection').observableValue()));
+        }
+        return PartyController.proteinSortedList;
     }).extend({ rateLimit: 500 });
 
     public static compareBy(option: SortOptions, direction: boolean): (a: PartyPokemon, b: PartyPokemon) => number {

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -43,6 +43,11 @@ class PartyController {
         return list.sort(PartyController.compareBy(Settings.getSetting('partySort').observableValue(), Settings.getSetting('partySortDirection').observableValue()));
     }).extend({ rateLimit: 500 });
 
+    static getHatcherySortedList = ko.pureComputed(() => {
+        const list = [...App.game.party.caughtPokemon];
+        return list.sort(PartyController.compareBy(Settings.getSetting('hatcherySort').observableValue(), Settings.getSetting('hatcherySortDirection').observableValue()));
+    }).extend({ rateLimit: 1000 });
+
     public static compareBy(option: SortOptions, direction: boolean): (a: PartyPokemon, b: PartyPokemon) => number {
         return function (a, b) {
             let res, dir = (direction) ? -1 : 1;

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -1,3 +1,5 @@
+declare const modalUtils: { observableState: typeof observableState };
+
 class PartyController {
 
     static getCaughtStatusByName(name: PokemonNameType): CaughtStatus {
@@ -43,9 +45,14 @@ class PartyController {
         return list.sort(PartyController.compareBy(Settings.getSetting('partySort').observableValue(), Settings.getSetting('partySortDirection').observableValue()));
     }).extend({ rateLimit: 500 });
 
+    private static hatcherySortedList = [];
     static getHatcherySortedList = ko.pureComputed(() => {
-        const list = [...App.game.party.caughtPokemon];
-        return list.sort(PartyController.compareBy(Settings.getSetting('hatcherySort').observableValue(), Settings.getSetting('hatcherySortDirection').observableValue()));
+        // If the breeding modal is open, we should sort it.
+        if (modalUtils.observableState['breedingModal'] === 'show') {
+            this.hatcherySortedList = [...App.game.party.caughtPokemon];
+            return this.hatcherySortedList.sort(PartyController.compareBy(Settings.getSetting('hatcherySort').observableValue(), Settings.getSetting('hatcherySortDirection').observableValue()));
+        }
+        return this.hatcherySortedList;
     }).extend({ rateLimit: 500 });
 
     static getProteinSortedList = ko.pureComputed(() => {

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -48,6 +48,11 @@ class PartyController {
         return list.sort(PartyController.compareBy(Settings.getSetting('hatcherySort').observableValue(), Settings.getSetting('hatcherySortDirection').observableValue()));
     }).extend({ rateLimit: 1000 });
 
+    static getProteinSortedList = ko.pureComputed(() => {
+        const list = [...App.game.party.caughtPokemon];
+        return list.sort(PartyController.compareBy(Settings.getSetting('proteinSort').observableValue(), Settings.getSetting('proteinSortDirection').observableValue()));
+    }).extend({ rateLimit: 1000 });
+
     public static compareBy(option: SortOptions, direction: boolean): (a: PartyPokemon, b: PartyPokemon) => number {
         return function (a, b) {
             let res, dir = (direction) ? -1 : 1;

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -46,12 +46,12 @@ class PartyController {
     static getHatcherySortedList = ko.pureComputed(() => {
         const list = [...App.game.party.caughtPokemon];
         return list.sort(PartyController.compareBy(Settings.getSetting('hatcherySort').observableValue(), Settings.getSetting('hatcherySortDirection').observableValue()));
-    }).extend({ rateLimit: 1000 });
+    }).extend({ rateLimit: 500 });
 
     static getProteinSortedList = ko.pureComputed(() => {
         const list = [...App.game.party.caughtPokemon];
         return list.sort(PartyController.compareBy(Settings.getSetting('proteinSort').observableValue(), Settings.getSetting('proteinSortDirection').observableValue()));
-    }).extend({ rateLimit: 1000 });
+    }).extend({ rateLimit: 500 });
 
     public static compareBy(option: SortOptions, direction: boolean): (a: PartyPokemon, b: PartyPokemon) => number {
         return function (a, b) {


### PR DESCRIPTION
Fixed hatchery sorting.
Hatchery can now be sorted independently of party.

@Aegyo
~~Any chance you could take a look at not sorting while the modal is hidden?
I tried using the `modalUtils.observableState['breedingModal'] === 'show'` but it just caused a ton of lag when trying to re-open the modal.~~

Fixes #1647