### PR TITLE
No more numbers

### DIFF
--- a/src/components/gymView.html
+++ b/src/components/gymView.html
@@ -4,7 +4,7 @@
         <h2 class="pageItemTitle" style="display: block;">
 
             <knockout class="left">
-                <knockout data-bind="text: GymBattle.gym.leaderName.replace(/\d/g,'')"></knockout>
+                <knockout data-bind="text: GymBattle.gym.leaderName.replace(/[0-9]/g, '')"></knockout>
             </knockout>
 
             <knockout>

--- a/src/components/receiveGymBadge.html
+++ b/src/components/receiveGymBadge.html
@@ -7,7 +7,7 @@ aria-labelledby="receiveBadgeModalLabel" aria-hidden="true">
                <img src="" onerror="this.src='assets/images/trainers/Mysterious Trainer.png'"
                     data-bind="attr:{ src: 'assets/images/gymLeaders/' + GymRunner.gymObservable().leaderName + '.png'}">
                <h5 class="modal-title" id="receiveBadgeModalLabel"
-                   data-bind="text: GymRunner.gymObservable().leaderName.replace(/\d/g,'')">Modal title</h5>
+                   data-bind="text: GymRunner.gymObservable().leaderName.replace(/[0-9]/g, '')">Modal title</h5>
 
            </div>
        </div>

--- a/src/components/temporaryBattleView.html
+++ b/src/components/temporaryBattleView.html
@@ -4,7 +4,7 @@
         <h2 class="pageItemTitle" style="display: block;">
 
             <knockout class="left">
-                <knockout data-bind="text: TemporaryBattleBattle.battle.name"></knockout>
+                <knockout data-bind="text: TemporaryBattleBattle.battle.name.replace(/[0-9]/g, '')"></knockout>
             </knockout>
 
             <knockout>

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -327,9 +327,9 @@ class AchievementHandler {
             GameConstants.RegionGyms[region]?.forEach(gym => {
                 const gymTitle: string = gym.includes('Elite') || gym.includes('Champion') ? gym : `${gym} Gym`;
                 if (GymList[gym]?.flags?.achievement) {
-                    AchievementHandler.addAchievement(`${gym} Gym regular`, `Clear ${gymTitle} 10 times`, new ClearGymRequirement(GameConstants.ACHIEVEMENT_DEFEAT_GYM_VALUES[0], GameConstants.getGymIndex(gym)), 1, region);
-                    AchievementHandler.addAchievement(`${gym} Gym ruler`, `Clear ${gymTitle} 100 times`, new ClearGymRequirement(GameConstants.ACHIEVEMENT_DEFEAT_GYM_VALUES[1], GameConstants.getGymIndex(gym)), 2, region);
-                    AchievementHandler.addAchievement(`${gym} Gym owner`, `Clear ${gymTitle} 1,000 times`, new ClearGymRequirement(GameConstants.ACHIEVEMENT_DEFEAT_GYM_VALUES[2], GameConstants.getGymIndex(gym)), 3, region);
+                    AchievementHandler.addAchievement(`${gym} Gym regular`, `Clear ${gymTitle.replace(/[0-9]/g, '')} 10 times`, new ClearGymRequirement(GameConstants.ACHIEVEMENT_DEFEAT_GYM_VALUES[0], GameConstants.getGymIndex(gym)), 1, region);
+                    AchievementHandler.addAchievement(`${gym} Gym ruler`, `Clear ${gymTitle.replace(/[0-9]/g, '')} 100 times`, new ClearGymRequirement(GameConstants.ACHIEVEMENT_DEFEAT_GYM_VALUES[1], GameConstants.getGymIndex(gym)), 2, region);
+                    AchievementHandler.addAchievement(`${gym} Gym owner`, `Clear ${gymTitle.replace(/[0-9]/g, '')} 1,000 times`, new ClearGymRequirement(GameConstants.ACHIEVEMENT_DEFEAT_GYM_VALUES[2], GameConstants.getGymIndex(gym)), 3, region);
                 }
             });
             // Dungeons

--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -72,7 +72,7 @@ class GymRunner {
         if (this.running()) {
             this.running(false);
             Notifier.notify({
-                message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName}`,
+                message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName.replace(/[0-9]/g, '')}`,
                 type: NotificationConstants.NotificationOption.danger,
             });
             App.game.gameState = GameConstants.GameState.town;
@@ -83,7 +83,7 @@ class GymRunner {
         if (this.running()) {
             this.running(false);
             Notifier.notify({
-                message: `Congratulations, you defeated ${GymBattle.gym.leaderName}!`,
+                message: `Congratulations, you defeated ${GymBattle.gym.leaderName.replace(/[0-9]/g, '')}!`,
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.General.gym_won,
             });


### PR DESCRIPTION
Removes numbers from Gym Leaders with multiple instances on the front-end. Back-end stays the same. Hopefully I caught everything - achievements also seem to update correctly.

Closes a task on #934