### PR TITLE
Fix DamageCalculator displaying NaN values

### DIFF
--- a/src/scripts/types/DamageCalculator.ts
+++ b/src/scripts/types/DamageCalculator.ts
@@ -1,13 +1,13 @@
 /// <reference path="../../declarations/GameHelper.d.ts" />
 
 class DamageCalculator {
-    static type1 = ko.observable(PokemonType.None);
-    static type2 = ko.observable(PokemonType.None);
+    static type1 = ko.observable(PokemonType.None).extend({ numeric: 0 });
+    static type2 = ko.observable(PokemonType.None).extend({ numeric: 0 });
     static region = ko.observable(GameConstants.Region.none);
     static includeBreeding = ko.observable(false);
     static baseAttackOnly = ko.observable(false);
     static ignoreLevel = ko.observable(false);
-    static detailType = ko.observable(PokemonType.None);
+    static detailType = ko.observable(PokemonType.None).extend({ numeric: 0 });
 
     static observableTypeDamageArray = ko.pureComputed(DamageCalculator.getDamageByTypes, DamageCalculator);
     static observableTypeDetails = ko.pureComputed(DamageCalculator.getTypeDetail);


### PR DESCRIPTION
TypeHelper changed to a strict equality check when defaulting `None` secondary types to the pokemon's primary type, but damage calculator has been silently passing these types as strings instead of numbers.