### PR TITLE
Fixup theme selectors when save different from default

### DIFF
--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -56,6 +56,9 @@ class App {
             PokedexHelper.updateList();
 
             App.game.initialize();
+
+            // Fixes custom theme css if Default theme was different from save theme (must be done before bindings)
+            document.body.className = 'no-select';
             ko.applyBindings(App.game);
 
             GameController.applyRouteBindings();


### PR DESCRIPTION
This PR fixes a minor bug,
If your default theme is different from your saves theme, the default theme name would remain in the body classes causing some odd appearances.

Example:
If default theme is `superhero` but save theme is `minty`.
before:
![image](https://user-images.githubusercontent.com/7288322/158006670-f20f8f5a-37dd-4ae0-9d1f-6b832bfdbf43.png)
after:
![image](https://user-images.githubusercontent.com/7288322/158006681-ec21fb20-a009-49f1-b338-53a10b11ffb5.png)

