### PR TITLE
Fix tooltips not showing after changing subregions

### DIFF
--- a/src/components/AlolaSVG.html
+++ b/src/components/AlolaSVG.html
@@ -1,2583 +1,2584 @@
 <g data-bind='visible: player.region == GameConstants.Region.alola'>
-    <!-- ko if: player.subregion == SubRegions.getSubRegion(GameConstants.Region.alola, 'Melemele Island').id -->
-    <image width="1600" height="960" xlink:href="assets/images/alola-melemele.png" href="assets/images/alola-melemele.png"></image>
-
-    <!-- ------ -->
-    <!-- ROUTES -->
-    <!-- ------ -->
-
-    <!--Route 1-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 10, height: 4
-        , x: 49, y: 25
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 7, height: 2
-        , x: 42, y: 28
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 1, height: 1
-        , x: 48, y: 27
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 1, height: 1
-        , x: 49, y: 29
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 9, height: 2
-        , x: 61, y: 25
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 8, height: 1
-        , x: 57, y: 24
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 2, height: 1
-        , x: 59, y: 25
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 2, height: 2.5
-        , x: 69, y: 27
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 1, height: 1
-        , x: 68, y: 27
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 2, height: 4
-        , x: 42, y: 24
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 5, height: 2
-        , x: 59, y: 27
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 2, height: 3
-        , x: 64, y: 29
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 1, height: 1
-        , x: 64, y: 28
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 1, height: 2
-        , x: 63, y: 29
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 1, height: 1
-        , x: 62, y: 29
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 8, height: 2
-        , x: 47, y: 41, name: "Outskirts"
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 5, height: 2
-        , x: 55, y: 39, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 4, height: 2
-        , x: 61, y: 37, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 4, height: 3
-        , x: 65, y: 34, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 1
-        , x: 53, y: 40, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 1
-        , x: 55, y: 41, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 3, height: 1
-        , x: 58, y: 38, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 1
-        , x: 60, y: 39, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 2
-        , x: 64, y: 32, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 1, height: 1
-        , x: 64, y: 34, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 1, height: 1
-        , x: 66, y: 33, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 1
-        , x: 63, y: 36, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 3
-        , x: 69, y: 37, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 1, height: 2
-        , x: 69, y: 35, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 1, height: 2
-        , x: 68, y: 37, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 1, height: 1
-        , x: 65, y: 37, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 6, height: 2
-        , x: 43, y: 39, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 1, height: 1
-        , x: 46, y: 41, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 1
-        , x: 49, y: 40, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 8, height: 1
-        , x: 39, y: 38, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 1
-        , x: 41, y: 39, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 6, height: 2
-        , x: 36, y: 36, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 4, height: 2
-        , x: 33, y: 34, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 2, height: 1
-        , x: 34, y: 36, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 17, height: 3
-        , x: 10, y: 12
-        , rotate: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 3, height: 2
-        , x: 13, y: 23
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 1
-        , x: 14, y: 25
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 5
-        , x: 13, y: 11
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 1, height: 2
-        , x: 15, y: 14
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 4
-        , x: 16, y: 14
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 5, height: 2
-        , x: 15, y: 11
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 5, height: 2
-        , x: 20, y: 10
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 4, height: 2
-        , x: 25, y: 9
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 3
-        , x: 29, y: 7
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 1
-        , x: 18, y: 10
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 1
-        , x: 23, y: 9
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 1
-        , x: 27, y: 8
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 2, height: 1
-        , x: 27, y: 11
-        , noText: true
-        })
-    %>
-
-    <!--Route 3-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 5, height: 5
-        , x: 37, y: 3
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 6, height: 2
-        , x: 31, y: 6
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 2, height: 1
-        , x: 31, y: 8
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 3, height: 1
-        , x: 34, y: 5
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 1, height: 1
-        , x: 36, y: 4
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 2, height: 5
-        , x: 42, y: 4
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 1, height: 1
-        , x: 41, y: 8
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 2, height: 4
-        , x: 44, y: 6
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 1, height: 1
-        , x: 44, y: 5
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 3, height: 3
-        , x: 45, y: 10
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 1, height: 1
-        , x: 46, y: 9
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 2, height: 5
-        , x: 46, y: 17
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 1, height: 1
-        , x: 47, y: 22
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 2, height: 4
-        , x: 45.5, y: 13
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 0.5, height: 1
-        , x: 47.5, y: 16
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 3, height: 2
-        , x: 48, y: 23
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 1, height: 1
-        , x: 47, y: 23
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 2, height: 1
-        , x: 48, y: 22
-        , noText: true
-        })
-    %>
-
-    <!--Route 3 extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 1, height: 1
-        , x: 48, y: 21
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 13, height: 3
-        , x: 78, y: 40, name: "Melemele"
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 13, height: 3
-        , x: 78, y: 43, name: "Sea"
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 11, height: 3
-        , x: 79, y: 37, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 2
-        , x: 90, y: 38, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 7, height: 2
-        , x: 78, y: 35, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 4, height: 1
-        , x: 85, y: 36, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 77, y: 34, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 10, height: 1
-        , x: 69, y: 45, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 3
-        , x: 76, y: 42, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 74, y: 44, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 75, y: 43, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 2
-        , x: 92, y: 43, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 5
-        , x: 91, y: 41, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 23, height: 6
-        , x: 69, y: 46, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 15, height: 3
-        , x: 76, y: 52, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 5
-        , x: 92, y: 47, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 2
-        , x: 91, y: 52, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 3
-        , x: 93, y: 49, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 75, y: 54, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 10, height: 1
-        , x: 79, y: 55, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 81, y: 56, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 7, height: 2
-        , x: 65, y: 52, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 12, height: 2
-        , x: 53, y: 54, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 8
-        , x: 47, y: 43, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 5, height: 3
-        , x: 49, y: 51, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 3, height: 2
-        , x: 49, y: 49, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 49, y: 48, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 52, y: 50, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 2
-        , x: 49, y: 43, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 51, y: 43, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 49, y: 45, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 45, y: 46, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 2
-        , x: 46, y: 47, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 2
-        , x: 48, y: 51, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 51, y: 54, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 57, y: 56, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 2
-        , x: 54, y: 52, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 3, height: 1
-        , x: 55, y: 53, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 64, y: 53, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 6, height: 1
-        , x: 65, y: 54, name: "Sea"
-        , noText: true
-        })
-    %>
-
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 67, y: 55, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 2
-        , x: 67, y: 50, name: "Sea"
-        , noText: true
-        })
-    %>
-
-
-    <!--Melemele Sea extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 2
-        , x: 68, y: 48, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 8, height: 6, name: "Kala'e Bay"
-        , x: 54, y: 12
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 1, height: 2, name: "Kala'e Bay"
-        , x: 62, y: 14
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 6.5, height: 2, name: "Kala'e Bay"
-        , x: 47.5, y: 14
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 1, height: 1, name: "Kala'e Bay"
-        , x: 53, y: 16
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 7, height: 1, name: "Kala'e Bay"
-        , x: 54, y: 11
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 4, height: 1, name: "Kala'e Bay"
-        , x: 55, y: 10
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 3, height: 3, name: "Kala'e Bay"
-        , x: 56, y: 18
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 1, height: 1, name: "Kala'e Bay"
-        , x: 55, y: 18
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 1, height: 2, name: "Kala'e Bay"
-        , x: 56, y: 21
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 1, height: 1, name: "Kala'e Bay"
-        , x: 55, y: 22
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 2, height: 2, name: "Kala'e Bay"
-        , x: 59, y: 18
-        , noText: true
-        })
-    %>
-
-    <!-- ----- -->
-    <!-- TOWNS -->
-    <!-- ----- -->
-
-    <!--Iki Town Outskirts-->
-    <%- include('templates/mapTown',
-        { name: "Iki Town Outskirts"
-        , x: 67, y: 29.5
-        , width: 5, height: 4.5
-        , home: true
-        })
-    %>
-
-    <!--Iki Town-->
-    <%- include('templates/mapTown',
-        { name: "Iki Town"
-        , x: 32, y: 16
-        , width: 13, height: 8
-        })
-    %>
-
-    <!--Iki Town extension-->
-    <%- include('templates/mapTown',
-        { name: "Iki Town"
-        , x: 31, y: 16
-        , width: 1, height: 7
-        })
-    %>
-
-    <!--Professor Kukui\'s Lab-->
-    <%- include('templates/mapTown',
-        { name: "Professor Kukui\'s Lab"
-        , x: 71, y: 37
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Hau'oli City-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 9, y: 30
-        , width: 23, height: 4
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 13, y: 29.5
-        , width: 5, height: 0.5
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 20, y: 29.5
-        , width: 5, height: 0.5
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 5, y: 34
-        , width: 28, height: 7
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 8, y: 33
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 14, y: 41
-        , width: 19, height: 2
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 13, y: 41
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 14, y: 43
-        , width: 10, height: 1
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 10, y: 29
-        , width: 3, height: 1
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 37, y: 32.5
-        , width: 5, height: 3.5
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 42, y: 34.5
-        , width: 5, height: 3.5
-        })
-    %>
-
-    <!--Roadside Motel-->
-    <%- include('templates/mapTown',
-        { name: "Roadside Motel"
-        , x: 5, y: 14.5
-        , width: 5, height: 5.5
-        })
-    %>
-
-    <!-- -------- -->
-    <!-- DUNGEONS -->
-    <!-- -------- -->
-
-    <!--Trainers School-->
-    <%- include('templates/mapDungeon',
-        { name: "Trainers' School"
-        , x: 55, y: 33.5
-        , width: 6, height: 4.5
-        })
-    %>
-
-    <!--Hau'oli Cemetery-->
-    <%- include('templates/mapDungeon',
-        { name: "Hau'oli Cemetery"
-        , x: 20, y: 21
-        , width: 6, height: 5
-        })
-    %>
-
-    <!--Hau'oli Cemetery extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Hau'oli Cemetery"
-        , x: 26, y: 22
-        , width: 1, height: 4
-        })
-    %>
-
-    <!--Hau'oli Cemetery extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Hau'oli Cemetery"
-        , x: 16, y: 24
-        , width: 4, height: 2
-        })
-    %>
-
-    <!-- Verdant Cavern-->
-    <%- include('templates/mapDungeon',
-        { name: "Verdant Cavern"
-        , x: 29, y: 10
-        , width: 5, height: 3
-        })
-    %>
-
-    <!--Melemele Meadow-->
-    <%- include('templates/mapDungeon',
-        { name: "Melemele Meadow"
-        , x: 38, y: 9
-        , width: 6, height: 2
-        })
-    %>
-
-    <!--Melemele Meadow extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Melemele Meadow"
-        , x: 44, y: 10
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Melemele Meadow extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Melemele Meadow"
-        , x: 36, y: 8
-        , width: 2, height: 2
-        })
-    %>
-
-    <!--Melemele Meadow extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Melemele Meadow"
-        , x: 35, y: 8
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Melemele Meadow extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Melemele Meadow"
-        , x: 38, y: 8
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Seaward Cave-->
-    <%- include('templates/mapDungeon',
-        { name: "Seaward Cave"
-        , x: 48, y: 8
-        , width: 3, height: 5
-        })
-    %>
-
-    <!--Seaward Cave extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Seaward Cave"
-        , x: 51, y: 9
-        , width: 2, height: 3
-        })
-    %>
-
-    <!--Seaward Cave extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Seaward Cave"
-        , x: 51, y: 12
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Ten Carat Hill-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 52, y: 43
-        , width: 16, height: 7
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 55, y: 50
-        , width: 10, height: 3
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 57, y: 41
-        , width: 11, height: 2
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 62, y: 39
-        , width: 6, height: 2
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 66, y: 37
-        , width: 2, height: 2
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 65, y: 38
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 60, y: 40
-        , width: 2, height: 1
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 55, y: 42
-        , width: 2, height: 1
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 51, y: 44
-        , width: 1, height: 2
-        })
-    %>
-
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 51, y: 47
-        , width: 1, height: 2
-        })
-    %>
-
     
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 54, y: 50
-        , width: 1, height: 2
-        })
-    %>
-    
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 53, y: 50
-        , width: 1, height: 1
-        })
-    %>
-    
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 58, y: 53
-        , width: 6, height: 1
-        })
-    %>
-    
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 65, y: 50
-        , width: 2, height: 2
-        })
-    %>
+    <g data-bind="visible: player.subregion == SubRegions.getSubRegion(GameConstants.Region.alola, 'Melemele Island').id">
+        <image width="1600" height="960" xlink:href="assets/images/alola-melemele.png" href="assets/images/alola-melemele.png"></image>
+
+        <!-- ------ -->
+        <!-- ROUTES -->
+        <!-- ------ -->
+
+        <!--Route 1-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 10, height: 4
+            , x: 49, y: 25
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 7, height: 2
+            , x: 42, y: 28
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 1, height: 1
+            , x: 48, y: 27
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 1, height: 1
+            , x: 49, y: 29
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 9, height: 2
+            , x: 61, y: 25
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 8, height: 1
+            , x: 57, y: 24
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 2, height: 1
+            , x: 59, y: 25
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 2, height: 2.5
+            , x: 69, y: 27
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 1, height: 1
+            , x: 68, y: 27
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 2, height: 4
+            , x: 42, y: 24
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 5, height: 2
+            , x: 59, y: 27
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 2, height: 3
+            , x: 64, y: 29
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 1, height: 1
+            , x: 64, y: 28
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 1, height: 2
+            , x: 63, y: 29
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 1, height: 1
+            , x: 62, y: 29
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 8, height: 2
+            , x: 47, y: 41, name: "Outskirts"
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 5, height: 2
+            , x: 55, y: 39, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 4, height: 2
+            , x: 61, y: 37, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 4, height: 3
+            , x: 65, y: 34, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 1
+            , x: 53, y: 40, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 1
+            , x: 55, y: 41, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 3, height: 1
+            , x: 58, y: 38, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 1
+            , x: 60, y: 39, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 2
+            , x: 64, y: 32, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 1, height: 1
+            , x: 64, y: 34, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 1, height: 1
+            , x: 66, y: 33, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 1
+            , x: 63, y: 36, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 3
+            , x: 69, y: 37, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 1, height: 2
+            , x: 69, y: 35, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 1, height: 2
+            , x: 68, y: 37, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 1, height: 1
+            , x: 65, y: 37, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 6, height: 2
+            , x: 43, y: 39, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 1, height: 1
+            , x: 46, y: 41, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 1
+            , x: 49, y: 40, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 8, height: 1
+            , x: 39, y: 38, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 1
+            , x: 41, y: 39, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 6, height: 2
+            , x: 36, y: 36, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 4, height: 2
+            , x: 33, y: 34, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 2, height: 1
+            , x: 34, y: 36, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 17, height: 3
+            , x: 10, y: 12
+            , rotate: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 3, height: 2
+            , x: 13, y: 23
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 1
+            , x: 14, y: 25
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 5
+            , x: 13, y: 11
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 1, height: 2
+            , x: 15, y: 14
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 4
+            , x: 16, y: 14
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 5, height: 2
+            , x: 15, y: 11
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 5, height: 2
+            , x: 20, y: 10
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 4, height: 2
+            , x: 25, y: 9
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 3
+            , x: 29, y: 7
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 1
+            , x: 18, y: 10
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 1
+            , x: 23, y: 9
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 1
+            , x: 27, y: 8
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 2, height: 1
+            , x: 27, y: 11
+            , noText: true
+            })
+        %>
+
+        <!--Route 3-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 5, height: 5
+            , x: 37, y: 3
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 6, height: 2
+            , x: 31, y: 6
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 2, height: 1
+            , x: 31, y: 8
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 3, height: 1
+            , x: 34, y: 5
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 1, height: 1
+            , x: 36, y: 4
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 2, height: 5
+            , x: 42, y: 4
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 1, height: 1
+            , x: 41, y: 8
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 2, height: 4
+            , x: 44, y: 6
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 1, height: 1
+            , x: 44, y: 5
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 3, height: 3
+            , x: 45, y: 10
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 1, height: 1
+            , x: 46, y: 9
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 2, height: 5
+            , x: 46, y: 17
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 1, height: 1
+            , x: 47, y: 22
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 2, height: 4
+            , x: 45.5, y: 13
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 0.5, height: 1
+            , x: 47.5, y: 16
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 3, height: 2
+            , x: 48, y: 23
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 1, height: 1
+            , x: 47, y: 23
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 2, height: 1
+            , x: 48, y: 22
+            , noText: true
+            })
+        %>
+
+        <!--Route 3 extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 1, height: 1
+            , x: 48, y: 21
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 13, height: 3
+            , x: 78, y: 40, name: "Melemele"
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 13, height: 3
+            , x: 78, y: 43, name: "Sea"
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 11, height: 3
+            , x: 79, y: 37, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 2
+            , x: 90, y: 38, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 7, height: 2
+            , x: 78, y: 35, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 4, height: 1
+            , x: 85, y: 36, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 77, y: 34, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 10, height: 1
+            , x: 69, y: 45, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 3
+            , x: 76, y: 42, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 74, y: 44, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 75, y: 43, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 2
+            , x: 92, y: 43, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 5
+            , x: 91, y: 41, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 23, height: 6
+            , x: 69, y: 46, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 15, height: 3
+            , x: 76, y: 52, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 5
+            , x: 92, y: 47, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 2
+            , x: 91, y: 52, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 3
+            , x: 93, y: 49, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 75, y: 54, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 10, height: 1
+            , x: 79, y: 55, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 81, y: 56, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 7, height: 2
+            , x: 65, y: 52, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 12, height: 2
+            , x: 53, y: 54, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 8
+            , x: 47, y: 43, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 5, height: 3
+            , x: 49, y: 51, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 3, height: 2
+            , x: 49, y: 49, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 49, y: 48, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 52, y: 50, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 2
+            , x: 49, y: 43, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 51, y: 43, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 49, y: 45, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 45, y: 46, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 2
+            , x: 46, y: 47, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 2
+            , x: 48, y: 51, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 51, y: 54, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 57, y: 56, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 2
+            , x: 54, y: 52, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 3, height: 1
+            , x: 55, y: 53, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 64, y: 53, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 6, height: 1
+            , x: 65, y: 54, name: "Sea"
+            , noText: true
+            })
+        %>
+
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 67, y: 55, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 2
+            , x: 67, y: 50, name: "Sea"
+            , noText: true
+            })
+        %>
+
+
+        <!--Melemele Sea extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 2
+            , x: 68, y: 48, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 8, height: 6, name: "Kala'e Bay"
+            , x: 54, y: 12
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 1, height: 2, name: "Kala'e Bay"
+            , x: 62, y: 14
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 6.5, height: 2, name: "Kala'e Bay"
+            , x: 47.5, y: 14
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 1, height: 1, name: "Kala'e Bay"
+            , x: 53, y: 16
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 7, height: 1, name: "Kala'e Bay"
+            , x: 54, y: 11
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 4, height: 1, name: "Kala'e Bay"
+            , x: 55, y: 10
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 3, height: 3, name: "Kala'e Bay"
+            , x: 56, y: 18
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 1, height: 1, name: "Kala'e Bay"
+            , x: 55, y: 18
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 1, height: 2, name: "Kala'e Bay"
+            , x: 56, y: 21
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 1, height: 1, name: "Kala'e Bay"
+            , x: 55, y: 22
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 2, height: 2, name: "Kala'e Bay"
+            , x: 59, y: 18
+            , noText: true
+            })
+        %>
+
+        <!-- ----- -->
+        <!-- TOWNS -->
+        <!-- ----- -->
+
+        <!--Iki Town Outskirts-->
+        <%- include('templates/mapTown',
+            { name: "Iki Town Outskirts"
+            , x: 67, y: 29.5
+            , width: 5, height: 4.5
+            , home: true
+            })
+        %>
+
+        <!--Iki Town-->
+        <%- include('templates/mapTown',
+            { name: "Iki Town"
+            , x: 32, y: 16
+            , width: 13, height: 8
+            })
+        %>
+
+        <!--Iki Town extension-->
+        <%- include('templates/mapTown',
+            { name: "Iki Town"
+            , x: 31, y: 16
+            , width: 1, height: 7
+            })
+        %>
+
+        <!--Professor Kukui\'s Lab-->
+        <%- include('templates/mapTown',
+            { name: "Professor Kukui\'s Lab"
+            , x: 71, y: 37
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Hau'oli City-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 9, y: 30
+            , width: 23, height: 4
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 13, y: 29.5
+            , width: 5, height: 0.5
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 20, y: 29.5
+            , width: 5, height: 0.5
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 5, y: 34
+            , width: 28, height: 7
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 8, y: 33
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 14, y: 41
+            , width: 19, height: 2
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 13, y: 41
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 14, y: 43
+            , width: 10, height: 1
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 10, y: 29
+            , width: 3, height: 1
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 37, y: 32.5
+            , width: 5, height: 3.5
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 42, y: 34.5
+            , width: 5, height: 3.5
+            })
+        %>
+
+        <!--Roadside Motel-->
+        <%- include('templates/mapTown',
+            { name: "Roadside Motel"
+            , x: 5, y: 14.5
+            , width: 5, height: 5.5
+            })
+        %>
+
+        <!-- -------- -->
+        <!-- DUNGEONS -->
+        <!-- -------- -->
+
+        <!--Trainers School-->
+        <%- include('templates/mapDungeon',
+            { name: "Trainers' School"
+            , x: 55, y: 33.5
+            , width: 6, height: 4.5
+            })
+        %>
+
+        <!--Hau'oli Cemetery-->
+        <%- include('templates/mapDungeon',
+            { name: "Hau'oli Cemetery"
+            , x: 20, y: 21
+            , width: 6, height: 5
+            })
+        %>
+
+        <!--Hau'oli Cemetery extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Hau'oli Cemetery"
+            , x: 26, y: 22
+            , width: 1, height: 4
+            })
+        %>
+
+        <!--Hau'oli Cemetery extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Hau'oli Cemetery"
+            , x: 16, y: 24
+            , width: 4, height: 2
+            })
+        %>
+
+        <!-- Verdant Cavern-->
+        <%- include('templates/mapDungeon',
+            { name: "Verdant Cavern"
+            , x: 29, y: 10
+            , width: 5, height: 3
+            })
+        %>
+
+        <!--Melemele Meadow-->
+        <%- include('templates/mapDungeon',
+            { name: "Melemele Meadow"
+            , x: 38, y: 9
+            , width: 6, height: 2
+            })
+        %>
+
+        <!--Melemele Meadow extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Melemele Meadow"
+            , x: 44, y: 10
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Melemele Meadow extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Melemele Meadow"
+            , x: 36, y: 8
+            , width: 2, height: 2
+            })
+        %>
+
+        <!--Melemele Meadow extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Melemele Meadow"
+            , x: 35, y: 8
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Melemele Meadow extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Melemele Meadow"
+            , x: 38, y: 8
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Seaward Cave-->
+        <%- include('templates/mapDungeon',
+            { name: "Seaward Cave"
+            , x: 48, y: 8
+            , width: 3, height: 5
+            })
+        %>
+
+        <!--Seaward Cave extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Seaward Cave"
+            , x: 51, y: 9
+            , width: 2, height: 3
+            })
+        %>
+
+        <!--Seaward Cave extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Seaward Cave"
+            , x: 51, y: 12
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Ten Carat Hill-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 52, y: 43
+            , width: 16, height: 7
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 55, y: 50
+            , width: 10, height: 3
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 57, y: 41
+            , width: 11, height: 2
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 62, y: 39
+            , width: 6, height: 2
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 66, y: 37
+            , width: 2, height: 2
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 65, y: 38
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 60, y: 40
+            , width: 2, height: 1
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 55, y: 42
+            , width: 2, height: 1
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 51, y: 44
+            , width: 1, height: 2
+            })
+        %>
+
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 51, y: 47
+            , width: 1, height: 2
+            })
+        %>
 
         
-    <!--Ten Carat Hill extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 68, y: 39
-        , width: 1, height: 2
-        })
-    %>
-
-    <!--Ruins of Conflict-->
-    <%- include('templates/mapDungeon',
-        { name: "Ruins of Conflict"
-        , x: 35, y: 12
-        , width: 5, height: 4
-        })
-    %>
-
-    <!-- ------------------ -->
-    <!-- PLACES OF INTEREST -->
-    <!-- ------------------ -->
-
-    <!--Dock-->
-    <%- include('templates/mapPOI',
-        { name: "Dock"
-        , x: 22, y: 46
-        , width: 12, height: 6
-        , databind: "click:function(){MapHelper.openShipModal()}"
-        })
-    %>
-
-    <!--Dock extension-->
-    <%- include('templates/mapPOI',
-        { name: "Dock"
-        , x: 30, y: 43
-        , width: 3, height: 3
-        , databind: "click:function(){MapHelper.openShipModal()}"
-        })
-    %>
-
-    <!--Dock extension-->
-    <%- include('templates/mapPOI',
-        { name: "Dock"
-        , x: 23, y: 45
-        , width: 7, height: 1
-        , databind: "click:function(){MapHelper.openShipModal()}"
-        })
-    %>
-    <!-- /ko -->
-
-    <!-- ko if: player.subregion == SubRegions.getSubRegion(GameConstants.Region.alola, 'Melemele & Akala islands').id -->
-    <image width="1600" height="960" xlink:href="assets/images/alola.png" href="assets/images/alola.png"></image>
-
-    <!-- ------ -->
-    <!-- ROUTES -->
-    <!-- ------ -->
-
-    <!--Route 1-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 15, height: 3
-        , x: 18, y: 24
-        })
-    %>
-
-    <!--Route 1 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 6
-        , width: 3, height: 5
-        , x: 30, y: 27
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 17, height: 3
-        , x: 17, y: 32, name: "Outskirts"
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts Extension--> 
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 3, height: 5
-        , x: 31, y: 35, name: "Outskirts"
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts Extension-->
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 4, height: 3
-        , x: 13, y: 30
-        , noText: true
-        })
-    %>
-
-    <!--Route 1 Hau'oli Outskirts Extension-->
-    <%- include('templates/mapRoute',
-        { route: 18, region: 6
-        , width: 3, height: 2
-        , x: 17, y: 30
-        , noText: true
-        })
-    %>
-
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 3, height: 19.5
-        , x: 4, y: 9
-        })
-    %>
-
-    <!--Route 2 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 6
-        , width: 11, height: 3
-        , x: 7, y: 9
-        , noText: true
-        })
-    %>
-
-    <!--Route 3-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 3, height: 15
-        , x: 24, y: 9
-        })
-    %>
-
-    <!--Route 3 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 6
-        , width: 6, height: 3
-        , x: 18, y: 9
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 5, height: 10
-        , x: 37, y: 33, name: "Sea"
-        })
-    %>
-
-    <!--Melemele Sea Extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 8, height: 3
-        , x: 29, y: 40, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea Extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 2, height: 1
-        , x: 35, y: 39, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Melemele Sea Extension-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 6
-        , width: 1, height: 1
-        , x: 36, y: 38, name: "Sea"
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 6, height: 9, name: "Bay"
-        , x: 31, y: 13
-        })
-    %>
-
-    <!--Kala'e Bay Extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 4, height: 6
-        , x: 27, y: 15, name: "Bay"
-        , noText: true
-        })
-    %>
-
-    <!--Kala'e Bay Extension-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 6
-        , width: 1, height: 1, name: "Bay"
-        , x: 30, y: 21
-        , noText: true
-        })
-    %>
-
-    <!--Route 4-->
-    <%- include('templates/mapRoute',
-        { route: 4, region: 6
-        , width: 3, height: 11
-        , x: 71, y: 30
-        })
-    %>
-
-    <!--Route 4 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 4, region: 6
-        , width: 4, height: 3
-        , x: 74, y: 30
-        , noText: true
-        })
-    %>
-
-    <!--Route 5-->
-    <%- include('templates/mapRoute',
-        { route: 5, region: 6
-        , width: 3, height: 14
-        , x: 80, y: 13
-        })
-    %>
-
-    <!--Route 6-->
-    <%- include('templates/mapRoute',
-        { route: 6, region: 6
-        , width: 3, height: 15
-        , x: 80, y: 30
-        })
-    %>
-
-    <!--Route 6 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 6, region: 6
-        , width: 6, height: 3
-        , x: 74, y: 42
-        , noText: true
-        })
-    %>
-
-    <!--Route 7-->
-    <%- include('templates/mapRoute',
-        { route: 7, region: 6
-        , width: 3, height: 29
-        , x: 92, y: 9
-        })
-    %>
-
-    <!--Route 8-->
-    <%- include('templates/mapRoute',
-        { route: 8, region: 6
-        , width: 20, height: 3
-        , x: 75, y: 6
-        })
-    %>
-
-    <!--Route 8 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 8, region: 6
-        , width: 3, height: 7
-        , x: 75, y: 9
-        , noText: true
-        })
-    %>
-
-    <!--Route 8 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 8, region: 6
-        , width: 2, height: 3
-        , x: 78, y: 13
-        , noText: true
-        })
-    %>
-
-    <!--Route 9-->
-    <%- include('templates/mapRoute',
-        { route: 9, region: 6
-        , width: 9, height: 3
-        , x: 65, y: 52
-        })
-    %>
-
-    <!--Route 9 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 9, region: 6
-        , width: 3, height: 1
-        , x: 71, y: 51
-        , noText: true
-        })
-    %>
-
-    <!--Akala Outskirts-->
-    <%- include('templates/mapRoute',
-        { route: 21, region: 6
-        , width: 6, height: 3
-        , x: 78, y: 52, name: "A.O."
-        })
-    %>
-
-    <!--Akala Outskirts Extension---->
-    <%- include('templates/mapRoute',
-        { route: 21, region: 6
-        , width: 3, height: 2
-        , x: 81, y: 50, name: "A.O."
-        , noText: true
-        })
-    %>
-
-    <!-- ----- -->
-    <!-- TOWNS -->
-    <!-- ----- -->
-
-    <!--Iki Town-->
-    <%- include('templates/mapTown',
-        { name: "Iki Town"
-        , x: 18, y: 19.5
-        , width: 5, height: 4.5
-        , home: true
-        })
-    %>
-
-    <!--Hau'oli City-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 4, y: 28.5
-        , width: 5, height: 4.5
-        })
-    %>
-
-    <!--Hau'oli City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Hau'oli City"
-        , x: 9, y: 29
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Heahea City-->
-    <%- include('templates/mapTown',
-        { name: "Heahea City"
-        , x: 65, y: 40.5
-        , width: 5, height: 4.5
-        })
-    %>
-
-    <!--Heahea City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Heahea City"
-        , x: 70, y: 41
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Paniola Town-->
-    <%- include('templates/mapTown',
-        { name: "Paniola Town"
-        , x: 75, y: 26
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Royal Avenue-->
-    <%- include('templates/mapTown',
-        { name: "Royal Avenue"
-        , x: 83, y: 33.5
-        , width: 5, height: 4.5
-        })
-    %>
-
-    <!--Royal Avenue Extension-->
-    <%- include('templates/mapTown',
-        { name: "Royal Avenue"
-        , x: 88, y: 34
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Konikoni City-->
-    <%- include('templates/mapTown',
-        { name: "Konikoni City"
-        , x: 64, y: 48
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Aether Paradise-->
-    <%- include('templates/mapTown',
-        { name: "Aether Paradise"
-        , x: 45, y: 51.5
-        , width: 5, height: 4.5
-        })
-    %>
-
-    <!-- -------- -->
-    <!-- DUNGEONS -->
-    <!-- -------- -->
-
-    <%- include('templates/mapDungeon',
-        { name: "Trainers' School"
-        , x: 20, y: 29
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Hau'oli Cemetery"
-        , x: 7, y: 22
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Verdant Cavern"
-        , x: 14, y: 12
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Melemele Meadow"
-        , x: 20, y: 12
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Seaward Cave"
-        , x: 27, y: 12
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 25, y: 35
-        , width: 6, height: 3
-        })
-    %>
-
-    <!--Ten Carat Hill Extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Ten Carat Hill"
-        , x: 25, y: 38
-        , width: 4, height: 4
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Ruins of Conflict"
-        , x: 18, y: 16
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Pikachu Valley"
-        , x: 69, y: 27
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Paniola Ranch"
-        , x: 79, y: 27
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Brooklet Hill"
-        , x: 72, y: 20
-        , width: 5, height: 6
-        })
-    %>
-
-    <!--Brooklet Hill Extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Brooklet Hill"
-        , x: 77, y: 20
-        , width: 3, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Wela Volcano Park"
-        , x: 88, y: 17
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Lush Jungle"
-        , x: 79, y: 10
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Diglett's Tunnel"
-        , x: 71, y: 45
-        , width: 3, height: 6
-        })
-    %>
-
-    <!--Diglett's Tunnel Extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Diglett's Tunnel"
-        , x: 74, y: 45
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Memorial Hill"
-        , x: 74, y: 52
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Ruins of Life"
-        , x: 80, y: 47
-        , width: 4, height: 3
-        })
-    %>
-
-    <!-- ------------------ -->
-    <!-- PLACES OF INTEREST -->
-    <!-- ------------------ -->
-
-    <%- include('templates/mapPOI',
-        { name: "Dock"
-        , x: 9, y: 33
-        , width: 2, height: 3
-        , databind: "click:function(){MapHelper.openShipModal()}"
-        })
-    %>
-    <!-- /ko -->
-
-    <!-- ko if: player.subregion == SubRegions.getSubRegion(GameConstants.Region.alola, 'Ula\'ula & Poni islands').id -->
-    <image width="1600" height="960" xlink:href="assets/images/kanto.png" href="assets/images/alola2.png"></image>
-
-    <!-- ------ -->
-    <!-- ROUTES -->
-    <!-- ------ -->
-
-    <!--Route 10-->
-    <%- include('templates/mapRoute',
-        { route: 10, region: 6
-        , width: 9, height: 3
-        , x: 64, y: 19
-        })
-    %>
-
-    <!--Mount Hokulani-->
-    <%- include('templates/mapRoute',
-        { route: 22, region: 6
-        , width: 3, height: 6, name: "MH"
-        , x: 64, y: 13
-        })
-    %>
-
-    <!--Route 11-->
-    <%- include('templates/mapRoute',
-        { route: 11, region: 6
-        , width: 3, height: 7
-        , x: 73, y: 22
-        })
-    %>
-
-    <!--Route 11 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 11, region: 6
-        , width: 6, height: 3
-        , x: 76, y: 26
-        , noText: true
-        })
-    %>
-
-    <!--Route 12-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 3, height: 12
-        , x: 84, y: 31
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 4
-        , x: 82, y: 26
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 4
-        , x: 83, y: 27
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 3
-        , x: 84, y: 28
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 2
-        , x: 85, y: 29
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 1
-        , x: 86, y: 30
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 1
-        , x: 86, y: 43
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 2
-        , x: 85, y: 43
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 3
-        , x: 84, y: 43
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 4
-        , x: 83, y: 43
-        , noText: true
-        })
-    %>
-
-    <!--Route 12 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 6
-        , width: 1, height: 3
-        , x: 82, y: 44
-        , noText: true
-        })
-    %>
-
-    <!--Route 13-->
-    <%- include('templates/mapRoute',
-        { route: 13, region: 6
-        , width: 14, height: 3
-        , x: 68, y: 44
-        })
-    %>
-
-    <!--Haina Desert-->
-    <%- include('templates/mapRoute',
-        { route: 23, region: 6
-        , width: 3, height: 10, name: "HD"
-        , x: 73, y: 34
-        })
-    %>
-
-    <!--Route 14-->
-    <%- include('templates/mapRoute',
-        { route: 14, region: 6
-        , width: 3, height: 7
-        , x: 62, y: 47
-        })
-    %>
-
-    <!--Route 14 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 14, region: 6
-        , width: 3, height: 3
-        , x: 65, y: 51
-        , noText: true
-        })
-    %>
-
-    <!--Route 15-->
-    <%- include('templates/mapRoute',
-        { route: 15, region: 6
-        , width: 4, height: 12
-        , x: 53, y: 35
-        })
-    %>
-
-    <!--Route 15 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 15, region: 6
-        , width: 5, height: 4
-        , x: 57, y: 43
-        , noText: true
-        })
-    %>
-
-    <!--Route 15 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 15, region: 6
-        , width: 2, height: 3
-        , x: 62, y: 44
-        , noText: true
-        })
-    %>
-
-    <!--Route 16-->
-    <%- include('templates/mapRoute',
-        { route: 16, region: 6
-        , width: 3, height: 6
-        , x: 54, y: 29
-        })
-    %>
-
-    <!--Route 17-->
-    <%- include('templates/mapRoute',
-        { route: 17, region: 6
-        , width: 3, height: 14
-        , x: 54, y: 12
-        })
-    %>
-
-    <!--Route 17 Extension-->
-    <%- include('templates/mapRoute',
-        { route: 17, region: 6
-        , width: 2, height: 3
-        , x: 52, y: 12
-        , noText: true
-        })
-    %>
-
-    <!--Poni Wilds-->
-    <%- include('templates/mapRoute',
-        { route: 24, region: 6
-        , width: 12, height: 3, name: "PW"
-        , x: 16, y: 38
-        })
-    %>
-
-    <!--Poni Wilds Extension-->
-    <%- include('templates/mapRoute',
-        { route: 24, region: 6
-        , width: 4, height: 3
-        , x: 25, y: 41
-        , noText: true
-        })
-    %>
-
-    <!--Poni Wilds Extension-->
-    <%- include('templates/mapRoute',
-        { route: 24, region: 6
-        , width: 3, height: 0.5
-        , x: 16, y: 41
-        , noText: true
-        })
-    %>
-
-    <!--Ancient Poni Path-->
-    <%- include('templates/mapRoute',
-        { route: 25, region: 6
-        , width: 7, height: 3, name: "APP"
-        , x: 29, y: 41
-        })
-    %>
-
-    <!--Ancient Poni Path Extension-->
-    <%- include('templates/mapRoute',
-        { route: 25, region: 6
-        , width: 3, height: 6
-        , x: 29, y: 35
-        , noText: true
-        })
-    %>
-
-    <!--Poni Breaker Coast-->
-    <%- include('templates/mapRoute',
-        { route: 26, region: 6
-        , width: 8, height: 3, name: "PBC"
-        , x: 31, y: 44
-        })
-    %>
-
-    <!--Poni Grove-->
-    <%- include('templates/mapRoute',
-        { route: 27, region: 6
-        , width: 3, height: 5, name: "PGr"
-        , x: 33, y: 36
-        })
-    %>
-
-    <!--Poni Plains-->
-    <%- include('templates/mapRoute',
-        { route: 28, region: 6
-        , width: 7, height: 3, name: "PP"
-        , x: 36, y: 36
-        })
-    %>
-
-    <!--Poni Coast-->
-    <%- include('templates/mapRoute',
-        { route: 29, region: 6
-        , width: 3, height: 8, name: "PC"
-        , x: 40, y: 28
-        })
-    %>
-
-    <!--Poni Gauntlet-->
-    <%- include('templates/mapRoute',
-        { route: 30, region: 6
-        , width: 7, height: 3, name: "PGa"
-        , x: 32, y: 23
-        })
-    %>
-
-    <!--Poni Gauntlet Extension-->
-    <%- include('templates/mapRoute',
-        { route: 30, region: 6
-        , width: 1, height: 1
-        , x: 38, y: 26
-        , noText: true
-        })
-    %>
-
-    <!--Poni Gauntlet Extension-->
-    <%- include('templates/mapRoute',
-        { route: 30, region: 6
-        , width: 1, height: 4
-        , x: 39, y: 24
-        , noText: true
-        })
-    %>
-
-    <!--Poni Gauntlet Extension-->
-    <%- include('templates/mapRoute',
-        { route: 30, region: 6
-        , width: 1, height: 3
-        , x: 40, y: 25
-        , noText: true
-        })
-    %>
-
-    <!--Poni Gauntlet Extension-->
-    <%- include('templates/mapRoute',
-        { route: 30, region: 6
-        , width: 1, height: 2
-        , x: 41, y: 26
-        , noText: true
-        })
-    %>
-
-    <!--Poni Gauntlet Extension-->
-    <%- include('templates/mapRoute',
-        { route: 30, region: 6
-        , width: 1, height: 1
-        , x: 42, y: 27
-        , noText: true
-        })
-    %>
-
-    <!-- ----- -->
-    <!-- TOWNS -->
-    <!-- ----- -->
-
-    <!--Aether Paradise-->
-    <%- include('templates/mapTown',
-        { name: "Aether Paradise"
-        , x: 40, y: 1.5
-        , width: 5, height: 4.5
-        })
-    %>
-
-    <!--Malie City-->
-    <%- include('templates/mapTown',
-        { name: "Malie City"
-        , x: 77, y: 17.5
-        , width: 5, height: 4.5
-        })
-    %>
-
-    <!--Malie City Extension-->
-    <%- include('templates/mapTown',
-        { name: "Malie City"
-        , x: 73, y: 18
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Tapu Village-->
-    <%- include('templates/mapTown',
-        { name: "Tapu Village"
-        , x: 64, y: 43
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Seafolk Village-->
-    <%- include('templates/mapTown',
-        { name: "Seafolk Village"
-        , x: 15, y: 41.5
-        , width: 5, height: 4.5
-        })
-    %>
-
-    <!--Exeggutor Island-->
-    <%- include('templates/mapTown',
-        { name: "Exeggutor Island"
-        , x: 5, y: 43
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Altar of the Sunne and Moone-->
-    <%- include('templates/mapTown',
-        { name: "Altar of the Sunne and Moone"
-        , x: 25, y: 25
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Pokémon League Alola-->
-    <%- include('templates/mapTown',
-        { name: "Pokémon League Alola"
-        , x: 60.5, y: 32
-        , width: 10, height: 7.5
-        })
-    %>
-
-    <!-- -------- -->
-    <!-- DUNGEONS -->
-    <!-- -------- -->
-
-    <%- include('templates/mapDungeon',
-        { name: "Malie Garden"
-        , x: 73, y: 15
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Hokulani Observatory"
-        , x: 64, y: 9
-        , width: 4, height: 4
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Thrifty Megamart"
-        , x: 65, y: 48
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Ula\'ula Meadow"
-        , x: 53, y: 26
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Po Town"
-        , x: 52, y: 9
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Mount Lanakila"
-        , x: 64, y: 40
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Ruins of Abundance"
-        , x: 73, y: 31
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Vast Poni Canyon"
-        , x: 29, y: 31
-        , width: 4, height: 4
-        })
-    %>
-
-    <!--Vast Poni Canyon Extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Vast Poni Canyon"
-        , x: 25, y: 29
-        , width: 4, height: 3
-        })
-    %>
-
-    <!--Vast Poni Canyon Extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Vast Poni Canyon"
-        , x: 28, y: 32
-        , width: 1, height: 1
-        })
-    %>
-
-    <!--Vast Poni Canyon Extension-->
-    <%- include('templates/mapDungeon',
-        { name: "Vast Poni Canyon"
-        , x: 29, y: 30
-        , width: 2, height: 1
-        })
-    %>
-
-    <!--Lake of the Sunne and Moone-->
-    <%- include('templates/mapDungeon',
-        { name: "Lake of the Sunne and Moone"
-        , x: 57, y: 26
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Ruins of Hope"
-        , x: 36, y: 41
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Poni Meadow"
-        , x: 36, y: 33
-        , width: 4, height: 3
-        })
-    %>
-
-    <%- include('templates/mapDungeon',
-        { name: "Resolution Cave"
-        , x: 36, y: 30
-        , width: 4, height: 3
-        })
-    %>
-
-    <!-- ------------------ -->
-    <!-- PLACES OF INTEREST -->
-    <!-- ------------------ -->
-
-    <!-- TODO: REMOVE IF UB QUESTLINE GETS MERGED -->
-    <%- include('templates/mapOverlay',
-        { name: "Access Denied - Future Content"
-        , x: 36, y: 30
-        , width: 4, height: 3
-        , databind: "click:function(){MapHelper.moveToTown('Seafolk Village')}, attr:{ class: MapHelper.calculateTownCssClass('Seafolk Village') }"
-        , visible:  "App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Poni Meadow')]() >= 1"
-        , image: "assets/images/map/transparent.png"
-        })
-    %>
-    <!-- /ko -->
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 54, y: 50
+            , width: 1, height: 2
+            })
+        %>
+        
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 53, y: 50
+            , width: 1, height: 1
+            })
+        %>
+        
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 58, y: 53
+            , width: 6, height: 1
+            })
+        %>
+        
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 65, y: 50
+            , width: 2, height: 2
+            })
+        %>
+
+            
+        <!--Ten Carat Hill extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 68, y: 39
+            , width: 1, height: 2
+            })
+        %>
+
+        <!--Ruins of Conflict-->
+        <%- include('templates/mapDungeon',
+            { name: "Ruins of Conflict"
+            , x: 35, y: 12
+            , width: 5, height: 4
+            })
+        %>
+
+        <!-- ------------------ -->
+        <!-- PLACES OF INTEREST -->
+        <!-- ------------------ -->
+
+        <!--Dock-->
+        <%- include('templates/mapPOI',
+            { name: "Dock"
+            , x: 22, y: 46
+            , width: 12, height: 6
+            , databind: "click:function(){MapHelper.openShipModal()}"
+            })
+        %>
+
+        <!--Dock extension-->
+        <%- include('templates/mapPOI',
+            { name: "Dock"
+            , x: 30, y: 43
+            , width: 3, height: 3
+            , databind: "click:function(){MapHelper.openShipModal()}"
+            })
+        %>
+
+        <!--Dock extension-->
+        <%- include('templates/mapPOI',
+            { name: "Dock"
+            , x: 23, y: 45
+            , width: 7, height: 1
+            , databind: "click:function(){MapHelper.openShipModal()}"
+            })
+        %>
+    </g>
+
+    <g data-bind="visible: player.subregion == SubRegions.getSubRegion(GameConstants.Region.alola, 'Melemele & Akala islands').id">
+        <image width="1600" height="960" xlink:href="assets/images/alola.png" href="assets/images/alola.png"></image>
+
+        <!-- ------ -->
+        <!-- ROUTES -->
+        <!-- ------ -->
+
+        <!--Route 1-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 15, height: 3
+            , x: 18, y: 24
+            })
+        %>
+
+        <!--Route 1 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 6
+            , width: 3, height: 5
+            , x: 30, y: 27
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 17, height: 3
+            , x: 17, y: 32, name: "Outskirts"
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts Extension--> 
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 3, height: 5
+            , x: 31, y: 35, name: "Outskirts"
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts Extension-->
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 4, height: 3
+            , x: 13, y: 30
+            , noText: true
+            })
+        %>
+
+        <!--Route 1 Hau'oli Outskirts Extension-->
+        <%- include('templates/mapRoute',
+            { route: 18, region: 6
+            , width: 3, height: 2
+            , x: 17, y: 30
+            , noText: true
+            })
+        %>
+
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 3, height: 19.5
+            , x: 4, y: 9
+            })
+        %>
+
+        <!--Route 2 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 6
+            , width: 11, height: 3
+            , x: 7, y: 9
+            , noText: true
+            })
+        %>
+
+        <!--Route 3-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 3, height: 15
+            , x: 24, y: 9
+            })
+        %>
+
+        <!--Route 3 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 6
+            , width: 6, height: 3
+            , x: 18, y: 9
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 5, height: 10
+            , x: 37, y: 33, name: "Sea"
+            })
+        %>
+
+        <!--Melemele Sea Extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 8, height: 3
+            , x: 29, y: 40, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea Extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 2, height: 1
+            , x: 35, y: 39, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Melemele Sea Extension-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 6
+            , width: 1, height: 1
+            , x: 36, y: 38, name: "Sea"
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 6, height: 9, name: "Bay"
+            , x: 31, y: 13
+            })
+        %>
+
+        <!--Kala'e Bay Extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 4, height: 6
+            , x: 27, y: 15, name: "Bay"
+            , noText: true
+            })
+        %>
+
+        <!--Kala'e Bay Extension-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 6
+            , width: 1, height: 1, name: "Bay"
+            , x: 30, y: 21
+            , noText: true
+            })
+        %>
+
+        <!--Route 4-->
+        <%- include('templates/mapRoute',
+            { route: 4, region: 6
+            , width: 3, height: 11
+            , x: 71, y: 30
+            })
+        %>
+
+        <!--Route 4 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 4, region: 6
+            , width: 4, height: 3
+            , x: 74, y: 30
+            , noText: true
+            })
+        %>
+
+        <!--Route 5-->
+        <%- include('templates/mapRoute',
+            { route: 5, region: 6
+            , width: 3, height: 14
+            , x: 80, y: 13
+            })
+        %>
+
+        <!--Route 6-->
+        <%- include('templates/mapRoute',
+            { route: 6, region: 6
+            , width: 3, height: 15
+            , x: 80, y: 30
+            })
+        %>
+
+        <!--Route 6 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 6, region: 6
+            , width: 6, height: 3
+            , x: 74, y: 42
+            , noText: true
+            })
+        %>
+
+        <!--Route 7-->
+        <%- include('templates/mapRoute',
+            { route: 7, region: 6
+            , width: 3, height: 29
+            , x: 92, y: 9
+            })
+        %>
+
+        <!--Route 8-->
+        <%- include('templates/mapRoute',
+            { route: 8, region: 6
+            , width: 20, height: 3
+            , x: 75, y: 6
+            })
+        %>
+
+        <!--Route 8 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 8, region: 6
+            , width: 3, height: 7
+            , x: 75, y: 9
+            , noText: true
+            })
+        %>
+
+        <!--Route 8 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 8, region: 6
+            , width: 2, height: 3
+            , x: 78, y: 13
+            , noText: true
+            })
+        %>
+
+        <!--Route 9-->
+        <%- include('templates/mapRoute',
+            { route: 9, region: 6
+            , width: 9, height: 3
+            , x: 65, y: 52
+            })
+        %>
+
+        <!--Route 9 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 9, region: 6
+            , width: 3, height: 1
+            , x: 71, y: 51
+            , noText: true
+            })
+        %>
+
+        <!--Akala Outskirts-->
+        <%- include('templates/mapRoute',
+            { route: 21, region: 6
+            , width: 6, height: 3
+            , x: 78, y: 52, name: "A.O."
+            })
+        %>
+
+        <!--Akala Outskirts Extension---->
+        <%- include('templates/mapRoute',
+            { route: 21, region: 6
+            , width: 3, height: 2
+            , x: 81, y: 50, name: "A.O."
+            , noText: true
+            })
+        %>
+
+        <!-- ----- -->
+        <!-- TOWNS -->
+        <!-- ----- -->
+
+        <!--Iki Town-->
+        <%- include('templates/mapTown',
+            { name: "Iki Town"
+            , x: 18, y: 19.5
+            , width: 5, height: 4.5
+            , home: true
+            })
+        %>
+
+        <!--Hau'oli City-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 4, y: 28.5
+            , width: 5, height: 4.5
+            })
+        %>
+
+        <!--Hau'oli City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Hau'oli City"
+            , x: 9, y: 29
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Heahea City-->
+        <%- include('templates/mapTown',
+            { name: "Heahea City"
+            , x: 65, y: 40.5
+            , width: 5, height: 4.5
+            })
+        %>
+
+        <!--Heahea City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Heahea City"
+            , x: 70, y: 41
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Paniola Town-->
+        <%- include('templates/mapTown',
+            { name: "Paniola Town"
+            , x: 75, y: 26
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Royal Avenue-->
+        <%- include('templates/mapTown',
+            { name: "Royal Avenue"
+            , x: 83, y: 33.5
+            , width: 5, height: 4.5
+            })
+        %>
+
+        <!--Royal Avenue Extension-->
+        <%- include('templates/mapTown',
+            { name: "Royal Avenue"
+            , x: 88, y: 34
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Konikoni City-->
+        <%- include('templates/mapTown',
+            { name: "Konikoni City"
+            , x: 64, y: 48
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Aether Paradise-->
+        <%- include('templates/mapTown',
+            { name: "Aether Paradise"
+            , x: 45, y: 51.5
+            , width: 5, height: 4.5
+            })
+        %>
+
+        <!-- -------- -->
+        <!-- DUNGEONS -->
+        <!-- -------- -->
+
+        <%- include('templates/mapDungeon',
+            { name: "Trainers' School"
+            , x: 20, y: 29
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Hau'oli Cemetery"
+            , x: 7, y: 22
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Verdant Cavern"
+            , x: 14, y: 12
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Melemele Meadow"
+            , x: 20, y: 12
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Seaward Cave"
+            , x: 27, y: 12
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 25, y: 35
+            , width: 6, height: 3
+            })
+        %>
+
+        <!--Ten Carat Hill Extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Ten Carat Hill"
+            , x: 25, y: 38
+            , width: 4, height: 4
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Ruins of Conflict"
+            , x: 18, y: 16
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Pikachu Valley"
+            , x: 69, y: 27
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Paniola Ranch"
+            , x: 79, y: 27
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Brooklet Hill"
+            , x: 72, y: 20
+            , width: 5, height: 6
+            })
+        %>
+
+        <!--Brooklet Hill Extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Brooklet Hill"
+            , x: 77, y: 20
+            , width: 3, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Wela Volcano Park"
+            , x: 88, y: 17
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Lush Jungle"
+            , x: 79, y: 10
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Diglett's Tunnel"
+            , x: 71, y: 45
+            , width: 3, height: 6
+            })
+        %>
+
+        <!--Diglett's Tunnel Extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Diglett's Tunnel"
+            , x: 74, y: 45
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Memorial Hill"
+            , x: 74, y: 52
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Ruins of Life"
+            , x: 80, y: 47
+            , width: 4, height: 3
+            })
+        %>
+
+        <!-- ------------------ -->
+        <!-- PLACES OF INTEREST -->
+        <!-- ------------------ -->
+
+        <%- include('templates/mapPOI',
+            { name: "Dock"
+            , x: 9, y: 33
+            , width: 2, height: 3
+            , databind: "click:function(){MapHelper.openShipModal()}"
+            })
+        %>
+    </g>
+
+    <g data-bind="visible: player.subregion == SubRegions.getSubRegion(GameConstants.Region.alola, 'Ula\'ula & Poni islands').id">
+        <image width="1600" height="960" xlink:href="assets/images/kanto.png" href="assets/images/alola2.png"></image>
+
+        <!-- ------ -->
+        <!-- ROUTES -->
+        <!-- ------ -->
+
+        <!--Route 10-->
+        <%- include('templates/mapRoute',
+            { route: 10, region: 6
+            , width: 9, height: 3
+            , x: 64, y: 19
+            })
+        %>
+
+        <!--Mount Hokulani-->
+        <%- include('templates/mapRoute',
+            { route: 22, region: 6
+            , width: 3, height: 6, name: "MH"
+            , x: 64, y: 13
+            })
+        %>
+
+        <!--Route 11-->
+        <%- include('templates/mapRoute',
+            { route: 11, region: 6
+            , width: 3, height: 7
+            , x: 73, y: 22
+            })
+        %>
+
+        <!--Route 11 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 11, region: 6
+            , width: 6, height: 3
+            , x: 76, y: 26
+            , noText: true
+            })
+        %>
+
+        <!--Route 12-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 3, height: 12
+            , x: 84, y: 31
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 4
+            , x: 82, y: 26
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 4
+            , x: 83, y: 27
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 3
+            , x: 84, y: 28
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 2
+            , x: 85, y: 29
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 1
+            , x: 86, y: 30
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 1
+            , x: 86, y: 43
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 2
+            , x: 85, y: 43
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 3
+            , x: 84, y: 43
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 4
+            , x: 83, y: 43
+            , noText: true
+            })
+        %>
+
+        <!--Route 12 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 6
+            , width: 1, height: 3
+            , x: 82, y: 44
+            , noText: true
+            })
+        %>
+
+        <!--Route 13-->
+        <%- include('templates/mapRoute',
+            { route: 13, region: 6
+            , width: 14, height: 3
+            , x: 68, y: 44
+            })
+        %>
+
+        <!--Haina Desert-->
+        <%- include('templates/mapRoute',
+            { route: 23, region: 6
+            , width: 3, height: 10, name: "HD"
+            , x: 73, y: 34
+            })
+        %>
+
+        <!--Route 14-->
+        <%- include('templates/mapRoute',
+            { route: 14, region: 6
+            , width: 3, height: 7
+            , x: 62, y: 47
+            })
+        %>
+
+        <!--Route 14 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 14, region: 6
+            , width: 3, height: 3
+            , x: 65, y: 51
+            , noText: true
+            })
+        %>
+
+        <!--Route 15-->
+        <%- include('templates/mapRoute',
+            { route: 15, region: 6
+            , width: 4, height: 12
+            , x: 53, y: 35
+            })
+        %>
+
+        <!--Route 15 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 15, region: 6
+            , width: 5, height: 4
+            , x: 57, y: 43
+            , noText: true
+            })
+        %>
+
+        <!--Route 15 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 15, region: 6
+            , width: 2, height: 3
+            , x: 62, y: 44
+            , noText: true
+            })
+        %>
+
+        <!--Route 16-->
+        <%- include('templates/mapRoute',
+            { route: 16, region: 6
+            , width: 3, height: 6
+            , x: 54, y: 29
+            })
+        %>
+
+        <!--Route 17-->
+        <%- include('templates/mapRoute',
+            { route: 17, region: 6
+            , width: 3, height: 14
+            , x: 54, y: 12
+            })
+        %>
+
+        <!--Route 17 Extension-->
+        <%- include('templates/mapRoute',
+            { route: 17, region: 6
+            , width: 2, height: 3
+            , x: 52, y: 12
+            , noText: true
+            })
+        %>
+
+        <!--Poni Wilds-->
+        <%- include('templates/mapRoute',
+            { route: 24, region: 6
+            , width: 12, height: 3, name: "PW"
+            , x: 16, y: 38
+            })
+        %>
+
+        <!--Poni Wilds Extension-->
+        <%- include('templates/mapRoute',
+            { route: 24, region: 6
+            , width: 4, height: 3
+            , x: 25, y: 41
+            , noText: true
+            })
+        %>
+
+        <!--Poni Wilds Extension-->
+        <%- include('templates/mapRoute',
+            { route: 24, region: 6
+            , width: 3, height: 0.5
+            , x: 16, y: 41
+            , noText: true
+            })
+        %>
+
+        <!--Ancient Poni Path-->
+        <%- include('templates/mapRoute',
+            { route: 25, region: 6
+            , width: 7, height: 3, name: "APP"
+            , x: 29, y: 41
+            })
+        %>
+
+        <!--Ancient Poni Path Extension-->
+        <%- include('templates/mapRoute',
+            { route: 25, region: 6
+            , width: 3, height: 6
+            , x: 29, y: 35
+            , noText: true
+            })
+        %>
+
+        <!--Poni Breaker Coast-->
+        <%- include('templates/mapRoute',
+            { route: 26, region: 6
+            , width: 8, height: 3, name: "PBC"
+            , x: 31, y: 44
+            })
+        %>
+
+        <!--Poni Grove-->
+        <%- include('templates/mapRoute',
+            { route: 27, region: 6
+            , width: 3, height: 5, name: "PGr"
+            , x: 33, y: 36
+            })
+        %>
+
+        <!--Poni Plains-->
+        <%- include('templates/mapRoute',
+            { route: 28, region: 6
+            , width: 7, height: 3, name: "PP"
+            , x: 36, y: 36
+            })
+        %>
+
+        <!--Poni Coast-->
+        <%- include('templates/mapRoute',
+            { route: 29, region: 6
+            , width: 3, height: 8, name: "PC"
+            , x: 40, y: 28
+            })
+        %>
+
+        <!--Poni Gauntlet-->
+        <%- include('templates/mapRoute',
+            { route: 30, region: 6
+            , width: 7, height: 3, name: "PGa"
+            , x: 32, y: 23
+            })
+        %>
+
+        <!--Poni Gauntlet Extension-->
+        <%- include('templates/mapRoute',
+            { route: 30, region: 6
+            , width: 1, height: 1
+            , x: 38, y: 26
+            , noText: true
+            })
+        %>
+
+        <!--Poni Gauntlet Extension-->
+        <%- include('templates/mapRoute',
+            { route: 30, region: 6
+            , width: 1, height: 4
+            , x: 39, y: 24
+            , noText: true
+            })
+        %>
+
+        <!--Poni Gauntlet Extension-->
+        <%- include('templates/mapRoute',
+            { route: 30, region: 6
+            , width: 1, height: 3
+            , x: 40, y: 25
+            , noText: true
+            })
+        %>
+
+        <!--Poni Gauntlet Extension-->
+        <%- include('templates/mapRoute',
+            { route: 30, region: 6
+            , width: 1, height: 2
+            , x: 41, y: 26
+            , noText: true
+            })
+        %>
+
+        <!--Poni Gauntlet Extension-->
+        <%- include('templates/mapRoute',
+            { route: 30, region: 6
+            , width: 1, height: 1
+            , x: 42, y: 27
+            , noText: true
+            })
+        %>
+
+        <!-- ----- -->
+        <!-- TOWNS -->
+        <!-- ----- -->
+
+        <!--Aether Paradise-->
+        <%- include('templates/mapTown',
+            { name: "Aether Paradise"
+            , x: 40, y: 1.5
+            , width: 5, height: 4.5
+            })
+        %>
+
+        <!--Malie City-->
+        <%- include('templates/mapTown',
+            { name: "Malie City"
+            , x: 77, y: 17.5
+            , width: 5, height: 4.5
+            })
+        %>
+
+        <!--Malie City Extension-->
+        <%- include('templates/mapTown',
+            { name: "Malie City"
+            , x: 73, y: 18
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Tapu Village-->
+        <%- include('templates/mapTown',
+            { name: "Tapu Village"
+            , x: 64, y: 43
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Seafolk Village-->
+        <%- include('templates/mapTown',
+            { name: "Seafolk Village"
+            , x: 15, y: 41.5
+            , width: 5, height: 4.5
+            })
+        %>
+
+        <!--Exeggutor Island-->
+        <%- include('templates/mapTown',
+            { name: "Exeggutor Island"
+            , x: 5, y: 43
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Altar of the Sunne and Moone-->
+        <%- include('templates/mapTown',
+            { name: "Altar of the Sunne and Moone"
+            , x: 25, y: 25
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Pokémon League Alola-->
+        <%- include('templates/mapTown',
+            { name: "Pokémon League Alola"
+            , x: 60.5, y: 32
+            , width: 10, height: 7.5
+            })
+        %>
+
+        <!-- -------- -->
+        <!-- DUNGEONS -->
+        <!-- -------- -->
+
+        <%- include('templates/mapDungeon',
+            { name: "Malie Garden"
+            , x: 73, y: 15
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Hokulani Observatory"
+            , x: 64, y: 9
+            , width: 4, height: 4
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Thrifty Megamart"
+            , x: 65, y: 48
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Ula\'ula Meadow"
+            , x: 53, y: 26
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Po Town"
+            , x: 52, y: 9
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Mount Lanakila"
+            , x: 64, y: 40
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Ruins of Abundance"
+            , x: 73, y: 31
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Vast Poni Canyon"
+            , x: 29, y: 31
+            , width: 4, height: 4
+            })
+        %>
+
+        <!--Vast Poni Canyon Extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Vast Poni Canyon"
+            , x: 25, y: 29
+            , width: 4, height: 3
+            })
+        %>
+
+        <!--Vast Poni Canyon Extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Vast Poni Canyon"
+            , x: 28, y: 32
+            , width: 1, height: 1
+            })
+        %>
+
+        <!--Vast Poni Canyon Extension-->
+        <%- include('templates/mapDungeon',
+            { name: "Vast Poni Canyon"
+            , x: 29, y: 30
+            , width: 2, height: 1
+            })
+        %>
+
+        <!--Lake of the Sunne and Moone-->
+        <%- include('templates/mapDungeon',
+            { name: "Lake of the Sunne and Moone"
+            , x: 57, y: 26
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Ruins of Hope"
+            , x: 36, y: 41
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Poni Meadow"
+            , x: 36, y: 33
+            , width: 4, height: 3
+            })
+        %>
+
+        <%- include('templates/mapDungeon',
+            { name: "Resolution Cave"
+            , x: 36, y: 30
+            , width: 4, height: 3
+            })
+        %>
+
+        <!-- ------------------ -->
+        <!-- PLACES OF INTEREST -->
+        <!-- ------------------ -->
+
+        <!-- TODO: REMOVE IF UB QUESTLINE GETS MERGED -->
+        <%- include('templates/mapOverlay',
+            { name: "Access Denied - Future Content"
+            , x: 36, y: 30
+            , width: 4, height: 3
+            , databind: "click:function(){MapHelper.moveToTown('Seafolk Village')}, attr:{ class: MapHelper.calculateTownCssClass('Seafolk Village') }"
+            , visible:  "App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Poni Meadow')]() >= 1"
+            , image: "assets/images/map/transparent.png"
+            })
+        %>
+    </g>
 </g>

--- a/src/components/GalarSVG.html
+++ b/src/components/GalarSVG.html
@@ -1,541 +1,541 @@
 <g data-bind='visible: player.region == GameConstants.Region.galar'>
-    <!-- ko if: player.subregion == SubRegions.getSubRegion(GameConstants.Region.galar, 'Galar').id -->
-    <image width="1600" height="960" xlink:href="assets/images/galar.png" href="assets/images/galar.png"></image>
+    <g data-bind="visible: player.subregion == SubRegions.getSubRegion(GameConstants.Region.galar, 'Galar').id">
+        <image width="1600" height="960" xlink:href="assets/images/galar.png" href="assets/images/galar.png"></image>
 
-    <!-- ------ -->
-    <!-- ROUTES -->
-    <!-- ------ -->
+        <!-- ------ -->
+        <!-- ROUTES -->
+        <!-- ------ -->
 
-    <!--Route 1-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 7
-        , width: 4, height: 2
-        , x: 45, y: 54
-        , rotate: true
-        , textY: 19
-        })
-    %>
+        <!--Route 1-->
+        <%- include('templates/mapRoute',
+            { route: 1, region: 7
+            , width: 4, height: 2
+            , x: 45, y: 54
+            , rotate: true
+            , textY: 19
+            })
+        %>
 
-    <!--Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 7
-        , width: 3, height: 2
-        , x: 48, y: 52
-        })
-    %>
-    <!--extra Route 2-->
-    <%- include('templates/mapRoute',
-        { route: 2, region: 7
-        , width: 1, height: 2
-        , x: 49, y: 51
-        , rotate: true
-        , noText: true
-        })
-    %>
+        <!--Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 7
+            , width: 3, height: 2
+            , x: 48, y: 52
+            })
+        %>
+        <!--extra Route 2-->
+        <%- include('templates/mapRoute',
+            { route: 2, region: 7
+            , width: 1, height: 2
+            , x: 49, y: 51
+            , rotate: true
+            , noText: true
+            })
+        %>
 
