### PR TITLE
Fix damage calculator not updating when "ignore level" checked

### DIFF
--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -27,6 +27,8 @@ class PartyPokemon implements Saveable {
     _shiny: KnockoutObservable<boolean>;
     _level: KnockoutObservable<number>;
     _attack: KnockoutObservable<number>;
+    _attackBonusPercent: KnockoutObservable<number>;
+    _attackBonusAmount: KnockoutObservable<number>;
     _category: KnockoutObservable<number>;
     proteinsUsed: KnockoutObservable<number>;
 
@@ -35,8 +37,8 @@ class PartyPokemon implements Saveable {
         public name: PokemonNameType,
         public evolutions: Evolution[],
         public baseAttack: number,
-        public attackBonusPercent: number = 0,
-        public attackBonusAmount: number = 0,
+        attackBonusPercent = 0,
+        attackBonusAmount = 0,
         proteinsUsed,
         public exp: number = 0,
         breeding = false,
@@ -47,6 +49,8 @@ class PartyPokemon implements Saveable {
         this._breeding = ko.observable(breeding);
         this._shiny = ko.observable(shiny);
         this._level = ko.observable(1);
+        this._attackBonusPercent = ko.observable(attackBonusPercent);
+        this._attackBonusAmount = ko.observable(attackBonusAmount);
         this._attack = ko.observable(this.calculateAttack());
         this._category = ko.observable(category);
     }
@@ -218,6 +222,22 @@ class PartyPokemon implements Saveable {
 
     set attack(attack: number) {
         this._attack(attack);
+    }
+
+    get attackBonusAmount(): number {
+        return this._attackBonusAmount();
+    }
+
+    set attackBonusAmount(attackBonusAmount: number) {
+        this._attackBonusAmount(attackBonusAmount);
+    }
+
+    get attackBonusPercent(): number {
+        return this._attackBonusPercent();
+    }
+
+    set attackBonusPercent(attackBonusPercent: number) {
+        this._attackBonusPercent(attackBonusPercent);
     }
 
     get breeding(): boolean {


### PR DESCRIPTION
Not sure if an issue was ever made for this, but to see the bug on development:
1. Check "ignore level" in damage calculator
2. Maybe also check the breeding one too, I didn't test without that
3. Hatch an egg
4. Don't catch any new pokemon while doing this
5. Total damage in the calculator doesn't increase (but should have because we hatched something)