### PR TITLE
Make Tabitha rarererer

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1646,10 +1646,10 @@ dungeonList['Mt. Chimney'] = new Dungeon('Mt. Chimney',
     [
         new DungeonTrainer('Team Magma Grunt',
             [new GymPokemon('Numel', 20000, 20)],
-            { weight: 1 }, undefined, '(female)'),
+            { weight: 2 }, undefined, '(female)'),
         new DungeonTrainer('Team Magma Grunt',
             [new GymPokemon('Zubat', 20000, 20)],
-            { weight: 1 }, undefined, '(male)'),
+            { weight: 2 }, undefined, '(male)'),
         new DungeonTrainer('Magma Admin',
             [
                 new GymPokemon('Numel', 18000, 18),


### PR DESCRIPTION
Actually made the grunts more common. The grunts are now twice as likely to appear, making Admin Tabitha less likely in turn.

By having the nameless grunts show up more it makes it seem like there's more than just 2. Which is good. Also having Tabitha show up less often is good. Named characters as random encounters is fine, provided they don't show up too often. 5 Admin Tabithas in one run of the dungeon is just weird.