### PR TITLE
A bunch of Alola npcs

### DIFF
--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -2313,6 +2313,35 @@ const AltaroftheSunneandMooneShop = new TownShop([
 
 //Alola NPCs
 
+const IkiKahuna = new NPC('Kahuna Hala', [
+    'Welcome to Alola!',
+    'Here we don\'t have gyms. We have the Island Challenge. On each of our four islands you will complete one or more trials.',
+    'After completing all of an island\'s trials you will battle that island\'s Kahuna in a Grand trial.',
+    'This island only has one trial: Captain Ilima\'s trial in Verdant Cavern. Come back here after clearing that challenge for your Grand trial battle.',
+]);
+const HeaheaCafeOwner = new NPC('Café Owner', [
+    'Akala Island has three trials.',
+    'Lana\'s trial in Brooklet Hill, Kiawe\'s trial in Wela Volcano Park and Mallow\'s trial in Lush Jungle.',
+    'For what it\'s worth, I say don\'t go to any of those places. Too wet, too hot and too... jungly. Why not stay here? Have a coffee! Enjoy the city!',
+    'Or go to Konikoni City down south. You might even meet our Kahuna there!',
+]);
+const RoyalAvenueSpectator = new NPC('Spectator', [
+    'I think batles in the Battle Royal Dome are more like games of chance. But Battle Royals are nothing compared to trying to evolve an Alolan Raichu with a Thunderstone.',
+    'Evolving Pikachu or Exeggute in Alola can result in a new form! Sometimes.',
+]);
+const KonikoniKahuna = new NPC('Kahuna Olivia', [
+    'What do you mean Grand trials are just like gym battles? It\'s a totally different thing!',
+    'Come fight me in our very special and unique brand new Pokémon League and see if you still think our Island Challenge is nothing special!',
+]);
+const MalieKahuna = new NPC('Kahuna Nanu', [
+    'A trial-goer, huh? Figures.',
+    'Just go clear Captain Sophocles\' trial at the Hokulani Observatory and Captain Acerola\'s Trial at the Thrifty Megamart. And take care of those Team Skull punks in Po Town while you\'re at it.',
+    'Then come back here so we can get this Grand trial over with.',
+]);
+const SeafolkCaptain = new NPC('Captain Mina', [
+    'My trial is in this town. Yes, it\'s just a gym battle. However, I want you to clear the trial in Vast Poni Canyon first. It has no Captain, so you\'ll be all on your own. Be careful.',
+    'If you can defeat me you\'ll find our Kahuna on Exeggutor Island.',
+]);
 const AetherParadiseAlolaRoamerNPC = new RoamerNPC('Assistant Branch Chief Wicke', [
     'Some very rare Pokémon have been sighted on {ROUTE_NAME}. I hope we can learn more about them.',
 ], GameConstants.Region.alola);
@@ -2332,6 +2361,7 @@ TownList['Iki Town'] = new Town(
     GameConstants.Region.alola,
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.alola, 1)],
+        npcs: [IkiKahuna],
     }
 );
 TownList['Professor Kukui\'s Lab'] = new Town(
@@ -2362,6 +2392,7 @@ TownList['Heahea City'] = new Town(
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.FightiniumZ)],
         shops: [HeaheaCityShop],
+        npcs: [HeaheaCafeOwner],
     }
 );
 TownList['Paniola Town'] = new Town(
@@ -2378,6 +2409,7 @@ TownList['Royal Avenue'] = new Town(
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.alola, 6)],
         shops: [DepartmentStoreShop],
+        npcs: [RoyalAvenueSpectator],
     }
 );
 TownList['Konikoni City'] = new Town(
@@ -2386,6 +2418,7 @@ TownList['Konikoni City'] = new Town(
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.alola, 9)],
         shops: [KonikoniCityShop],
+        npcs: [KonikoniKahuna],
     }
 );
 TownList['Aether Paradise'] = new Town(
@@ -2404,6 +2437,7 @@ TownList['Malie City'] = new Town(
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_Nihilego)],
         shops: [MalieCityShop],
+        npcs: [MalieKahuna],
     }
 );
 TownList['Tapu Village'] = new Town(
@@ -2420,6 +2454,7 @@ TownList['Seafolk Village'] = new Town(
     {
         requirements: [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Aether Foundation'))],
         shops: [SeafolkVillageShop],
+        npcs: [SeafolkCaptain],
     }
 );
 TownList['Exeggutor Island'] = new Town(

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -2327,7 +2327,7 @@ const HeaheaCafeOwner = new NPC('Café Owner', [
 ]);
 const RoyalAvenueSpectator = new NPC('Spectator', [
     'I think batles in the Battle Royal Dome are more like games of chance. But Battle Royals are nothing compared to trying to evolve an Alolan Raichu with a Thunderstone.',
-    'Evolving Pikachu or Exeggute in Alola can result in a new form! Sometimes.',
+    'Evolving Pikachu or Exeggcute in Alola can result in a new form! Sometimes.',
 ]);
 const KonikoniKahuna = new NPC('Kahuna Olivia', [
     'What do you mean Grand trials are just like gym battles? It\'s a totally different thing!',

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -2321,7 +2321,7 @@ const IkiKahuna = new NPC('Kahuna Hala', [
 ]);
 const HeaheaCafeOwner = new NPC('Café Owner', [
     'Akala Island has three trials.',
-    'Lana\'s trial in Brooklet Hill, Kiawe\'s trial in Wela Volcano Park and Mallow\'s trial in Lush Jungle.',
+    'Captain Lana\'s trial in Brooklet Hill, Captain Kiawe\'s trial in Wela Volcano Park and Captain Mallow\'s trial in Lush Jungle.',
     'For what it\'s worth, I say don\'t go to any of those places. Too wet, too hot and too... jungly. Why not stay here? Have a coffee! Enjoy the city!',
     'Or go to Konikoni City down south. You might even meet our Kahuna there!',
 ]);


### PR DESCRIPTION
Hala in Iki Town to explain the Island Challenge and point to the Verdant Cavern trial. Also points to his own Grand trial.
Café Owner in Heahea to point to the Brooklet Hill, Wela Volcano Park and Lush Jungle trials. Also points to Konikoni for the Grand Trial.
Spectator in Royal Avenue to explain Alolan Raichu and Alolan Exeggutor.
Olivia in Konikoni because lulz. I kinda want to put her at the Pokémon League as well but I don't know how to put an NPC in a Pokémon League.
Nanu in Malie City to point to Hokulani Observatory and Thrifty Megamart trials. Also points to Po Town. Also also points to his own Grand trial.
Mina in Seafolk Village to point to the Vast Poni Canyon trial. Also points to her own trial and the Grand Trial on Exeggutor Island.