### PR TITLE
PikaClones in Pikachu Valley

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -6006,7 +6006,7 @@ dungeonList['Ten Carat Hill'] = new Dungeon('Ten Carat Hill',
 
 
 dungeonList['Pikachu Valley'] = new Dungeon('Pikachu Valley',
-    ['Pikachu', 'Pichu'],
+    ['Pikachu', 'Pichu', 'Plusle', 'Minun', 'Pachirisu', 'Emolga', 'Dedenne'],
     [{loot: 'xClick', weight: 4}, {loot: 'Item_magnet', weight: 4}],
     11952804,
     [


### PR DESCRIPTION
Added all of the previous generation's "Pikachu clones" to the random encounters in Pikachu Valley, giving a bit more encounter diversity than just Pikachu and Pichu over and over.