### PR TITLE
Add image selection for Trainer and Background on Profile

### DIFF
--- a/src/components/profileBackgroundModal.html
+++ b/src/components/profileBackgroundModal.html
@@ -1,0 +1,24 @@
+<div class="modal noselect fade" id="profileBackgroundModal" tabindex="-1" role="dialog" aria-labelledby="profileBackgroundModalLabel">
+    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-sm" role="document">
+        <div class="modal-content">
+            <div class="modal-header" style='justify-content: space-around;'>
+                <h5 class="modal-title">Select a Background</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <!-- ko foreach: new Array(Profile.MAX_BACKGROUND).fill(0) -->
+                <button style="position: relative; height: 160px; width: 100%;"
+                    data-dismiss='modal'
+                    data-bind='click: () => {
+                        App.game.profile.background($index());
+                        $("#profileBackgroundModal").modal("hide");
+                    },
+                    class: `btn trainer-card trainer-bg-${$index()}`'>
+                </button>
+                <!-- /ko -->
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/components/profileModal.html
+++ b/src/components/profileModal.html
@@ -14,14 +14,6 @@
                         <input autocomplete="off" class="form-control" oninput="App.game.profile.name(this.value)" placeholder="name" data-bind="value: decodeURI(App.game.profile.name())"/>
                     </div>
                     <div class="form-group col-12">
-                        <label>Trainer</label>
-                        <select autocomplete="off" class="custom-select" onchange="App.game.profile.trainer(+this.value)">
-                            <!-- ko foreach: new Array(Profile.MAX_TRAINER).fill(0) -->
-                            <option data-bind="attr: { value: $index(), selected: App.game.profile.trainer() === $index() }, text: `Trainer ${$index()}`">Trainer</option>
-                            <!-- /ko -->
-                        </select>
-                    </div>
-                    <div class="form-group col-12">
                         <label>Pokemon</label>
                         <select autocomplete="off" class="custom-select" onchange="App.game.profile.pokemon(+this.value)">
                             <!-- ko foreach: App.game.party.caughtPokemon -->
@@ -30,18 +22,16 @@
                         </select>
                     </div>
                     <div class="form-group col-12">
-                        <label>Background</label>
-                        <select autocomplete="off" class="custom-select" onchange="App.game.profile.background(+this.value)">
-                            <!-- ko foreach: new Array(Profile.MAX_BACKGROUND).fill(0) -->
-                            <option data-bind="attr: { value: $index(), selected: App.game.profile.background() === $index() }, text: `Background ${$index()}`">Background</option>
-                            <!-- /ko -->
-                        </select>
-                    </div>
-                    <div class="form-group col-12">
                         <label>Text Color</label>
                         <p class="p-0" data-bind="style: { background: App.game.profile.textColor() }">
                           <label style="width:100%; min-height: 28px; padding:0px; margin: 0px;"><input style="opacity: 0;" type="color" data-bind="value: App.game.profile.textColor"/></label>
                         </p>
+                    </div>
+                    <div class="form-group col-12">
+                        <a class="btn btn-block btn-primary text-left" href="#profileTrainerModal" data-toggle="modal">Trainer <img style="position:absolute; right: 10px;" data-bind="attr: { src: `assets/images/profile/trainer-${App.game.profile.trainer() || 0}.png` }"/></a>
+                    </div>
+                    <div class="form-group col-12">
+                        <a class="btn btn-block btn-primary text-left" href="#profileBackgroundModal" data-toggle="modal">Background <knockout style="position:absolute; right: 10px;" data-bind="text: `#${App.game.profile.background()}`"></knockout></a>
                     </div>
                 </div>
                 <div id="profile-trainer-card"></div>

--- a/src/components/profileTrainerModal.html
+++ b/src/components/profileTrainerModal.html
@@ -1,0 +1,24 @@
+<div class="modal noselect fade" id="profileTrainerModal" tabindex="-1" role="dialog" aria-labelledby="profileTrainerModalLabel">
+    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-sm" role="document">
+        <div class="modal-content">
+            <div class="modal-header" style='justify-content: space-around;'>
+                <h5 class="modal-title">Select a Trainer</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <!-- ko foreach: new Array(Profile.MAX_TRAINER).fill(0) -->
+                <button style="position: relative;" class='btn'
+                    data-dismiss='modal'
+                    data-bind='click: () => {
+                        App.game.profile.trainer($index());
+                        $("#profileTrainerModal").modal("hide");
+                    },'>
+                    <img data-bind="attr: { src: `assets/images/profile/trainer-${$index()}.png` }"/>
+                </button>
+                <!-- /ko -->
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/index.html
+++ b/src/index.html
@@ -104,6 +104,8 @@
 
 <!-- Show profile modal -->
 @import "profileModal.html"
+@import "profileTrainerModal.html"
+@import "profileBackgroundModal.html"
 
 <!-- Show keyitems modal-->
 @import "itemModal.html"


### PR DESCRIPTION
Allow players to select a trainer or background image by clicking an image rather than a dropdown of numbers.

Closes #1646 

![image](https://user-images.githubusercontent.com/7288322/142334042-14fcab52-b2ac-4833-8a24-c7aeaadde31f.png)
![image](https://user-images.githubusercontent.com/7288322/142334048-8579c9a6-0c59-44c4-8bfe-09f6a3a0c99f.png)
![image](https://user-images.githubusercontent.com/7288322/142334055-ab1a24db-538c-4b4b-b90e-75ea68b9af82.png)
