### PR TITLE
Update git test nodejs to latest lts version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 16.x
     - run: npm ci
     - run: gulp scripts
     - run: npm run eslint


### PR DESCRIPTION
Updates the nodejs version used in git test to the latest lts version (v16).