### PR TITLE
Changed default value of berry time

### DIFF
--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -87,7 +87,7 @@ Settings.add(new Setting<string>('farmDisplay', 'Farm timer display:',
         new SettingOption('To Next Stage', 'nextStage'),
         new SettingOption('Ripe/Death', 'ripeDeath'),
     ],
-    'nextStage'));
+    'ripeDeath'));
 Settings.add(new BooleanSetting('currencyMainDisplayReduced', 'Shorten currency amount shown on main screen', false));
 Settings.add(new BooleanSetting('showGymGoAnimation', 'Show Gym GO animation', true));
 


### PR DESCRIPTION
By default, the berries are no longer in "next stage" display but in "ripe death" one.
Tested by playing a new file, value was correct in the settings, and it was correctly applied to the farm