### PR TITLE
Option to hide shiny Pokémon in the protein menu

### DIFF
--- a/src/components/pokemonSelectorModal.html
+++ b/src/components/pokemonSelectorModal.html
@@ -43,10 +43,18 @@
                               onchange="Settings.setSettingByName('proteinSortDirection', this.checked)"/>
                       </div>
                   </div>
-                  <input type="checkbox" id="hide-max-protein-pokemons" class="form-check-input"
-                      data-bind="checked: Settings.getSetting('proteinHideMaxedPokemon').observableValue()"
-                      onchange="Settings.setSettingByName('proteinHideMaxedPokemon', this.checked)"/>
-                  <label for="hide-max-protein-pokemons" class="form-check-label">Hide Pokémon with max protein</label>
+				  <div class="form-check">
+					  <input type="checkbox" id="hide-max-protein-pokemons" class="form-check-input"
+						  data-bind="checked: Settings.getSetting('proteinHideMaxedPokemon').observableValue()"
+						  onchange="Settings.setSettingByName('proteinHideMaxedPokemon', this.checked)"/>
+					  <label for="hide-max-protein-pokemons" class="form-check-label">Hide Pokémon with max protein</label>
+				  </div>
+				  <div class="form-check">
+					  <input type="checkbox" id="hide-shiny-pokemons" class="form-check-input"
+						  data-bind="checked: Settings.getSetting('proteinHideShinyPokemon').observableValue()"
+						  onchange="Settings.setSettingByName('proteinHideShinyPokemon', this.checked)"/>
+					  <label for="hide-shiny-pokemons" class="form-check-label">Hide shiny Pokémon</label>
+				  </div>
                 </div>
                 <table class="table table-striped table-hover table-bordered table-sm m-0">
                   <thead>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -149,6 +149,7 @@ const proteinSortSettings = Object.keys(SortOptionConfigs).map((opt) => (
 Settings.add(new Setting<number>('proteinSort', 'Sort:', proteinSortSettings, SortOptions.id));
 Settings.add(new BooleanSetting('proteinSortDirection', 'reverse', false));
 Settings.add(new BooleanSetting('proteinHideMaxedPokemon', 'Hide Pokémon with max protein', false));
+Settings.add(new BooleanSetting('proteinHideShinyPokemon', 'Hide shiny Pokémon', false));
 
 // Breeding Filters
 Settings.add(new Setting<string>('breedingCategoryFilter', 'breedingCategoryFilter',

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -129,7 +129,8 @@ class PartyPokemon implements Saveable {
 
     public hideFromProteinList = (): boolean => {
         return this.breeding ||
-            (this.proteinUsesRemaining() == 0 && Settings.getSetting('proteinHideMaxedPokemon').observableValue());
+            (this.proteinUsesRemaining() == 0 && Settings.getSetting('proteinHideMaxedPokemon').observableValue()) ||
+            (this.shiny && Settings.getSetting('proteinHideShinyPokemon').observableValue());
     }
 
     public fromJSON(json: Record<string, any>): void {


### PR DESCRIPTION
Could be useful for people who want to prioritize non-shinies for breeding.