### PR TITLE
Fix #2334 Sorting achievements by progress now use a float value

### DIFF
--- a/src/modules/achievements/AchievementSortOptions.ts
+++ b/src/modules/achievements/AchievementSortOptions.ts
@@ -23,7 +23,7 @@ export const AchievementSortOptionConfigs: Record<AchievementSortOptions, Achiev
 
     [AchievementSortOptions.progress]: {
         text: 'Progress',
-        getValue: (a) => parseInt(a.getProgressPercentage(), 10),
+        getValue: (a) => parseFloat(a.getProgressPercentage()),
     },
 
     [AchievementSortOptions.bonus]: {


### PR DESCRIPTION
Closes #2334