### PR TITLE
Fixup starter popup re-appearing if you select a grass starter

### DIFF
--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -76,7 +76,7 @@ class Player {
             }
         }
         for (let i = 1; i <= GameConstants.MAX_AVAILABLE_REGION; i++) {
-            if (savedPlayer.regionStarters && savedPlayer.regionStarters[i]) {
+            if (savedPlayer.regionStarters && savedPlayer.regionStarters[i] != undefined) {
                 this.regionStarters.push(ko.observable(savedPlayer.regionStarters[i]));
             } else if (i < (savedPlayer.highestRegion ?? 0)) {
                 this.regionStarters.push(ko.observable(0));

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -82,13 +82,6 @@ class Player {
                 this.regionStarters.push(ko.observable(0));
             } else if (i == (savedPlayer.highestRegion ?? 0)) {
                 this.regionStarters.push(ko.observable(undefined));
-                if (this._region() != i) {
-                    this._region(i);
-                    this._subregion(0);
-                    this.route(undefined);
-                    this._townName = GameConstants.StartingTowns[i];
-                    this._town = ko.observable(TownList[this._townName]);
-                }
                 $('#pickStarterModal').modal('show');
             } else {
                 this.regionStarters.push(ko.observable(undefined));


### PR DESCRIPTION
This PR fixes a bug where the select starter popup will re-appear if the player selected the grass starter.
Also no longer moves the player when getting them to select a starter as this was confusing to some players.