-    <!--Rolling Fields-->
-    <%- include('templates/mapRoute',
-        { route: 3, region: 7
-        , width: 5, height: 2
-        , x: 45, y: 45, name: "R.F."
-        , rotate: true
-        , textY: 19
-        , textX: 5
-        })
-    %>
+        <!--Rolling Fields-->
+        <%- include('templates/mapRoute',
+            { route: 3, region: 7
+            , width: 5, height: 2
+            , x: 45, y: 45, name: "R.F."
+            , rotate: true
+            , textY: 19
+            , textX: 5
+            })
+        %>
 
-    <!--Dappled Grove-->
-    <%- include('templates/mapRoute',
-        { route: 4, region: 7
-        , width: 6, height: 2
-        , x: 39, y: 47, name: "D.G."
-        })
-    %>
-    <!--DG Extras-->
-    <%- include('templates/mapRoute',
-        { route: 4, region: 7
-        , width: 4, height: 2
-        , x: 39, y: 43
-        , rotate: true
-        , noText: true
-        })
-    %>
+        <!--Dappled Grove-->
+        <%- include('templates/mapRoute',
+            { route: 4, region: 7
+            , width: 6, height: 2
+            , x: 39, y: 47, name: "D.G."
+            })
+        %>
+        <!--DG Extras-->
+        <%- include('templates/mapRoute',
+            { route: 4, region: 7
+            , width: 4, height: 2
+            , x: 39, y: 43
+            , rotate: true
+            , noText: true
+            })
+        %>
 
