### PR TITLE
Fixed flutes multiplier

### DIFF
--- a/src/scripts/gems/FluteEffectRunner.ts
+++ b/src/scripts/gems/FluteEffectRunner.ts
@@ -117,7 +117,7 @@ class FluteEffectRunner {
 
     public static getFluteMultiplier(itemName: GameConstants.FluteItemType) {
         const flute = (ItemList[itemName] as FluteItem);
-        return this.isActive(flute.name)() ? (1 + (flute.multiplyBy - 1) * AchievementHandler.achievementBonus()) : 1;
+        return this.isActive(flute.name)() ? flute.getMultiplier() : 1;
     }
 
 

--- a/src/scripts/items/FluteItem.ts
+++ b/src/scripts/items/FluteItem.ts
@@ -18,8 +18,12 @@ class FluteItem extends Item {
     }
 
     getDescription(): string {
-        const multiplier = (((this.multiplyBy - 1) * AchievementHandler.achievementBonus()) * 100).toFixed(2);
+        const multiplier = ((this.getMultiplier() - 1) * 100).toFixed(2);
         return `+${multiplier}% bonus to ${this.description}`;
+    }
+
+    public getMultiplier() {
+        return (this.multiplyBy - 1) * (AchievementHandler.achievementBonus() + 1) + 1;
     }
 
     isSoldOut(): boolean {


### PR DESCRIPTION
Before this PR, flutes started at 0% bonus, and gave 2% bonus at 100% achievement bonus. Now it starts at 2%.
This follows everything else that uses achievement bonus