### PR TITLE
Fixup town images breaking when containing a ' character

### DIFF
--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -1,5 +1,5 @@
 <knockout data-bind="if: App.game.gameState === GameConstants.GameState.town">
-<div id="townView" data-bind="style: { backgroundImage: 'url(\'assets/images/towns/' + player.town().name + '.png\')' }"
+<div id="townView" data-bind="style: { backgroundImage: `url('assets/images/towns/${player.town().name.replace(/'/, `\\'`)}.png')` }"
      class="justify-content-center no-gutters no-select">
     <div class="row justify-content-center no-gutters">
         <div class="col no-gutters">


### PR DESCRIPTION
This PR fixes town images being broken if the town name contained a `'` character