### PR TITLE
Change Elf Munchlax into a level evolution

### DIFF
--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -9484,7 +9484,7 @@ const pokemonList = createPokemonArray(
         'levelType': LevelType.slow,
         'exp': 78,
         'catchRate': 50,
-        'evolutions': [new StoneEvolution('Elf Munchlax', 'Santa Snorlax', GameConstants.StoneType.Soothe_bell)],
+        'evolutions': [new LevelEvolution('Elf Munchlax', 'Santa Snorlax', 69420)],
         'baby': true,
         'base': {
             'hitpoints': 135,


### PR DESCRIPTION
The mysterious issue with Soothe bells in shops indicating that there are still more mons to get with them was caused by Elf Munchlax. The Munchlax to Snorlax evolution is canonically a friendship evolution, so it makes sense to program it like that for their christmas variants in clicker, but the result is that players think they are missing something.

I have changed it to a level evolution. Usually Munchlax evolve through Soothe Bell, but this specific variant doesn't accept that item, so it can't evolve at all. By having it be an impossibly high level evolution it can still hatch from a Santa Snorlax egg though. The Phione treatment.

We should avoid doing stone evolutions for event mons in future.