### PR TITLE
Players highest subregion visited, is now saved

### DIFF
--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -229,6 +229,7 @@ class Player {
             'effectList',
             'effectTimer',
             'highestRegion',
+            'highestSubRegion',
         ];
         const plainJS = ko.toJS(this);
         return Save.filter(plainJS, keep);


### PR DESCRIPTION
The "flash on new subregion" resetted on page reload. Fixed that.