### PR TITLE
Rename Totem Wishiwashi

### DIFF
--- a/src/modules/pokemons/PokemonNameType.ts
+++ b/src/modules/pokemons/PokemonNameType.ts
@@ -937,7 +937,7 @@ export type PokemonNameType
     | 'Lycanroc (Dusk)'
     | 'Wishiwashi (Solo)'
     | 'Wishiwashi (School)'
-    | 'Totem Wishiwashi (School)'
+    | 'Totem Wishiwashi'
     | 'Mareanie'
     | 'Toxapex'
     | 'Mudbray'

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -5308,7 +5308,7 @@ dungeonList['Brooklet Hill'] = new Dungeon('Brooklet Hill',
     [
         new DungeonBossPokemon('Wishiwashi (School)', 60690300, 20),
         new DungeonBossPokemon('Araquanid', 60690300, 20),
-        new DungeonBossPokemon('Totem Wishiwashi (School)', 82543791, 60, {requirement: new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)}),
+        new DungeonBossPokemon('Totem Wishiwashi', 82543791, 60, {requirement: new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)}),
         new DungeonBossPokemon('Totem Araquanid', 82543791, 60, {requirement: new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)}),
     ],
     875000, 5, 17,

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -16395,7 +16395,7 @@ const pokemonList = createPokemonArray(
     },
     {
         'id': 746.02,
-        'name': 'Totem Wishiwashi (School)',
+        'name': 'Totem Wishiwashi',
         'type': [PokemonType.Water],
         'eggCycles': 23,
         'levelType': LevelType.fast,


### PR DESCRIPTION
Removed (School) from Totem Wishiwashi's name. There is no Solo form of the Totem Wishiwashi so the distinction is not really necessary. Also the name was just too long.