### PR TITLE
Now going to the correct subregion when moving region

### DIFF
--- a/src/components/shipModal.html
+++ b/src/components/shipModal.html
@@ -14,7 +14,7 @@
                     <button style="position: relative;" class='btn btn-block btn-success'
                         data-dismiss='modal'
                         data-bind='visible: GameConstants.Region[$data] <= player.highestRegion() && GameConstants.Region[$data] <= GameConstants.MAX_AVAILABLE_REGION,
-                        click: () => { MapHelper.moveToTown(GameConstants.DockTowns[GameConstants.Region[$data]]); player.region = GameConstants.Region[$data]; $("#ShipModal").modal("hide");  },
+                        click: () => { MapHelper.moveToTown(GameConstants.DockTowns[GameConstants.Region[$data]]); player.region = GameConstants.Region[$data]; player.subregion = 0; $("#ShipModal").modal("hide");  },
                         attr: { disabled: player.region == GameConstants.Region[$data] }'>
                         <img style="position:absolute; left: 10px;" data-bind="visible: player.region == GameConstants.Region[$data], attr: { src: `assets/images/profile/trainer-${App.game.profile.trainer() || 0}.png` }"/> <knockout data-bind="text: GameConstants.camelCaseToString($data)">Region</knockout>
                     </button>

--- a/src/components/shipModal.html
+++ b/src/components/shipModal.html
@@ -14,7 +14,7 @@
                     <button style="position: relative;" class='btn btn-block btn-success'
                         data-dismiss='modal'
                         data-bind='visible: GameConstants.Region[$data] <= player.highestRegion() && GameConstants.Region[$data] <= GameConstants.MAX_AVAILABLE_REGION,
-                        click: () => { MapHelper.moveToTown(GameConstants.DockTowns[GameConstants.Region[$data]]); player.region = GameConstants.Region[$data]; player.subregion = 0; $("#ShipModal").modal("hide");  },
+                        click: () => { MapHelper.moveToTown(GameConstants.DockTowns[GameConstants.Region[$data]]); player.region = GameConstants.Region[$data]; player._subregion(0); $("#ShipModal").modal("hide");  },
                         attr: { disabled: player.region == GameConstants.Region[$data] }'>
                         <img style="position:absolute; left: 10px;" data-bind="visible: player.region == GameConstants.Region[$data], attr: { src: `assets/images/profile/trainer-${App.game.profile.trainer() || 0}.png` }"/> <knockout data-bind="text: GameConstants.camelCaseToString($data)">Region</knockout>
                     </button>


### PR DESCRIPTION
When you moved from Alola, it remembered which subregion you where in. So when you moved back (using the dock), it set you to a town in subregion 0, but the map was still in the same subregion, as before you left.
This PR is a quick fix. As long as the main-dock is in subregion 0, it will work. So it might be a problem in later regions.

The "correct" fix is to add subregions to each town, like i have done with routes, and then change the subregion, in the MapHelper.moveToTown()-method.