### PR TITLE
Roaming Pokémon Berry

### DIFF
--- a/src/modules/multiplier/MultiplierType.ts
+++ b/src/modules/multiplier/MultiplierType.ts
@@ -6,6 +6,7 @@ enum MultiplierType {
     dungeonToken,
     shiny,
     eggStep,
+    roaming,
 }
 
 export default MultiplierType;

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -51,9 +51,11 @@ class Farming implements Feature {
         this.externalAuras[AuraType.Attract] = ko.observable<number>(1);
         this.externalAuras[AuraType.Egg] = ko.observable<number>(1);
         this.externalAuras[AuraType.Shiny] = ko.observable<number>(1);
+        this.externalAuras[AuraType.Roaming] = ko.observable<number>(1);
 
         this.multiplier.addBonus('shiny', () => this.externalAuras[AuraType.Shiny]());
         this.multiplier.addBonus('eggStep', () => this.externalAuras[AuraType.Egg]());
+        this.multiplier.addBonus('roaming', () => this.externalAuras[AuraType.Roaming]());
 
         this.highestUnlockedBerry = ko.pureComputed(() => {
             for (let i = GameHelper.enumLength(BerryType) - 2; i >= 0; i--) {
@@ -364,7 +366,7 @@ class Farming implements Feature {
             [
                 'The cluster of drupelets that make up this Berry pop rhythmically if the Berry is handled roughly.',
                 'The sound of these Berries attracts wild Pokémon.',
-            ], undefined, ['Flabébé (Yellow)']);
+            ], new Aura(AuraType.Roaming, [1.005, 1.01, 1.015]), ['Flabébé (Yellow)']);
         this.berryData[BerryType.Rowap]     = new Berry(BerryType.Rowap,    [5760, 9000, 14040, 21240, 42480],
             1, 0.05, 2900, 20,
             [10, 0, 0, 0, 40], BerryColor.Blue,
@@ -990,6 +992,7 @@ class Farming implements Feature {
         this.externalAuras[AuraType.Attract](1);
         this.externalAuras[AuraType.Egg](1);
         this.externalAuras[AuraType.Shiny](1);
+        this.externalAuras[AuraType.Roaming](1);
         this.plotList.forEach(plot => plot.clearAuras());
 
         // Handle Boost Auras first

--- a/src/scripts/farming/aura/Aura.ts
+++ b/src/scripts/farming/aura/Aura.ts
@@ -20,6 +20,7 @@ class Aura {
             case AuraType.Attract:
             case AuraType.Egg:
             case AuraType.Shiny:
+            case AuraType.Roaming:
                 const currentMultiplier = App.game.farming.externalAuras[this.auraType]();
                 App.game.farming.externalAuras[this.auraType](currentMultiplier * multiplier);
                 break;

--- a/src/scripts/farming/aura/AuraType.ts
+++ b/src/scripts/farming/aura/AuraType.ts
@@ -8,4 +8,5 @@ enum AuraType {
     Shiny,
     Death,
     Boost,
+    Roaming,
 }

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -199,11 +199,12 @@ class PokemonFactory {
         return true;
     }
 
-    private static roamingChance(maxRoute: number, minRoute: number, curRoute: RegionRoute, region: GameConstants.Region, max = GameConstants.ROAMING_MAX_CHANCE, min = GameConstants.ROAMING_MIN_CHANCE) {
+    private static roamingChance(maxRoute: number, minRoute: number, curRoute: RegionRoute, region: GameConstants.Region, max = GameConstants.ROAMING_MAX_CHANCE, min = GameConstants.ROAMING_MIN_CHANCE, skipBonus = false) {
+        const bonus = skipBonus ? 1 : App.game.multiplier.getBonus('roaming');
         const routeNum = MapHelper.normalizeRoute(curRoute?.number, region);
         // Check if we should have increased chances on this route (3 x rate)
         const increasedChance = RoamingPokemonList.getIncreasedChanceRouteByRegion(player.region)()?.number == curRoute?.number;
-        const roamingChance = (max + ( (min - max) * (maxRoute - routeNum) / (maxRoute - minRoute))) / (increasedChance ? 3 : 1);
+        const roamingChance = (max + ( (min - max) * (maxRoute - routeNum) / (maxRoute - minRoute))) / ((increasedChance ? 3 : 1) * bonus);
         return Rand.chance(roamingChance);
     }
 


### PR DESCRIPTION
This one might be controversial, so please provide feedback.

Addresses #1668. Roaming Pokémon Aura added, along with bonus to appropriate multiplier files. I did a bit of testing, and it does seem that the changes make an impact on Roamer odds (although more eyes/testing would be ideal). Starf bonuses (0.005, 0.01, 0.015) used instead of Lum, for math reasons below.

Min Roamer Chance (no Jaboca, min route, no increased chance) - 1/8192
Max current Chance (no Jaboca, max route, increased chance) - 1/1365

**Jaboca Modifications**

Max 1.015x Jaboca Roamer Chance (21 Jaboca w/ Lum Boost, max route, increased chance) ~ 1/394 - This seems too high for the absolute max, basically triple what the current max is. Lum boost is OP.

Max 1.03x Jaboca Roamer Chance (21 Jaboca w/ Lum Boost, max route, increased chance) ~ 1/536 - This seems good (maybe even still too high) for the absolute max, more than double what the current max is.

**_Summary_**

Jaboca is a very good berry for a niche reason, it is excellent for Roaming events and region completion. To address NiceDice's concerns with the Farm, I generally agree; the Farm is flawed and needs a rework. I just don't think that means we can't improve upon the flawed concept in the meantime. No devs have picked up the Farm and a rework would likely come after other reworks/rebalancing in progress. As mentioned in the beginning I expect some resistance against this change, Let me know what you all think.