### PR TITLE
Fixup negative quest

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -193,6 +193,13 @@ class Game {
         if (App.game.badgeCase.badgeList[BadgeEnums.Earth]() && !App.game.keyItems.itemList[KeyItemType.Gem_case].isUnlocked()) {
             App.game.keyItems.gainKeyItem(KeyItemType.Gem_case, true);
         }
+        // Check that none of our quest are less than their initial value
+        App.game.quests.questLines().filter(q => q.state() == 1).forEach(questLine => {
+            const quest = questLine.curQuestObject();
+            if (quest.initial() > quest.focus()) {
+                quest.initial(quest.focus());
+            }
+        });
     }
 
     start() {

--- a/src/scripts/quests/QuestLine.ts
+++ b/src/scripts/quests/QuestLine.ts
@@ -51,9 +51,7 @@ class QuestLine {
         this.autoBegin = this.curQuest.subscribe((num) => {
             if (this.curQuest() < this.totalQuests) {
                 if (this.curQuestObject().initial() == null) {
-                    setTimeout(() => {
-                        this.beginQuest(this.curQuest());
-                    }, 2000);
+                    this.beginQuest(this.curQuest());
                 }
             } else {
                 this.state(QuestLineState.ended);


### PR DESCRIPTION
This PR should fix questlines having negative amounts:
![image](https://user-images.githubusercontent.com/7288322/170610952-48efc416-82a5-413d-bb2b-a23bae4479b5.png)

Hopefully fixed the initial problem of the bug occurring,
But also added a check and fix to `Game.ts` to fix any already existing negative values, Unfortunately it can't really be done within `Update.ts` due to us not knowing the focus value.

Closes #2183