### PR TITLE
Change Sinnoh 224 requirement

### DIFF
--- a/src/scripts/wildBattle/Routes.ts
+++ b/src/scripts/wildBattle/Routes.ts
@@ -1009,7 +1009,7 @@ Routes.add(new RegionRoute(
         land: ['Oddish', 'Gloom', 'Bellsprout', 'Weepinbell', 'Beautifly', 'Dustox', 'Roselia', 'Floatzel', 'Gastrodon (east)', 'Chatot'],
         water: ['Tentacruel', 'Magikarp', 'Gyarados', 'Remoraid', 'Octillery', 'Pelipper', 'Luvdisc', 'Gastrodon (east)'],
     }),
-    [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Victory Road Sinnoh'))]
+    [new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion)]
 ));
 Routes.add(new RegionRoute(
     'Sinnoh Route 225', GameConstants.Region.sinnoh, 225,


### PR DESCRIPTION
Turns out that in the main series the exit from Victory Road that leads to 224 is blocked until the player enters the hall of fame.

Changed Sinnoh Route 224 requirement from clearing Victory Road to defeating the Sinnoh champion.