### PR TITLE
Fix weird rounding of some items in the store

### DIFF
--- a/src/scripts/items/Item.ts
+++ b/src/scripts/items/Item.ts
@@ -83,7 +83,7 @@ class Item {
             const maxCost = (this.basePrice * 100 * (amount - incAmount));
             const total = incCost + maxCost;
 
-            return Math.max(0, Math.floor(total));
+            return Math.max(0, Math.round(total));
         }
     }
 


### PR DESCRIPTION
Some pokemons (like "Type: null") costed 1 less. This was because of a float getting rounded down, instead of just rounded