### PR TITLE
Change several Johto requirements

### DIFF
--- a/src/scripts/gym/Gym.ts
+++ b/src/scripts/gym/Gym.ts
@@ -311,7 +311,10 @@ gymList['Ecruteak City'] = new Gym(
     BadgeEnums.Fog,
     1500,
     'I\'m not good enough yet... All right. This Badge is yours.',
-    [new GymBadgeRequirement(BadgeEnums.Plain)]
+    [new GymBadgeRequirement(BadgeEnums.Plain)],
+    () => {
+        App.game.quests.getQuestLine('Team Rocket').beginQuest();
+    }
 );
 gymList['Cianwood City'] = new Gym(
     'Chuck',
@@ -349,10 +352,7 @@ gymList['Mahogany Town'] = new Gym(
     BadgeEnums.Glacier,
     4000,
     'Ah, I am impressed by your prowess. With your strong will, I know you will overcome all life\'s obstacles. You are worthy of this Badge!',
-    [new RouteKillRequirement(10, GameConstants.Region.johto, 43)],
-    () => {
-        App.game.quests.getQuestLine('Radio Tower Takeover').beginQuest();
-    }
+    [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Team Rockets Hideout'))]
 );
 gymList['Blackthorn City'] = new Gym(
     'Clair',

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -237,7 +237,7 @@ class QuestLineHelper {
     }
 
     public static createRocketjohtoQuestLine() {
-        const RocketjohtoQuestLine = new QuestLine('Radio Tower Takeover', 'Team Rocket is up to no good again!');
+        const RocketjohtoQuestLine = new QuestLine('Team Rocket', 'Team Rocket is up to no good again!');
 
         const clearTeamRocketHideout = new CustomQuest(1, 0, 'Clear the Team Rockets Hideout dungeon in Mahogany Town', () => App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Team Rockets Hideout')](), 0);
         RocketjohtoQuestLine.addQuest(clearTeamRocketHideout);

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -560,7 +560,10 @@ TownList['Mahogany Town'] = new Town(
     'Mahogany Town',
     GameConstants.Region.johto,
     {
-        requirements: [new RouteKillRequirement(10, GameConstants.Region.johto, 42)],
+        requirements: [new OneFromManyRequirement([
+            new RouteKillRequirement(10, GameConstants.Region.johto, 42),
+            new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Mt Mortar')),
+        ])],
         shops: [MahoganyTownShop],
         dungeon: dungeonList['Team Rockets Hideout'],
         npcs: [MahoganySouvenirShopAttendant],
@@ -620,20 +623,20 @@ TownList['Whirl Islands'] = new DungeonTown(
 TownList['Mt Mortar'] = new DungeonTown(
     'Mt Mortar',
     GameConstants.Region.johto,
-    [new RouteKillRequirement(10, GameConstants.Region.johto, 42)]
+    [new RouteKillRequirement(10, GameConstants.Region.johto, 37)]
 );
 TownList['Team Rockets Hideout'] = new DungeonTown(
     'Team Rockets Hideout',
+    GameConstants.Region.johto,
+    [new RouteKillRequirement(10, GameConstants.Region.johto, 43)]
+);
+TownList['Radio Tower'] = new DungeonTown(
+    'Radio Tower',
     GameConstants.Region.johto,
     [
         new GymBadgeRequirement(BadgeEnums.Mineral),
         new GymBadgeRequirement(BadgeEnums.Glacier),
     ]
-);
-TownList['Radio Tower'] = new DungeonTown(
-    'Radio Tower',
-    GameConstants.Region.johto,
-    [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Team Rockets Hideout'))]
 );
 TownList['Ice Path'] = new DungeonTown(
     'Ice Path',

--- a/src/scripts/wildBattle/Routes.ts
+++ b/src/scripts/wildBattle/Routes.ts
@@ -396,7 +396,6 @@ Routes.add(new RegionRoute(
         water: ['Tentacool', 'Tentacruel', 'Krabby', 'Magikarp', 'Staryu', 'Corsola', 'Kingler'],
     }),
     [
-
         new RouteKillRequirement(10, GameConstants.Region.johto, 39),
         new GymBadgeRequirement(BadgeEnums.Fog),
     ]
@@ -424,7 +423,15 @@ Routes.add(new RegionRoute(
         water: ['Magikarp', 'Poliwag'],
         headbutt: ['Venonat', 'Exeggcute', 'Hoothoot', 'Pineco'],
     }),
-    [new RouteKillRequirement(10, GameConstants.Region.johto, 42)]
+    [
+        new OneFromManyRequirement([
+            new MultiRequirement([
+                new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Mt Mortar')),
+                new GymBadgeRequirement(BadgeEnums.Fog),
+            ]),
+            new RouteKillRequirement(10, GameConstants.Region.johto, 42)
+        ]),
+    ],
 ));
 Routes.add(new RegionRoute(
     'Johto Route 44', GameConstants.Region.johto, 44,

--- a/src/scripts/wildBattle/Routes.ts
+++ b/src/scripts/wildBattle/Routes.ts
@@ -429,7 +429,7 @@ Routes.add(new RegionRoute(
                 new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Mt Mortar')),
                 new GymBadgeRequirement(BadgeEnums.Fog),
             ]),
-            new RouteKillRequirement(10, GameConstants.Region.johto, 42)
+            new RouteKillRequirement(10, GameConstants.Region.johto, 42),
         ]),
     ],
 ));

--- a/src/scripts/wildBattle/Routes.ts
+++ b/src/scripts/wildBattle/Routes.ts
@@ -431,7 +431,7 @@ Routes.add(new RegionRoute(
             ]),
             new RouteKillRequirement(10, GameConstants.Region.johto, 42),
         ]),
-    ],
+    ]
 ));
 Routes.add(new RegionRoute(
     'Johto Route 44', GameConstants.Region.johto, 44,


### PR DESCRIPTION
I got the order of events wrong when adding the Team Rocket dungeons. Hideout before Pryce. You can't even enter Pryce's gym before doing the Hideout. Some dude blocks the way. So the order is now route 43, Hideout, Pryce(+ Jasmine), Radio Tower. 43 first because I am counting Lake of Rage as part of 43 and the red Gyarados thing must be done before Hideout.
Radio Tower now requires Mineral+Glacier.

I have also changed other things for the sake of why not.
You see, in the gen 2 games you can walk all the way up to Lake of Rage before beating Morty. You can't actually go into the lake, because that requires surf, but you can walk up to the shoreline if you want. This is possible because you can avoid the water on route 42 by going through Mt Mortar. You can enter Mt Mortar before encountering any water (or grass). SO:

Mt Mortar now requires 37, same as Ecruteak.
Mahogany now requires 42 OR Mt Mortar.
43 is special, because like I said before I count Lake of Rage as part of 43, which requires surf, so
Route 43 now requires (Mt Mortar AND Fog badge) OR route 42. 42 requires Fog as usual so all good there.

As mentioned above the Mahogany Gym now requires Hideout and Hideout requires 43, so in the end you can now get to Mahogany early and... do nothing. I guess you can now get Upgrade early. Yay! Doesn't actually change much, but the option is there if you want. I didn't touch Mt Mortar's difficulty at all and it's tuned to be rather difficult for this stage of the game, so if you want to do this you'd better get your grind on.

The quest now starts after Fog badge. I'd love for it to start after route 43, but I don't see a way to start a quest after a route clear and can't be arsed creating one. Fog implies you can clear 43 because surf, so Fog is the quest starter.

I think this is the first instance of a MultiRequirement inside a OneFromManyRequirement. The reverse has happened a couple of times.