### PR TITLE
Update map colors, and text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -350,11 +350,11 @@
                     <span class='float-right px-4 bg-incomplete'>&nbsp;</span>
                     <br/><span>Uncaught Pokemon:</span>
                     <span class='float-right px-4 bg-uncaughtPokemon'>&nbsp;</span>
-                    <br/><span>Uncaught Shiny Pokemon and missing achievement:</span>
+                    <br/><span>Uncaught Shiny Pokemon and Missing Achievement:</span>
                     <span class='float-right px-4 bg-uncaughtShinyPokemonAndMissingAchievement'>&nbsp;</span>
                     <br/><span>Uncaught Shiny Pokemon:</span>
                     <span class='float-right px-4 bg-uncaughtShinyPokemon'>&nbsp;</span>
-                    <br/><span>Missing achievement:</span>
+                    <br/><span>Missing Achievement:</span>
                     <span class='float-right px-4 bg-missingAchievement'>&nbsp;</span>
                     <br/><span>Completed:</span>
                     <span class='float-right px-4 bg-completed'>&nbsp;</span>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -94,9 +94,9 @@ Settings.add(new CssVariableSetting('locked', 'Locked Location', [], '#000000'))
 Settings.add(new CssVariableSetting('currentPlace', 'Current Location', [], '#55ff00'));
 Settings.add(new CssVariableSetting('incomplete', 'Incomplete Area', [], '#ff9100'));
 Settings.add(new CssVariableSetting('uncaughtPokemon', 'Uncaught Pokemon', [], '#3498db'));
-Settings.add(new CssVariableSetting('uncaughtShinyPokemonAndMissingAchievement', 'Uncaught Shiny Pokemon and Missing Aachievement', [], '#ff3874'));
+Settings.add(new CssVariableSetting('uncaughtShinyPokemonAndMissingAchievement', 'Uncaught Shiny Pokemon and Missing Aachievement', [], '#c939fe'));
 Settings.add(new CssVariableSetting('uncaughtShinyPokemon', 'Uncaught Shiny Pokemon', [], '#ffee00'));
-Settings.add(new CssVariableSetting('missingAchievement', 'Missing Achievement', [], '#c939fe'));
+Settings.add(new CssVariableSetting('missingAchievement', 'Missing Achievement', [], '#57e3ff'));
 Settings.add(new CssVariableSetting('completed', 'Completed Location', [], '#ffffff'));
 
 // Other settings

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -94,7 +94,7 @@ Settings.add(new CssVariableSetting('locked', 'Locked Location', [], '#000000'))
 Settings.add(new CssVariableSetting('currentPlace', 'Current Location', [], '#55ff00'));
 Settings.add(new CssVariableSetting('incomplete', 'Incomplete Area', [], '#ff9100'));
 Settings.add(new CssVariableSetting('uncaughtPokemon', 'Uncaught Pokemon', [], '#3498db'));
-Settings.add(new CssVariableSetting('uncaughtShinyPokemonAndMissingAchievement', 'Uncaught Shiny Pokemon and Missing Aachievement', [], '#c939fe'));
+Settings.add(new CssVariableSetting('uncaughtShinyPokemonAndMissingAchievement', 'Uncaught Shiny Pokemon and Missing Achievement', [], '#c939fe'));
 Settings.add(new CssVariableSetting('uncaughtShinyPokemon', 'Uncaught Shiny Pokemon', [], '#ffee00'));
 Settings.add(new CssVariableSetting('missingAchievement', 'Missing Achievement', [], '#57e3ff'));
 Settings.add(new CssVariableSetting('completed', 'Completed Location', [], '#ffffff'));

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -14,9 +14,9 @@
 @currentPlace: #55ff00;
 @incomplete: #ff9100;
 @uncaughtPokemon: #3498db;
-@uncaughtShinyPokemonAndMissingAchievement: #ff3874;
+@uncaughtShinyPokemonAndMissingAchievement: #c939fe;
 @uncaughtShinyPokemon: #ffee00;
-@missingAchievement: #c939fe;
+@missingAchievement: #57e3ff;
 @completed: #ffffff00;
 
 // Usage: fill: var(--locked);


### PR DESCRIPTION
Changed default map colors for new colors and fixed up some text.

The old pink was a little too close to red and made it look like the route still needed to be completed in terms of progress.

PRE:
![image](https://user-images.githubusercontent.com/7288322/160053622-61527efb-7646-4912-973d-36de5ac98194.png)
POST:
![image](https://user-images.githubusercontent.com/7288322/160053136-db4df1c1-af4d-4a72-863b-6efc18dfb9bc.png)
