### PR TITLE
Make text inside code element lighter on dark themes

### DIFF
--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -21,6 +21,10 @@
     filter: brightness(0%) invert(100%);
     opacity: 0.3;
   }
+
+  code {
+      color: #f291bf;
+  }
 }
 
 /* Individual themes */


### PR DESCRIPTION
Fixes #2197

Kept the original color's hue and saturation, but increased lightness.
Only applies to dark mode themes.

Before:
![Screenshot_2022-05-26_01-34-42](https://user-images.githubusercontent.com/4183969/170391457-634e9953-fdae-42f0-8709-a4c1b400f9ad.png)

After:
![Screenshot_2022-05-26_01-35-32](https://user-images.githubusercontent.com/4183969/170391510-fa9c2aea-0e20-4e8d-8dfe-677f5744fa58.png)


