### PR TITLE
Fixes the DT Missingno and catchrate:catchrate bugs

### DIFF
--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -8,7 +8,7 @@ class MapHelper {
             return;
         }
         let genNewEnemy = false;
-        if (route != player.route()) {
+        if (route != Battle.route) {
             genNewEnemy = true;
         }
         if (this.accessToRoute(route, region)) {
@@ -155,6 +155,8 @@ class MapHelper {
         if (MapHelper.accessToTown(townName)) {
             App.game.gameState = GameConstants.GameState.idle;
             player.route(0);
+            Battle.route = 0;
+            Battle.catching(false);
             const town = TownList[townName];
             player.town(town);
             Battle.enemyPokemon(null);


### PR DESCRIPTION
Hopefully fixes the weird catch rate:catch rate bug and the Missingno glitch caused by the initial DT fix. Doesn't fix a slightly abusable trick where you can go to a Dungeon mid-catch and gain the dungeonDifficultyRoute amount of DT. Related, switching to a Town mid catch gives you route 1 (of that region) DT. There is probably a fix in there, but this is a good start.