### PR TITLE
Achievement tracker is now bound to Holo Caster

### DIFF
--- a/src/modules/keyItems/KeyItems.ts
+++ b/src/modules/keyItems/KeyItems.ts
@@ -81,10 +81,11 @@ export default class KeyItems implements Feature {
             new KeyItem(KeyItemType.Super_rod, 'The best fishing rod for catching wild water Pokémon',
                 () => App.game.statistics.routeKills[Region.kanto][12]() >= ROUTE_KILLS_NEEDED, undefined, undefined, 'Super Rod'),
             // TODO obtain somewhere at the start
-            new KeyItem(KeyItemType.Holo_caster, 'A device that allows users to receive and view hologram clips at any time. It’s also used to chat with others', undefined, undefined, undefined, 'Holo Caster'),
+            new KeyItem(KeyItemType.Holo_caster, 'A device that allows users to see and track Achievements. Completing Achievements gives useful bonuses.',
+                () => App.game.party.caughtPokemon.length >= 110, undefined, undefined, 'Holo Caster'),
             new KeyItem(KeyItemType.Mystery_egg, 'A mysterious Egg obtained from Mr. Pokémon. This allows you to use the Pokémon Day Care to help improve your Pokémons attack; some baby Pokémon can only be found through breeding too!',
                 () => App.game.statistics.routeKills[Region.kanto][5]() >= ROUTE_KILLS_NEEDED, undefined, undefined, 'Mystery Egg'),
-            new KeyItem(KeyItemType.Safari_ticket, 'This ticket grants access to the Safari Zone right outside Fuchsia City'),
+            new KeyItem(KeyItemType.Safari_ticket, 'This ticket grants access to the Safari Zone right outside Fuchsia City.'),
             new KeyItem(KeyItemType.Wailmer_pail, 'This is a tool for watering Berries to allow you to operate the farm.',
                 () => MapHelper.accessToRoute(14, Region.kanto), undefined, undefined, 'Wailmer Pail'),
 

--- a/src/modules/keyItems/KeyItems.ts
+++ b/src/modules/keyItems/KeyItems.ts
@@ -80,7 +80,6 @@ export default class KeyItems implements Feature {
             }, 'Dungeon Ticket'),
             new KeyItem(KeyItemType.Super_rod, 'The best fishing rod for catching wild water Pokémon',
                 () => App.game.statistics.routeKills[Region.kanto][12]() >= ROUTE_KILLS_NEEDED, undefined, undefined, 'Super Rod'),
-            // TODO obtain somewhere at the start
             new KeyItem(KeyItemType.Holo_caster, 'A device that allows users to see and track Achievements. Completing Achievements gives useful bonuses.',
                 () => App.game.party.caughtPokemon.length >= 110, undefined, undefined, 'Holo Caster'),
             new KeyItem(KeyItemType.Mystery_egg, 'A mysterious Egg obtained from Mr. Pokémon. This allows you to use the Pokémon Day Care to help improve your Pokémons attack; some baby Pokémon can only be found through breeding too!',

--- a/src/scripts/achievements/AchievementTracker.ts
+++ b/src/scripts/achievements/AchievementTracker.ts
@@ -16,7 +16,7 @@ class AchievementTracker implements Feature {
     }
 
     canAccess(): boolean {
-        return App.game.party.caughtPokemon.length >= 110;
+        return App.game.keyItems.hasKeyItem(KeyItemType.Holo_caster);
     }
 
     update(delta: number): void {


### PR DESCRIPTION
New players did not notice that achievement tracker showed up, because it was at a very random time. To make this clear, i have bound it to a key item.
We (discord chat) came to the conclusion that Holo Caster was the best key item for the job, so i have used that.

![image](https://user-images.githubusercontent.com/2961347/168652812-ad84982b-853a-4229-8bd1-0eeac9d548bd.png)
