### PR TITLE
Add ability to hide dungeon bosses from the encounter list

### DIFF
--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -133,7 +133,7 @@
           <!-- /ko -->
           <!--Display all available bosses in this dungeon-->
           <!-- ko foreach: player.town().dungeon.bossEncounterList -->
-          <li class="list-inline-item">
+          <li class="list-inline-item" data-bind="hidden: $data.hide">
             <img class="boss" src="assets/images/dungeons/boss.svg"/>
             <img class="dungeon-pokemon-preview" src="" data-bind="attr:{ src: $data.image },
             css: { 'dungeon-pokemon-locked': $data.hidden }" onerror="this.src='assets/images/trainers/Mysterious Trainer.png';"/>

--- a/src/modules/requirements/SeededDateRequirement.ts
+++ b/src/modules/requirements/SeededDateRequirement.ts
@@ -1,0 +1,19 @@
+import { AchievementOption } from '../GameConstants';
+import Requirement from './Requirement';
+
+export default class SeededDateRequirement extends Requirement {
+    seededRandFunction: ()=>boolean;
+    constructor(seededRandFunction: ()=>boolean, option: AchievementOption = AchievementOption.equal) {
+        super(1, option);
+        this.seededRandFunction = seededRandFunction;
+    }
+
+    public getProgress(): number {
+        return +this.seededRandFunction();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public hint(): string {
+        return 'Try again another day.';
+    }
+}

--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -29,6 +29,7 @@ import SettingOption from './settings/SettingOption';
 import WeatherType from './weather/WeatherType';
 import Weather from './weather/Weather';
 import SeededRand from './utilities/SeededRand';
+import SeededDateRand from './utilities/SeededDateRand';
 import Rand from './utilities/Rand';
 import Settings from './settings/index';
 import { SortOptionConfigs, SortOptions } from './settings/SortOptions';
@@ -93,6 +94,7 @@ import PokeballRequirement from './requirements/PokeballRequirement';
 import ProteinObtainRequirement from './requirements/ProteinObtainRequirement';
 import QuestRequirement from './requirements/QuestRequirement';
 import RouteKillRequirement from './requirements/RouteKillRequirement';
+import SeededDateRequirement from './requirements/SeededDateRequirement';
 import ShinyPokemonRequirement from './requirements/ShinyPokemonRequirement';
 import SubregionRequirement from './requirements/SubregionRequirement';
 import TokenRequirement from './requirements/TokenRequirement';
@@ -135,6 +137,7 @@ Object.assign(<any>window, {
     WeatherType,
     Weather,
     SeededRand,
+    SeededDateRand,
     Rand,
     Settings,
     NotificationConstants,
@@ -203,6 +206,7 @@ Object.assign(<any>window, {
     ProteinObtainRequirement,
     QuestRequirement,
     RouteKillRequirement,
+    SeededDateRequirement,
     ShinyPokemonRequirement,
     SubregionRequirement,
     TokenRequirement,

--- a/src/modules/utilities/SeededDateRand.ts
+++ b/src/modules/utilities/SeededDateRand.ts
@@ -1,0 +1,13 @@
+import SeededRand from './SeededRand';
+
+export default class SeededDateRand extends SeededRand {
+    public static next(): number {
+        return this.state;
+    }
+
+    public static seedWithDate(d: Date): void {
+        this.state = Number((d.getFullYear() - 1900) * d.getDate() + 1000 * d.getMonth() + 100000 * d.getDate());
+        this.state = (this.state * this.MULTIPLIER + this.OFFSET) % this.MOD;
+        this.state /= this.MOD;
+    }
+}

--- a/src/modules/utilities/SeededRand.ts
+++ b/src/modules/utilities/SeededRand.ts
@@ -1,10 +1,10 @@
 import { MINUTE, HOUR } from '../GameConstants';
 
 export default class SeededRand {
-    private static state = 12345;
-    private static readonly MOD: number = 233280;
-    private static readonly OFFSET: number = 49297;
-    private static readonly MULTIPLIER: number = 9301;
+    public static state = 12345;
+    public static readonly MOD: number = 233280;
+    public static readonly OFFSET: number = 49297;
+    public static readonly MULTIPLIER: number = 9301;
 
     public static next(): number {
         this.state = (this.state * this.MULTIPLIER + this.OFFSET) % this.MOD;

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -90,6 +90,7 @@ class Game {
         AchievementHandler.calculateMaxBonus(); //recalculate bonus based on active challenges
 
         const now = new Date();
+        SeededDateRand.seedWithDate(now);
         DailyDeal.generateDeals(this.underground.getDailyDealsMax(), now);
         BerryDeal.generateDeals(now);
         Weather.generateWeather(now);
@@ -253,6 +254,7 @@ class Game {
 
             // Check if it's a new day
             if (old.toLocaleDateString() !== now.toLocaleDateString()) {
+                SeededDateRand.seedWithDate(now);
                 // Give the player a free quest refresh
                 this.quests.freeRefresh(true);
                 //Refresh the Underground deals

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -10,6 +10,7 @@ interface EnemyOptions {
     weight?: number,
     requirement?: MultiRequirement | OneFromManyRequirement | Requirement,
     reward?: Amount,
+    hide?: boolean,
 }
 
 interface DetailedPokemon {
@@ -31,6 +32,7 @@ type Boss = DungeonBossPokemon | DungeonTrainer;
 interface EncounterInfo {
     image: string,
     shiny: boolean,
+    hide: boolean,
     hidden: boolean,
     locked: boolean,
     lockMessage: string,
@@ -248,6 +250,7 @@ class Dungeon {
                 const encounter = {
                     image: `assets/images/${(App.game.party.alreadyCaughtPokemonByName(pokemonName, true) ? 'shiny' : '')}pokemon/${pokemonMap[pokemonName].id}.png`,
                     shiny:  App.game.party.alreadyCaughtPokemonByName(pokemonName, true),
+                    hide: boss.options?.hide ? (boss.options?.requirement ? !boss.options?.requirement.isCompleted() : boss.options?.hide) : false,
                     hidden: !App.game.party.alreadyCaughtPokemonByName(pokemonName),
                     lock: boss.options?.requirement ? !boss.options?.requirement.isCompleted() : false,
                     lockMessage: boss.options?.requirement ? boss.options?.requirement.hint() : '',
@@ -258,6 +261,7 @@ class Dungeon {
                 const encounter = {
                     image: boss.image,
                     shiny:  false,
+                    hide: boss.options?.hide ? (boss.options?.requirement ? !boss.options?.requirement.isCompleted() : boss.options?.hide) : false,
                     hidden: false,
                     lock: boss.options?.requirement ? !boss.options?.requirement.isCompleted() : false,
                     lockMessage: boss.options?.requirement ? boss.options?.requirement.hint() : '',

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -2,6 +2,8 @@
 ///<reference path="DungeonBossPokemon.ts"/>
 ///<reference path="../../declarations/requirements/GymBadgeRequirement.d.ts"/>
 ///<reference path="../../declarations/requirements/MultiRequirement.d.ts"/>
+///<reference path="../../declarations/requirements/SeededDateRequirement.d.ts"/>
+///<reference path="../../declarations/utilities/SeededDateRand.d.ts"/>
 ///<reference path="../achievements/ObtainedPokemonRequirement.ts"/>
 ///<reference path="./DungeonTrainer.ts"/>
 ///<reference path="../gym/GymPokemon.ts"/>
@@ -942,13 +944,118 @@ dungeonList['Ruins of Alph'] = new Dungeon('Ruins of Alph',
     ],
     60600,
     [
-        new DungeonBossPokemon('Unown (A)', 280000, 14),
-        new DungeonBossPokemon('Unown (F)', 280000, 14),
-        new DungeonBossPokemon('Unown (H)', 280000, 14),
-        new DungeonBossPokemon('Unown (L)', 280000, 14),
-        new DungeonBossPokemon('Unown (N)', 280000, 14),
-        new DungeonBossPokemon('Unown (P)', 280000, 14),
-        new DungeonBossPokemon('Unown (U)', 280000, 14),
+        new DungeonBossPokemon('Unown (A)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 0),
+        }),
+        new DungeonBossPokemon('Unown (B)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 1),
+        }),
+        new DungeonBossPokemon('Unown (C)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 2),
+        }),
+        new DungeonBossPokemon('Unown (D)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 3),
+        }),
+        new DungeonBossPokemon('Unown (E)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 4),
+        }),
+        new DungeonBossPokemon('Unown (F)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 5),
+        }),
+        new DungeonBossPokemon('Unown (G)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 6),
+        }),
+        new DungeonBossPokemon('Unown (H)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 7),
+        }),
+        new DungeonBossPokemon('Unown (I)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 8),
+        }),
+        new DungeonBossPokemon('Unown (J)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 9),
+        }),
+        new DungeonBossPokemon('Unown (K)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 10),
+        }),
+        new DungeonBossPokemon('Unown (L)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 11),
+        }),
+        new DungeonBossPokemon('Unown (M)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 12),
+        }),
+        new DungeonBossPokemon('Unown (N)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 13),
+        }),
+        new DungeonBossPokemon('Unown (O)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 14),
+        }),
+        new DungeonBossPokemon('Unown (P)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 15),
+        }),
+        new DungeonBossPokemon('Unown (Q)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 16),
+        }),
+        new DungeonBossPokemon('Unown (R)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 17),
+        }),
+        new DungeonBossPokemon('Unown (S)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 18),
+        }),
+        new DungeonBossPokemon('Unown (T)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 19),
+        }),
+        new DungeonBossPokemon('Unown (U)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 20),
+        }),
+        new DungeonBossPokemon('Unown (V)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 21),
+        }),
+        new DungeonBossPokemon('Unown (W)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 22),
+        }),
+        new DungeonBossPokemon('Unown (X)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 23),
+        }),
+        new DungeonBossPokemon('Unown (Y)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 24),
+        }),
+        new DungeonBossPokemon('Unown (Z)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 25),
+        }),
+        new DungeonBossPokemon('Unown (!)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 26),
+        }),
+        new DungeonBossPokemon('Unown (?)', 280000, 14, {
+            hide: true,
+            requirement: new SeededDateRequirement(() => SeededDateRand.intBetween(0, 27) == 27),
+        }),
     ],
     3000, 32);
 


### PR DESCRIPTION
Bosses will be hidden if `hide: true`
Will be shown if the boss has a requirement, that is currently met.
if `hide: true` and no requirement, the boss will always be hidden (but can still be encountered).

Added `SeededDateRand` class, which is always seeded with todays date.
Added `SeededDateRequirement` which checks against a provided function.

Also updated `Ruins of Alph` to include all 28 `Unown`, but only 1 variant will be available per day.
![image](https://user-images.githubusercontent.com/7288322/163095022-e259cd70-f54f-485a-b914-7852924f8607.png)