-    <!--West Lake Axwell-->
-    <%- include('templates/mapRoute',
-        { route: 5, region: 7
-        , width: 5, height: 2
-        , x: 43, y: 42, name: "W.L.A."
-        , rotate: true
-        , textY: 19
-        , textX: -10
-        })
-    %>
-    <!--WLA Extra-->
-    <%- include('templates/mapRoute',
-        { route: 5, region: 7
-        , width: 4, height: 2
-        , x: 42, y: 40, name: "W.L.A"
-        , noText: true
-        })
-    %>
+        <!--West Lake Axwell-->
+        <%- include('templates/mapRoute',
+            { route: 5, region: 7
+            , width: 5, height: 2
+            , x: 43, y: 42, name: "W.L.A."
+            , rotate: true
+            , textY: 19
+            , textX: -10
+            })
+        %>
+        <!--WLA Extra-->
+        <%- include('templates/mapRoute',
+            { route: 5, region: 7
+            , width: 4, height: 2
+            , x: 42, y: 40, name: "W.L.A"
+            , noText: true
+            })
+        %>
 
-    <!--East Lake Axwell-->
-    <%- include('templates/mapRoute',
-        { route: 6, region: 7
-        , width: 8, height: 2
-        , x: 46, y: 40, name: "E.L.A"
-        })
-    %>
-    <!--ELA Extras-->
-    <%- include('templates/mapRoute',
-        { route: 6, region: 7
-        , width: 1, height: 2
-        , x: 49, y: 39, name: "E.L.A"
-        , noText: true
-        , rotate: true
-        })
-    %>
+        <!--East Lake Axwell-->
+        <%- include('templates/mapRoute',
+            { route: 6, region: 7
+            , width: 8, height: 2
+            , x: 46, y: 40, name: "E.L.A"
+            })
+        %>
+        <!--ELA Extras-->
+        <%- include('templates/mapRoute',
+            { route: 6, region: 7
+            , width: 1, height: 2
+            , x: 49, y: 39, name: "E.L.A"
+            , noText: true
+            , rotate: true
+            })
+        %>
 
