### PR TITLE
Adjust Hatchery Helpers

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -197,13 +197,25 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                         <tr>
                                             <td class="text-left">Step Efficiency:</td>
                                             <td class="text-right">
-                                                <knockout data-bind="text: $data.stepEfficiency.toLocaleString('en-US') + '%'">100%</knockout>
+                                                <knockout data-bind="text: `${$data.stepEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
                                             </td>
                                         </tr>
                                         <tr>
                                             <td class="text-left text-nowrap">Attack Efficiency:</td>
                                             <td class="text-right">
-                                                <knockout data-bind="text: $data.attackEfficiency.toLocaleString('en-US') + '%'">100%</knockout>
+                                                <knockout data-bind="text: `${$data.attackEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left text-nowrap">Hatched:</td>
+                                            <td class="text-right">
+                                                <knockout data-bind="text: $data.hatched().toLocaleString('en-US')">0</knockout>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left text-nowrap">Bonus to Efficiency:</td>
+                                            <td class="text-right">
+                                                <knockout data-bind="text: `+ ${$data.hatchBonus().toLocaleString('en-US')}%`">0%</knockout>
                                             </td>
                                         </tr>
                                     </tbody>
@@ -269,6 +281,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                     <p>They will only breed Pokémon based on your current Hatchery filters.</p>
                     <p>All of the Helpers have different step efficiencies and will hatch eggs faster or slower depending on their value.</p>
                     <p>They each also have different attack efficiencies which will determine how much attack you gain compared to manually hatching the pokemon yourself.</p>
+                    <p>These efficiencies will gain a bonus based on how many times you've used the helper to hatch eggs.</p>
                     <p><i>More Hatchery Helpers can be unlocked through shops and hatching more Pokémon</i></p>
                 </div>
 

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -182,9 +182,10 @@ class HatcheryHelpers {
     }
 }
 
-// Note: Gender-neutral names used as the trainer sprite is (seeded) randomly generated
+// Note: Mostly Gender-neutral names used as the trainer sprite is (seeded) randomly generated, or check the sprite
 HatcheryHelpers.add(new HatcheryHelper('Sam', new Amount(1000, GameConstants.Currency.money), 10, 10, new HatchRequirement(100)));
-HatcheryHelpers.add(new HatcheryHelper('Blake', new Amount(10000, GameConstants.Currency.money), 10, 15, new HatchRequirement(500)));
+HatcheryHelpers.add(new HatcheryHelper('Blake', new Amount(10000, GameConstants.Currency.money), 10, 20, new HatchRequirement(500)));
+HatcheryHelpers.add(new HatcheryHelper('Jasmine', new Amount(50000, GameConstants.Currency.money), 15, 50, new ItemOwnedRequirement('HatcheryHelperJasmine')));
 HatcheryHelpers.add(new HatcheryHelper('Parker', new Amount(1000, GameConstants.Currency.dungeonToken), 15, 25, new HatchRequirement(1000)));
 HatcheryHelpers.add(new HatcheryHelper('Dakota', new Amount(10000, GameConstants.Currency.dungeonToken), 50, 50, new ItemOwnedRequirement('HatcheryHelperDakota')));
 HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(10, GameConstants.Currency.questPoint), 100, 50, new QuestRequirement(200)));

--- a/src/scripts/items/HatcheryHelperItem.ts
+++ b/src/scripts/items/HatcheryHelperItem.ts
@@ -13,8 +13,8 @@ class HatcheryHelperItem extends Item {
     get description(): string {
         const hatcheryHelper = this.hatcheryHelper;
         return `Cost: <img src="assets/images/currency/${GameConstants.Currency[hatcheryHelper?.cost?.currency]}.svg" width="20px">&nbsp;${(hatcheryHelper?.cost?.amount ?? 0).toLocaleString('en-US')}/hatch<br/>
-        Step Efficiency: ${(hatcheryHelper?.stepEfficiency ?? 0).toLocaleString('en-US')}%<br/>
-        Attack Efficiency: ${(hatcheryHelper?.attackEfficiency ?? 0).toLocaleString('en-US')}%`;
+        Step Efficiency: ${(hatcheryHelper?.stepEfficiencyBase ?? 0).toLocaleString('en-US')}%<br/>
+        Attack Efficiency: ${(hatcheryHelper?.attackEfficiencyBase ?? 0).toLocaleString('en-US')}%`;
     }
 
     isAvailable(): boolean {

--- a/src/scripts/items/HatcheryHelperItem.ts
+++ b/src/scripts/items/HatcheryHelperItem.ts
@@ -29,6 +29,7 @@ class HatcheryHelperItem extends Item {
 }
 
 // Berry Masters
+ItemList['HatcheryHelperJasmine'] = new HatcheryHelperItem('Jasmine', 10000000, GameConstants.Currency.money);
 ItemList['HatcheryHelperDakota'] = new HatcheryHelperItem('Dakota', 100000, GameConstants.Currency.dungeonToken);
 ItemList['HatcheryHelperCarey']  = new HatcheryHelperItem('Carey', 10000, GameConstants.Currency.questPoint);
 ItemList['HatcheryHelperKris']   = new HatcheryHelperItem('Kris', 2000, GameConstants.Currency.diamond);

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -663,6 +663,7 @@ const MauvilleCityShop = new Shop([
     ItemList['Electric_egg'],
     ItemList['Thunder_stone'],
     ItemList['Metal_coat'],
+    ItemList['HatcheryHelperJasmine'],
 ]);
 const VerdanturfTownShop = new Shop([
     ItemList['Grass_egg'],


### PR DESCRIPTION
They now give a slight bonus to their efficiency based on how many Pokémon they have hatched.

Hatches | Bonus
--: | --:
10 | 0.4%
100 | 1.4%
1,000 | 4.5%
10,000 | 14.1%
100,000 | 44.7%

For example with a base efficiency of 50% and 100 hatches they would give 51.4% efficiency

Added 1 more PokéCoin/Money cost helper