### PR TITLE
Tell google to stop translating our game

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
 <head>
     <title>Pokéclicker</title>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">


### PR DESCRIPTION
We have recently have some problems with google translate making Pokeclicker unplayable, by changing the dungeon window. Every time the fix has been to disable google translate.
I tried playing with translate on, but i could not reproduce the bug (maybe the bug only happens when you translate to French... I played in Danish, so i understood the game).
But the game was still super laggy, and stuff was jumping around and showing up places it should not (i played though the tutorial).
This PR will disable google translate for Pokeclicker, which i believe leads to a better experience, even if they are struggling to read the page.