-    <!--North Lake Miloch-->
-    <%- include('templates/mapRoute',
-        { route: 9, region: 7
-        , width: 7, height: 2
-        , x: 54, y: 40, name: "N.L.M."
-        , rotate: true
-        , textY: 19
-        , textX: 3
-        })
-    %>
+        <!--North Lake Miloch-->
+        <%- include('templates/mapRoute',
+            { route: 9, region: 7
+            , width: 7, height: 2
+            , x: 54, y: 40, name: "N.L.M."
+            , rotate: true
+            , textY: 19
+            , textX: 3
+            })
+        %>
 
-    <!--South Lake Miloch-->
-    <%- include('templates/mapRoute',
-        { route: 8, region: 7
-        , width: 7, height: 2
-        , x: 47, y: 45, name: "S.L.M."
-        })
-    %>
-     <!--SLM Extras-->
-    <%- include('templates/mapRoute',
-        { route: 8, region: 7
-        , width: 3, height: 2
-        , x: 49, y: 42, name: "S.L.M"
-        , noText: true
-        , rotate: true
-        })
-    %>
+        <!--South Lake Miloch-->
+        <%- include('templates/mapRoute',
+            { route: 8, region: 7
+            , width: 7, height: 2
+            , x: 47, y: 45, name: "S.L.M."
+            })
+        %>
+        <!--SLM Extras-->
+        <%- include('templates/mapRoute',
+            { route: 8, region: 7
+            , width: 3, height: 2
+            , x: 49, y: 42, name: "S.L.M"
+            , noText: true
+            , rotate: true
+            })
+        %>
 
