### PR TITLE
"Sell all" in underground no longer start fossils

### DIFF
--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -347,7 +347,7 @@ class Underground implements Feature {
     public static sellAllMineItems() {
         for (let i = 0; i < player.mineInventory().length; i++) {
             const item = player.mineInventory()[i];
-            if (!item.sellLocked()) {
+            if (!item.sellLocked() && item.valueType != 'Mine Egg') {
                 Underground.sellMineItem(item.id, Infinity);
             }
         }


### PR DESCRIPTION
Fixed a bug, which made the "Sell all"-button start breeding fossils