### PR TITLE
Now attempting to save on window unload

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -191,10 +191,15 @@ class Game {
         }
 
         this.interval = setInterval(() => !this.worker || !Settings.getSetting('useWebWorkerForGameTicks').value ? this.gameTick() : null, GameConstants.TICK_TIME);
+        window.onbeforeunload = () => {
+            player._lastSeen = Date.now();
+            Save.store(player);
+        };
     }
 
     stop() {
         clearTimeout(this.interval);
+        window.onbeforeunload = () => {};
     }
 
     gameTick() {


### PR DESCRIPTION
I have seen a couple of people been confused that the game only saves each 10th sec.
My solution is to do a save, when the window is unloading, which should fix most cases.
The save-code seams to be quick enough, that we are not hanging on to the window long enough, for the user to notice.
Only people, i could see not liking this change, is people exploiting the delay, to farm shiny from evo-stones... I don't know if that is a problem...