-    <!--Giant's Seat-->
-    <%- include('templates/mapRoute',
-        { route: 7, region: 7
-        , width: 9, height: 2
-        , x: 47, y: 47, name: "G.S"
-        })
-    %>
+        <!--Giant's Seat-->
+        <%- include('templates/mapRoute',
+            { route: 7, region: 7
+            , width: 9, height: 2
+            , x: 47, y: 47, name: "G.S"
+            })
+        %>
 
-    <!--Route 3-->
-    <%- include('templates/mapRoute',
-        { route: 10, region: 7
-        , width: 6, height: 2
-        , x: 39, y: 36, name: "3"
-        })
-    %>
+        <!--Route 3-->
+        <%- include('templates/mapRoute',
+            { route: 10, region: 7
+            , width: 6, height: 2
+            , x: 39, y: 36, name: "3"
+            })
+        %>
 
-    <!--Route 4-->
-    <%- include('templates/mapRoute',
-        { route: 11, region: 7
-        , width: 3, height: 2
-        , x: 35, y: 32, name: "4"
-        , rotate: true
-        , textY: 19
-        })
-    %>
+        <!--Route 4-->
+        <%- include('templates/mapRoute',
+            { route: 11, region: 7
+            , width: 3, height: 2
+            , x: 35, y: 32, name: "4"
+            , rotate: true
+            , textY: 19
+            })
+        %>
 
