### PR TITLE
Fixup some quest not starting

### DIFF
--- a/src/scripts/quests/QuestLine.ts
+++ b/src/scripts/quests/QuestLine.ts
@@ -7,7 +7,7 @@ enum QuestLineState {
 class QuestLine {
     name: string;
     description: string;
-    state: KnockoutObservable<QuestLineState> = ko.observable(QuestLineState.inactive);
+    state: KnockoutObservable<QuestLineState> = ko.observable(QuestLineState.inactive).extend({ numeric: 0 });
     quests: KnockoutObservableArray<Quest>;
     curQuest: KnockoutComputed<number>;
     curQuestObject: KnockoutComputed<any>;


### PR DESCRIPTION
Questline statuses were showing as `undefined` this should make sure they are always a number.
Specifically Easter Togepi event.