### PR TITLE
Trimming searchtext in pokedex

### DIFF
--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -161,7 +161,7 @@ class PokedexHelper {
         return res;
     }
 
-    private static getImage(id: number, name: string) {
+    public static getImage(id: number) {
         let src = 'assets/images/';
         if (App.game.party.alreadyCaughtPokemon(id, true) && this.toggleAllShiny()) {
             src += 'shiny';
@@ -170,7 +170,7 @@ class PokedexHelper {
         return src;
     }
 
-    private static getImageStatistics(id: number) {
+    public static getImageStatistics(id: number) {
         let src = 'assets/images/';
         if (App.game.party.alreadyCaughtPokemon(id, true) && this.toggleStatisticShiny()) {
             src += 'shiny';

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -94,7 +94,7 @@ class PokedexHelper {
             }
 
             // Check if the name contains the string
-            if (filter['name'] && !pokemon.name.toLowerCase().includes(filter['name'].toLowerCase())) {
+            if (filter['name'] && !pokemon.name.toLowerCase().includes(filter['name'].toLowerCase().trim())) {
                 return false;
             }
 


### PR DESCRIPTION
This pull request removed whitespaces before and after the searchtext, when searching in the pokedex/breeding. This makes it less annoying, when you accidentally copy a whitespace, while copying a pokemon name.

Also some small code cleanup: 2 methods where marked as private, but used publicly, and one of the methods had an unused parameter