-    <!--Route 5-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 7
-        , width: 20, height: 2
-        , x: 38, y: 30, name: "5"
-        })
-    %>
-    <!--Extra bits of Route 5-->
-    <%- include('templates/mapRoute',
-        { route: 12, region: 7
-        , width: 1, height: 1
-        , x: 57, y: 32
-        , noText: true
-        })
-    %>
+        <!--Route 5-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 7
+            , width: 20, height: 2
+            , x: 38, y: 30, name: "5"
+            })
+        %>
+        <!--Extra bits of Route 5-->
+        <%- include('templates/mapRoute',
+            { route: 12, region: 7
+            , width: 1, height: 1
+            , x: 57, y: 32
+            , noText: true
+            })
+        %>
 
-    <!--Motostoke Outskirts-->
-    <%- include('templates/mapRoute',
-        { route: 13, region: 7
-        , width: 5, height: 2
-        , x: 54, y: 36, name: "M.S."
-        })
-    %>
+        <!--Motostoke Outskirts-->
+        <%- include('templates/mapRoute',
+            { route: 13, region: 7
+            , width: 5, height: 2
+            , x: 54, y: 36, name: "M.S."
+            })
+        %>
 
-    <!--Hammerlocke Hills-->
-    <%- include('templates/mapRoute',
-        { route: 14, region: 7
-        , width: 3, height: 1.75
-        , x: 47, y: 33, name: "H.H."
-        })
-     %>
-     <!--HH extras-->
-    <%- include('templates/mapRoute',
-        { route: 14, region: 7
-        , width: 1, height: 1
-        , x: 49, y: 32, name: "H.H."
-        , noText: true
-        })
-     %>
-     <!--HH extras-->
-    <%- include('templates/mapRoute',
-        { route: 1146, region: 7
-        , width: 1, height: 2
-        , x: 49, y: 29, name: "H.H."
-        , noText: true
-        , rotate: true
-        })
-     %>
+        <!--Hammerlocke Hills-->
+        <%- include('templates/mapRoute',
+            { route: 14, region: 7
+            , width: 3, height: 1.75
+            , x: 47, y: 33, name: "H.H."
+            })
+        %>
+        <!--HH extras-->
+        <%- include('templates/mapRoute',
+            { route: 14, region: 7
+            , width: 1, height: 1
+            , x: 49, y: 32, name: "H.H."
+            , noText: true
+            })
+        %>
+        <!--HH extras-->
+        <%- include('templates/mapRoute',
+            { route: 1146, region: 7
+            , width: 1, height: 2
+            , x: 49, y: 29, name: "H.H."
+            , noText: true
+            , rotate: true
+            })
+        %>
 
