### PR TITLE
Hide type bars in damage calculator with 0 damage

### DIFF
--- a/src/components/damageCalculatorModal.html
+++ b/src/components/damageCalculatorModal.html
@@ -86,6 +86,7 @@ aria-labelledby="damageCalculatorModalLabel" aria-hidden="true">
                         data-bind="style: {'flex-grow': $data,
                                             'background-color': '#' + TypeHelper.typeColorsLocked[$index()]
                                           },
+                                    visible: $data > 0,
                                     tooltip: {title: `${PokemonType[$index()]}: ${Math.round($data).toLocaleString('en-US')}`,
                                               trigger: 'hover',
                                               placement:'bottom'


### PR DESCRIPTION
When you have no damage in some type, there is a bigger gap in the damage calculator type bars because of this 0-width bar still existing with some margin.

Before:
![Screenshot_2022-05-28_07-23-54](https://user-images.githubusercontent.com/4183969/170813344-fc98022e-c6d1-4cc1-ae4d-bf67b38ac830.png)

After:
![Screenshot_2022-05-28_07-26-13](https://user-images.githubusercontent.com/4183969/170813368-3e37a861-b3c5-439c-af32-5945715efe47.png)

