### PR TITLE
More webworker changes

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -188,7 +188,12 @@ class Game {
                     ticks += delta;
                     _time = time;
                     if (ticks >= ${GameConstants.TICK_TIME}) {
-                        ticks -= ${GameConstants.TICK_TIME};
+                        // Skip the ticks if we have too many...
+                        if (ticks >= ${GameConstants.TICK_TIME * 2}) {
+                          ticks = 0;
+                        } else {
+                            ticks -= ${GameConstants.TICK_TIME};
+                        }
                         postMessage('tick');
                     }
                     requestAnimationFrame(tick);

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -181,9 +181,29 @@ class Game {
             console.log('starting web worker...');
             const blob = new Blob([
                 `
+                // Window visibility state
+                let pageHidden = false;
+                self.onmessage = function(e) {
+                    if (e.data.pageHidden != undefined) {
+                        pageHidden = e.data.pageHidden;
+                    }
+                };
+
+                // setInterval (slower on FireFox)
+                const tickInterval = setInterval(() => {
+                    // Don't process while page visible
+                    if (!pageHidden) return;
+
+                    postMessage('tickInterval')
+                }, ${GameConstants.TICK_TIME});
+
+                // requestAnimationFrame (consistent if page visible)
                 let _time = 0;
                 let ticks = 0;
                 const tick = (time) => {
+                    // Don't process while page hidden
+                    if (pageHidden) return requestAnimationFrame(tick);
+
                     const delta = time - _time;
                     ticks += delta;
                     _time = time;
@@ -206,6 +226,16 @@ class Game {
             this.worker = new Worker(blobURL);
             // use a setTimeout to queue the event
             this.worker?.addEventListener('message', () => Settings.getSetting('useWebWorkerForGameTicks').value ? this.gameTick() : null);
+
+            // Let our worker know if the page is visible or not
+            let pageHidden = document.hidden;
+            document.addEventListener('visibilitychange', () => {
+                if (pageHidden != document.hidden) {
+                    pageHidden = document.hidden;
+                    this.worker.postMessage({'pageHidden': pageHidden});
+                }
+            });
+            this.worker.postMessage({'pageHidden': pageHidden});
         } catch (e) {}
 
         this.interval = setInterval(() => !this.worker || !Settings.getSetting('useWebWorkerForGameTicks').value ? this.gameTick() : null, GameConstants.TICK_TIME);

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -194,7 +194,7 @@ class Game {
                     // Don't process while page visible
                     if (!pageHidden) return;
 
-                    postMessage('tickInterval')
+                    postMessage('tick')
                 }, ${GameConstants.TICK_TIME});
 
                 // requestAnimationFrame (consistent if page visible)


### PR DESCRIPTION
`setAnimationFrame`:
- Only runs while the page is visible
- Skips frames if there is too many in the buffer (paused while unfocused, initial frame etc)

`setInterval`:
- Only runs while page hidden
- Seems to run ~10ms slower on FireFox, sometimes getting around 1100ms per 10 ticks
  - _less of a problem now that it's a background only thing._