-    <!--Route 6-->
-    <%- include('templates/mapRoute',
-        { route: 15, region: 7
-        , width: 4, height: 1
-        , x: 45, y: 25
-        , rotate: true
-        , noText: true
-        })
-    %>
-    <!--Extra bit of Route 6-->
-    <%- include('templates/mapRoute',
-        { route: 15, region: 7
-        , width: 5, height: 2
-        , x: 42, y: 23, name: "6"
-        })
-    %>
-    <!--Extra bit of Route 6-->
-    <%- include('templates/mapRoute',
-        { route: 15, region: 7
-        , width: 3, height: 2
-        , x: 42, y: 20
-        , noText: true
-        , rotate: true
-        })
-    %>
-    <!--Extra bit of Route 6-->
-    <%- include('templates/mapRoute',
-        { route: 15, region: 7
-        , width: 2, height: 2
-        , x: 40, y: 20
-        , noText: true
-        })
-    %>
+        <!--Route 6-->
+        <%- include('templates/mapRoute',
+            { route: 15, region: 7
+            , width: 4, height: 1
+            , x: 45, y: 25
+            , rotate: true
+            , noText: true
+            })
+        %>
+        <!--Extra bit of Route 6-->
+        <%- include('templates/mapRoute',
+            { route: 15, region: 7
+            , width: 5, height: 2
+            , x: 42, y: 23, name: "6"
+            })
+        %>
+        <!--Extra bit of Route 6-->
+        <%- include('templates/mapRoute',
+            { route: 15, region: 7
+            , width: 3, height: 2
+            , x: 42, y: 20
+            , noText: true
+            , rotate: true
+            })
+        %>
+        <!--Extra bit of Route 6-->
+        <%- include('templates/mapRoute',
+            { route: 15, region: 7
+            , width: 2, height: 2
+            , x: 40, y: 20
+            , noText: true
+            })
+        %>
 
-    <!--Route 7-->
-    <%- include('templates/mapRoute',
-        { route: 16, region: 7
-        , width: 5, height: 2
-        , x: 51, y: 27, name: "7"
-        })
-    %>
+        <!--Route 7-->
+        <%- include('templates/mapRoute',
+            { route: 16, region: 7
+            , width: 5, height: 2
+            , x: 51, y: 27, name: "7"
+            })
+        %>
 
-    <!--Route 8-->
-    <%- include('templates/mapRoute',
-        { route: 17, region: 7
-        , width: 6, height: 2
-        , x: 52, y: 21, name: "8"
-        , rotate: true
-        , textY: 19
-        })
-    %>
+        <!--Route 8-->
+        <%- include('templates/mapRoute',
+            { route: 17, region: 7
+            , width: 6, height: 2
+            , x: 52, y: 21, name: "8"
+            , rotate: true
+            , textY: 19
+            })
+        %>
 
-    <!--Steamdrift Way-->
-    <%- include('templates/mapRoute',
-        { route: 18, region: 7
-        , width: 4, height: 2
-        , x: 54, y: 19, name: "S.W."
-        , rotate: true
-        , textY: 19
-        })
-    %>
+        <!--Steamdrift Way-->
+        <%- include('templates/mapRoute',
+            { route: 18, region: 7
+            , width: 4, height: 2
+            , x: 54, y: 19, name: "S.W."
+            , rotate: true
+            , textY: 19
+            })
+        %>
 
-    <!--Route 2 Lakeside-->
-     <%- include('templates/mapRoute',
-        { route: 19, region: 7
-        , width: 3, height: 2
-        , x: 49, y: 49, name: "L.S."
-        , textX: 10
-        })
-    %>
-    <!--Route 2 LS extras-->
-    <%- include('templates/mapRoute',
-        { route: 19, region: 7
-        , width: 2, height: 2
-        , x: 51, y: 50
-        , noText: true
-        })
-    %>
+        <!--Route 2 Lakeside-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 7
+            , width: 3, height: 2
+            , x: 49, y: 49, name: "L.S."
+            , textX: 10
+            })
+        %>
+        <!--Route 2 LS extras-->
+        <%- include('templates/mapRoute',
+            { route: 19, region: 7
+            , width: 2, height: 2
+            , x: 51, y: 50
+            , noText: true
+            })
+        %>
 
-    <!--Route 9-->
-    <%- include('templates/mapRoute',
-        { route: 20, region: 7
-        , width: 3, height: 2
-        , x: 59, y: 19, name: "9"
-        , rotate: true
-        , textY: 19
-        })
-     %>
+        <!--Route 9-->
+        <%- include('templates/mapRoute',
+            { route: 20, region: 7
+            , width: 3, height: 2
+            , x: 59, y: 19, name: "9"
+            , rotate: true
+            , textY: 19
+            })
+        %>
 
-    <!--Circhester Bay-->
-    <%- include('templates/mapRoute',
-        { route: 21, region: 7
-        , width: 5, height: 2
-        , x: 59, y: 22, name: "C.B."
-        , rotate: true
-        , textY: 19
-        })
-     %>
+        <!--Circhester Bay-->
+        <%- include('templates/mapRoute',
+            { route: 21, region: 7
+            , width: 5, height: 2
+            , x: 59, y: 22, name: "C.B."
+            , rotate: true
+            , textY: 19
+            })
+        %>
 
-    <!--Outer Spikemuth-->
-    <%- include('templates/mapRoute',
-        { route: 22, region: 7
-        , width: 5, height: 2
-        , x: 56, y: 27, name: "O.S."
-        })
-    %>
+        <!--Outer Spikemuth-->
+        <%- include('templates/mapRoute',
+            { route: 22, region: 7
+            , width: 5, height: 2
+            , x: 56, y: 27, name: "O.S."
+            })
+        %>
 
