### PR TITLE
Small UI changes

### DIFF
--- a/src/components/berryMasterModal.html
+++ b/src/components/berryMasterModal.html
@@ -39,7 +39,14 @@
                                     <!-- ko if: $index() === 0 -->
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.berries.length }">→</td>
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.berries.length }">
-                                        <img class='mineInventoryItem' data-bind='attr: {src: $parent.item.itemType.image}'>
+                                        <img class='mineInventoryItem' data-bind="
+                                            attr: {src: $parent.item.itemType.image},
+                                            tooltip: {
+                                                title: $parent.item.itemType.description ? $parent.item.itemType.description : '',
+                                                trigger: 'hover',
+                                                placement:'bottom',
+                                                html: true
+                                              }">
                                     </td>
                                     <td class='vertical-middle' data-bind='attr: { rowspan: $parent.berries.length }, text: $parent.item.amount + " × " + $parent.item.itemType.displayName'></td>
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.berries.length }">

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -37,7 +37,7 @@
                         <!-- /ko -->
                         <!-- ko if: $data.isCompleted() -->
                         <button class="btn btn-success btn-sm btn-block p-0" data-bind="click: () => { App.game.quests.claimQuest($data.index) }">
-                            claim
+                            Claim
                         </button>
                         <!-- /ko -->
                     </td>

--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -41,9 +41,9 @@ class BattleItem extends Item {
     }
 }
 
-ItemList['xAttack']         = new BattleItem(GameConstants.BattleItemType.xAttack, '+50% Bonus to Pokémon attack', 600, undefined, undefined, 'pokemonAttack', 1.5);
-ItemList['xClick']          = new BattleItem(GameConstants.BattleItemType.xClick, '+50% Bonus to click attack', 400, undefined, undefined, 'clickAttack', 1.5);
-ItemList['Lucky_egg']       = new BattleItem(GameConstants.BattleItemType.Lucky_egg, '+50% Bonus to experience gained', 800, undefined, 'Lucky Egg', 'exp', 1.5);
-ItemList['Token_collector'] = new BattleItem(GameConstants.BattleItemType.Token_collector, '+50% Bonus to dungeon tokens gained', 1000, undefined, 'Token Collector', 'dungeonToken', 1.5);
-ItemList['Item_magnet']     = new BattleItem(GameConstants.BattleItemType.Item_magnet, 'Increased chance of gaining extra items', 1500, undefined, 'Item Magnet');
-ItemList['Lucky_incense']   = new BattleItem(GameConstants.BattleItemType.Lucky_incense, '+50% Bonus to money gained', 2000, undefined, 'Lucky Incense', 'money', 1.5);
+ItemList['xAttack']         = new BattleItem(GameConstants.BattleItemType.xAttack, '+50% Bonus to Pokémon attack for 30 seconds', 600, undefined, undefined, 'pokemonAttack', 1.5);
+ItemList['xClick']          = new BattleItem(GameConstants.BattleItemType.xClick, '+50% Bonus to click attack for 30 seconds', 400, undefined, undefined, 'clickAttack', 1.5);
+ItemList['Lucky_egg']       = new BattleItem(GameConstants.BattleItemType.Lucky_egg, '+50% Bonus to experience gained for 30 seconds', 800, undefined, 'Lucky Egg', 'exp', 1.5);
+ItemList['Token_collector'] = new BattleItem(GameConstants.BattleItemType.Token_collector, '+50% Bonus to dungeon tokens gained for 30 seconds', 1000, undefined, 'Token Collector', 'dungeonToken', 1.5);
+ItemList['Item_magnet']     = new BattleItem(GameConstants.BattleItemType.Item_magnet, 'Increased chance of gaining extra items for 30 seconds', 1500, undefined, 'Item Magnet');
+ItemList['Lucky_incense']   = new BattleItem(GameConstants.BattleItemType.Lucky_incense, '+50% Bonus to money gained for 30 seconds', 2000, undefined, 'Lucky Incense', 'money', 1.5);

--- a/src/scripts/items/EggItem.ts
+++ b/src/scripts/items/EggItem.ts
@@ -5,7 +5,7 @@ class EggItem extends CaughtIndicatingItem {
     type: GameConstants.EggItemType;
 
     constructor(type: GameConstants.EggItemType, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.questPoint, displayName?: string) {
-        super(GameConstants.EggItemType[type], basePrice, currency, undefined, displayName, undefined, 'egg');
+        super(GameConstants.EggItemType[type], basePrice, currency, undefined, displayName, 'An egg. Can be hatched in the Day Care.', 'egg');
         this.type = type;
     }
 

--- a/src/scripts/items/EnergyRestore.ts
+++ b/src/scripts/items/EnergyRestore.ts
@@ -4,7 +4,7 @@ class EnergyRestore extends Item {
     type: GameConstants.EnergyRestoreSize;
 
     constructor(type: GameConstants.EnergyRestoreSize, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.money, displayName?: string) {
-        super(GameConstants.EnergyRestoreSize[type], basePrice, currency, undefined, displayName);
+        super(GameConstants.EnergyRestoreSize[type], basePrice, currency, undefined, displayName, 'Restores Energy in the Underground.');
         this.type = type;
     }
 

--- a/src/scripts/items/EvolutionStone.ts
+++ b/src/scripts/items/EvolutionStone.ts
@@ -5,7 +5,7 @@ class EvolutionStone extends CaughtIndicatingItem {
     public unlockedRegion: GameConstants.Region;
 
     constructor(type: GameConstants.StoneType, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.questPoint, displayName: string, unlockedRegion?: GameConstants.Region) {
-        super(GameConstants.StoneType[type], basePrice, currency, undefined, displayName, undefined, 'evolution');
+        super(GameConstants.StoneType[type], basePrice, currency, undefined, displayName, 'An evolution item. See your itembag for more information.', 'evolution');
         this.type = type;
         this.unlockedRegion = unlockedRegion;
     }


### PR DESCRIPTION
I was watching a play though of pokeclicker, and found some things, which could be improved for new players. This PR contains all the easy ones (have some other PRs coming up, hopefully).
- Battle item descriptions now tell how long they last
- Berry master now shows item description on mouseover (if there are any)
- (Not really new player improvement) fixed casing for "Claim"-button in quest display, to match our other buttons (mostly the "quit"-button in same display)
- Added generic descriptions to eggs, evostones and proteins, so people knows how and where to use them

Lastly the youtuber was kinda used as free user research (and he is entertaining), so i feel like i owe a shout-out, but i don't know how i could do it... (he is called "FireFarmer123" on youtube).