-    <!--Route 10-->
-    <%- include('templates/mapRoute',
-        { route: 23, region: 7
-        , width: 4, height: 2
-        , x: 47, y: 15, name: "10 S."
-        , rotate: true
-        , textY: 19
-        })
-    %>
+        <!--Route 10-->
+        <%- include('templates/mapRoute',
+            { route: 23, region: 7
+            , width: 4, height: 2
+            , x: 47, y: 15, name: "10 S."
+            , rotate: true
+            , textY: 19
+            })
+        %>
 
-    <!--Route 10 North-->
-    <%- include('templates/mapRoute',
-        { route: 24, region: 7
-        , width: 7, height: 2
-        , x: 48, y: 8, name: "10 N."
-        , rotate: true
-        , textY: 19
-        })
-    %>
-    <!--Route 10 North extras-->
-    <%- include('templates/mapRoute',
-        { route: 24, region: 7
-        , width: 1, height: 2
-        , x: 47, y: 13, name: "10 N."
-        , noText: true
-        })
-    %>
+        <!--Route 10 North-->
+        <%- include('templates/mapRoute',
+            { route: 24, region: 7
+            , width: 7, height: 2
+            , x: 48, y: 8, name: "10 N."
+            , rotate: true
+            , textY: 19
+            })
+        %>
+        <!--Route 10 North extras-->
+        <%- include('templates/mapRoute',
+            { route: 24, region: 7
+            , width: 1, height: 2
+            , x: 47, y: 13, name: "10 N."
+            , noText: true
+            })
+        %>
 
-    <!-- ----- -->
-    <!-- TOWNS -->
-    <!-- ----- -->
+        <!-- ----- -->
+        <!-- TOWNS -->
+        <!-- ----- -->
 
-    <!--Postwick-->
-    <%- include('templates/mapTown',
-        { name: "Postwick"
-        , x: 40, y: 54.5
-        , width: 5, height: 4.5
-        , home: true
-        })
-    %>
+        <!--Postwick-->
+        <%- include('templates/mapTown',
+            { name: "Postwick"
+            , x: 40, y: 54.5
+            , width: 5, height: 4.5
+            , home: true
+            })
+        %>
 
-    <!--Wedgehurst-->
-    <%- include('templates/mapTown',
-        { name: "Wedgehurst"
-        , x: 44, y: 50
-        })
-    %>
+        <!--Wedgehurst-->
+        <%- include('templates/mapTown',
+            { name: "Wedgehurst"
+            , x: 44, y: 50
+            })
+        %>
 
-    <!--Motostoke-->
-    <%- include('templates/mapTown',
-        { name: "Motostoke"
-        , x: 45, y: 34.75
-        , width: 5, height: 4.25
-        })
-    %>
-    <!--Motostoke Extension-->
-    <%- include('templates/mapTown',
-        { name: "Motostoke"
-        , x: 50, y: 35
-        })
-    %>
+        <!--Motostoke-->
+        <%- include('templates/mapTown',
+            { name: "Motostoke"
+            , x: 45, y: 34.75
+            , width: 5, height: 4.25
+            })
+        %>
+        <!--Motostoke Extension-->
+        <%- include('templates/mapTown',
+            { name: "Motostoke"
+            , x: 50, y: 35
+            })
+        %>
 
-    <!--Turffield-->
-    <%- include('templates/mapTown',
-        { name: "Turffield"
-        , x: 34, y: 28
-        })
-    %>
+        <!--Turffield-->
+        <%- include('templates/mapTown',
+            { name: "Turffield"
+            , x: 34, y: 28
+            })
+        %>
 
-    <!--Hulbury-->
-    <%- include('templates/mapTown',
-        { name: "Hulbury"
-        , x: 58, y: 29
-        })
-    %>
+        <!--Hulbury-->
+        <%- include('templates/mapTown',
+            { name: "Hulbury"
+            , x: 58, y: 29
+            })
+        %>
 
-    <!--Hammerlocke-->
-    <%- include('templates/mapTown',
-        { name: "Hammerlocke"
-        , x: 46, y: 24.5
-        , width: 5, height: 4.5
-        })
-    %>
+        <!--Hammerlocke-->
+        <%- include('templates/mapTown',
+            { name: "Hammerlocke"
+            , x: 46, y: 24.5
+            , width: 5, height: 4.5
+            })
+        %>
 
-    <!--Stow-on-Side-->
-    <%- include('templates/mapTown',
-        { name: "Stow-on-Side"
-        , x: 36, y: 18
-        })
-    %>
+        <!--Stow-on-Side-->
+        <%- include('templates/mapTown',
+            { name: "Stow-on-Side"
+            , x: 36, y: 18
+            })
+        %>
 
-    <!--Ballonlea-->
-    <%- include('templates/mapTown',
-        { name: "Ballonlea"
-        , x: 35, y: 11
-        })
-    %>
+        <!--Ballonlea-->
+        <%- include('templates/mapTown',
+            { name: "Ballonlea"
+            , x: 35, y: 11
+            })
+        %>
 
-    <!--Circhester-->
-    <%- include('templates/mapTown',
-        { name: "Circhester"
-        , x: 54, y: 14.5
-        , width: 5, height: 4.5
-        })
-    %>
-    <!--Circhester extension-->
-    <%- include('templates/mapTown',
-        { name: "Circhester"
-        , x: 59, y: 15
-        })
-    %>
+        <!--Circhester-->
+        <%- include('templates/mapTown',
+            { name: "Circhester"
+            , x: 54, y: 14.5
+            , width: 5, height: 4.5
+            })
+        %>
+        <!--Circhester extension-->
+        <%- include('templates/mapTown',
+            { name: "Circhester"
+            , x: 59, y: 15
+            })
+        %>
 
-    <!--Spikemuth-->
-    <%- include('templates/mapTown',
-        { name: "Spikemuth"
-        , x: 61, y: 25
-        })
-    %>
+        <!--Spikemuth-->
+        <%- include('templates/mapTown',
+            { name: "Spikemuth"
+            , x: 61, y: 25
+            })
+        %>
 
-    <!--Wyndon-->
-    <%- include('templates/mapTown',
-        { name: "Wyndon"
-        , x: 44, y: 3.5
-        , width: 5, height: 4.5
-        })
-    %>
-    <!--Wyndon Extension-->
-    <%- include('templates/mapTown',
-        { name: "Wyndon"
-        , x: 49, y: 4
-        })
-    %>
+        <!--Wyndon-->
+        <%- include('templates/mapTown',
+            { name: "Wyndon"
+            , x: 44, y: 3.5
+            , width: 5, height: 4.5
+            })
+        %>
+        <!--Wyndon Extension-->
+        <%- include('templates/mapTown',
+            { name: "Wyndon"
+            , x: 49, y: 4
+            })
+        %>
 
-    <!--Wyndon Stadium-->
-    <%- include('templates/mapTown',
-        { name: "Wyndon Stadium"
-        , x: 53.5, y: 0.25
-        , width: 10, height: 7.5
-        })
-    %>
+        <!--Wyndon Stadium-->
+        <%- include('templates/mapTown',
+            { name: "Wyndon Stadium"
+            , x: 53.5, y: 0.25
+            , width: 10, height: 7.5
+            })
+        %>
 
 
-    <!-- -------- -->
-    <!-- DUNGEONS -->
-    <!-- -------- -->
+        <!-- -------- -->
+        <!-- DUNGEONS -->
+        <!-- -------- -->
 
-    <!--Slumbering Weald-->
-    <%- include('templates/mapDungeon',
-        { name: "Slumbering Weald"
-        , x: 36, y: 57
-        , width: 4, height: 3
-        })
-    %>
+        <!--Slumbering Weald-->
+        <%- include('templates/mapDungeon',
+            { name: "Slumbering Weald"
+            , x: 36, y: 57
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Inner Slumbering Weald-->
-    <%- include('templates/mapDungeon',
-        { name: "Inner Slumbering Weald"
-        , x: 36, y: 54
-        , width: 4, height: 3
-        })
-    %>
+        <!--Inner Slumbering Weald-->
+        <%- include('templates/mapDungeon',
+            { name: "Inner Slumbering Weald"
+            , x: 36, y: 54
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Watchtower Ruins-->
-    <%- include('templates/mapDungeon',
-        { name: "Watchtower Ruins"
-        , x: 38, y: 40
-        , width: 4, height: 3
-        })
-    %>
+        <!--Watchtower Ruins-->
+        <%- include('templates/mapDungeon',
+            { name: "Watchtower Ruins"
+            , x: 38, y: 40
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Galar Mine-->
-    <%- include('templates/mapDungeon',
-        { name: "Galar Mine"
-        , x: 35, y: 35
-        , width: 4, height: 3
-        })
-    %>
+        <!--Galar Mine-->
+        <%- include('templates/mapDungeon',
+            { name: "Galar Mine"
+            , x: 35, y: 35
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Galar Mine No. 2-->
-    <%- include('templates/mapDungeon',
-        { name: "Galar Mine No. 2"
-        , x: 55, y: 33
-        , width: 4, height: 3
-        })
-    %>
+        <!--Galar Mine No. 2-->
+        <%- include('templates/mapDungeon',
+            { name: "Galar Mine No. 2"
+            , x: 55, y: 33
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Dusty Bowl-->
-    <%- include('templates/mapDungeon',
-        { name: "Dusty Bowl"
-        , x: 50, y: 32
-        , width: 4, height: 3
-        })
-    %>
+        <!--Dusty Bowl-->
+        <%- include('templates/mapDungeon',
+            { name: "Dusty Bowl"
+            , x: 50, y: 32
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Lake of Outrage-->
-    <%- include('templates/mapDungeon',
-        { name: "Lake of Outrage"
-        , x: 43, y: 32
-        , width: 4, height: 3
-        })
-    %>
+        <!--Lake of Outrage-->
+        <%- include('templates/mapDungeon',
+            { name: "Lake of Outrage"
+            , x: 43, y: 32
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Glimwood Tangle-->
-    <%- include('templates/mapDungeon',
-        { name: "Glimwood Tangle"
-        , x: 36, y: 15
-        , width: 4, height: 3
-        })
-    %>
+        <!--Glimwood Tangle-->
+        <%- include('templates/mapDungeon',
+            { name: "Glimwood Tangle"
+            , x: 36, y: 15
+            , width: 4, height: 3
+            })
+        %>
 
-    <!--Rose Tower-->
-    <%- include('templates/mapDungeon',
-        { name: "Rose Tower"
-        , x: 50, y: 5
-        , moveToTown: "Wyndon"
-        , width: 1, height: 1
-        })
-    %>
+        <!--Rose Tower-->
+        <%- include('templates/mapDungeon',
+            { name: "Rose Tower"
+            , x: 50, y: 5
+            , moveToTown: "Wyndon"
+            , width: 1, height: 1
+            })
+        %>
 
-    <!-- ------------------ -->
-    <!-- PLACES OF INTEREST -->
+        <!-- ------------------ -->
+        <!-- PLACES OF INTEREST -->
 
-    <!-- ------------------ -->
-    <%- include('templates/mapPOI',
-        { name: "Dock"
-        , x: 60, y: 33
-        , width: 2, height: 3
-        , databind: "click:function(){MapHelper.openShipModal()}, attr: { class: MapHelper.calculateTownCssClass('Hulbury') }"
-        })
-     %>
-    <!-- /ko -->
+        <!-- ------------------ -->
+        <%- include('templates/mapPOI',
+            { name: "Dock"
+            , x: 60, y: 33
+            , width: 2, height: 3
+            , databind: "click:function(){MapHelper.openShipModal()}, attr: { class: MapHelper.calculateTownCssClass('Hulbury') }"
+            })
+        %>
+    </g>
 </g>


### PR DESCRIPTION
Replace knockout if → visible for Alola and Galar maps
Fixes the tooltips not showing after changing subregions

Note: best to [hide whitespace changes in this PR to see what's actually changed.](https://github.com/pokeclicker/pokeclicker/pull/1880/files?w=1)