### PR TITLE
Change Money to Pokédollars in-game

### DIFF
--- a/src/components/achievementsModal.html
+++ b/src/components/achievementsModal.html
@@ -3,7 +3,7 @@ aria-labelledby="AchievementsModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 data-bind="tooltip: { title: 'As you earn achievements, you gain up to 100% (per region) more Click Attack, Money, Dungeon Tokens, Flute effects and Experience from all sources.', trigger: 'hover', placement:'right' }">Achievements Bonus: <u class="text-primary" data-bind="text: AchievementHandler.achievementBonusPercent()"></u></h5>
+                <h5 data-bind="tooltip: { title: 'As you earn achievements, you gain up to 100% (per region) more Click Attack, Pokédollars, Dungeon Tokens, Flute effects and Experience from all sources.', trigger: 'hover', placement:'right' }">Achievements Bonus: <u class="text-primary" data-bind="text: AchievementHandler.achievementBonusPercent()"></u></h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>

--- a/src/components/starterCaught.html
+++ b/src/components/starterCaught.html
@@ -27,7 +27,7 @@ aria-labelledby="starterCaughtModalLabel" aria-hidden="true">
                </div>
                <div class="col-sm-3">
                    <img
-                           title="A case for holding money. It can hold up to 1,000,000 coins."
+                           title="A case for holding Pokédollars."
                            class="key-item"
                            src="assets/images/keyitems/Coin_case.png"/>
                    <br>

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -51,7 +51,7 @@
                         "></button>
                     <!-- ko if: $data instanceof Gym -->
                     <button class="btn btn-info p-0 btn-gym-auto-restart" data-bind="
-                        tooltip: { html: true, title: `Auto restart Gym fight<br/>Cost: <img src='assets/images/currency/money.svg' height='18px'></button> ${($data.moneyReward * 2).toLocaleString('en-US')} per battle<br/><br/><i class='text-warning'>You will not receive money for clearing the gym</i>`, trigger: 'hover', placement:'right' },
+                        tooltip: { html: true, title: `Auto restart Gym fight<br/>Cost: <img src='assets/images/currency/money.svg' height='18px'></button> ${($data.moneyReward * 2).toLocaleString('en-US')} per battle<br/><br/><i class='text-warning'>You will not receive A case for holding Pokédollars for clearing the gym</i>`, trigger: 'hover', placement:'right' },
                         click: () => GymRunner.startGym($data, true),
                         visible: $data.isUnlocked() && App.game.statistics.gymsDefeated[GameConstants.getGymIndex($data.town)]() >= 100">↻</button>
                     <!-- /ko -->

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -51,7 +51,7 @@
                         "></button>
                     <!-- ko if: $data instanceof Gym -->
                     <button class="btn btn-info p-0 btn-gym-auto-restart" data-bind="
-                        tooltip: { html: true, title: `Auto restart Gym fight<br/>Cost: <img src='assets/images/currency/money.svg' height='18px'></button> ${($data.moneyReward * 2).toLocaleString('en-US')} per battle<br/><br/><i class='text-warning'>You will not receive A case for holding Pokédollars for clearing the gym</i>`, trigger: 'hover', placement:'right' },
+                        tooltip: { html: true, title: `Auto restart Gym fight<br/>Cost: <img src='assets/images/currency/money.svg' height='18px'></button> ${($data.moneyReward * 2).toLocaleString('en-US')} per battle<br/><br/><i class='text-warning'>You will not receive Pokédollars for clearing the gym</i>`, trigger: 'hover', placement:'right' },
                         click: () => GymRunner.startGym($data, true),
                         visible: $data.isUnlocked() && App.game.statistics.gymsDefeated[GameConstants.getGymIndex($data.town)]() >= 100">↻</button>
                     <!-- /ko -->

--- a/src/index.html
+++ b/src/index.html
@@ -156,13 +156,13 @@
                         <tr class="row">
                             <td class="col">
                                 <span style="display: inline; position: relative;">
-                                    <img title="Money" src="assets/images/currency/money.svg" height="25px">
+                                    <img title="Pokédollars&#013;&#010;Gained by defeating Pokémon and trainers in battle" src="assets/images/currency/money.svg" height="25px">
                                     <span id="animateCurrency-money" data-bind="text: Settings.getSetting('currencyMainDisplayReduced').observableValue() ? GameConstants.formatNumber(App.game.wallet.currencies[GameConstants.Currency.money]()) : App.game.wallet.currencies[GameConstants.Currency.money]().toLocaleString('en-US')">0</span>
                                 </span>
                             </td>
                             <td class="col">
                                 <span style="display: inline; position: relative;">
-                                    <img title="Dungeon Tokens&#013;&#010;Gained by capturing Pokémon" src="assets/images/currency/dungeonToken.svg" height="25px">
+                                    <img title="Dungeon Tokens&#013;&#010;Gained by catching wild Pokémon" src="assets/images/currency/dungeonToken.svg" height="25px">
                                     <span id="animateCurrency-dungeonToken" data-bind="text: Settings.getSetting('currencyMainDisplayReduced').observableValue() ? GameConstants.formatNumber(App.game.wallet.currencies[GameConstants.Currency.dungeonToken]()) : App.game.wallet.currencies[GameConstants.Currency.dungeonToken]().toLocaleString('en-US')">0</span>
                                 </span>
                             </td>

--- a/src/modules/keyItems/KeyItems.ts
+++ b/src/modules/keyItems/KeyItems.ts
@@ -20,7 +20,7 @@ export default class KeyItems implements Feature {
     initialize(): void {
         this.itemList = [
             new KeyItem(KeyItemType.Teachy_tv, 'A television set that is tuned to a program with useful tips for novice TRAINERS.', null, true, undefined, 'Teachy TV'),
-            new KeyItem(KeyItemType.Coin_case, 'A case for holding money.', null, true, undefined, 'Coin Case'),
+            new KeyItem(KeyItemType.Coin_case, 'A case for holding Pokédollars.', null, true, undefined, 'Coin Case'),
             new KeyItem(KeyItemType.Pokeball_bag, 'A small bag that can hold many different types of Pokéballs.', null, true, undefined, 'Pokéball Bag'),
             new KeyItem(KeyItemType.Town_map, 'A very convenient map that can be viewed anytime. It even shows you your present location in the region.',
                 () => App.game.statistics.routeKills[Region.kanto][1]() >= ROUTE_KILLS_NEEDED,

--- a/src/modules/oakItems/OakItems.ts
+++ b/src/modules/oakItems/OakItems.ts
@@ -31,7 +31,7 @@ export default class OakItems implements Feature {
         this.itemList = [
             new OakItem(OakItemType.Magic_Ball, 'Magic Ball', 'Gives a bonus to your catchrate',
                 true, [5, 6, 7, 8, 9, 10], 0, 20, 2, undefined, undefined, undefined, '%'),
-            new OakItem(OakItemType.Amulet_Coin, 'Amulet Coin', 'Gain more coins from battling',
+            new OakItem(OakItemType.Amulet_Coin, 'Amulet Coin', 'Gain more Pokédollars from battling',
                 true, [1.25, 1.30, 1.35, 1.40, 1.45, 1.50], 1, 30, 1),
             new OakItem(OakItemType.Poison_Barb, 'Poison Barb', 'Clicks do more damage',
                 true, [1.25, 1.30, 1.35, 1.40, 1.45, 1.50], 1, 40, 3),

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -144,7 +144,7 @@ class Game {
                 type: NotificationConstants.NotificationOption.info,
                 title: 'Offline-time bonus',
                 message: `Defeated: ${numberOfPokemonDefeated.toLocaleString('en-US')} Pokémon\nEarned: <img src="./assets/images/currency/money.svg" height="24px"/> ${moneyToEarn.toLocaleString('en-US')}`,
-                strippedMessage: `Defeated: ${numberOfPokemonDefeated.toLocaleString('en-US')} Pokémon\nEarned: ${moneyToEarn.toLocaleString('en-US')} money`,
+                strippedMessage: `Defeated: ${numberOfPokemonDefeated.toLocaleString('en-US')} Pokémon\nEarned: ${moneyToEarn.toLocaleString('en-US')} Pokédollars`,
                 timeout: 2 * GameConstants.MINUTE,
                 setting: NotificationConstants.NotificationSetting.General.offline_earnings,
             });

--- a/src/scripts/items/BattleItem.ts
+++ b/src/scripts/items/BattleItem.ts
@@ -44,6 +44,6 @@ class BattleItem extends Item {
 ItemList['xAttack']         = new BattleItem(GameConstants.BattleItemType.xAttack, '+50% Bonus to Pokémon attack for 30 seconds', 600, undefined, undefined, 'pokemonAttack', 1.5);
 ItemList['xClick']          = new BattleItem(GameConstants.BattleItemType.xClick, '+50% Bonus to click attack for 30 seconds', 400, undefined, undefined, 'clickAttack', 1.5);
 ItemList['Lucky_egg']       = new BattleItem(GameConstants.BattleItemType.Lucky_egg, '+50% Bonus to experience gained for 30 seconds', 800, undefined, 'Lucky Egg', 'exp', 1.5);
-ItemList['Token_collector'] = new BattleItem(GameConstants.BattleItemType.Token_collector, '+50% Bonus to dungeon tokens gained for 30 seconds', 1000, undefined, 'Token Collector', 'dungeonToken', 1.5);
+ItemList['Token_collector'] = new BattleItem(GameConstants.BattleItemType.Token_collector, '+50% Bonus to Dungeon Tokens gained for 30 seconds', 1000, undefined, 'Token Collector', 'dungeonToken', 1.5);
 ItemList['Item_magnet']     = new BattleItem(GameConstants.BattleItemType.Item_magnet, 'Increased chance of gaining extra items for 30 seconds', 1500, undefined, 'Item Magnet');
-ItemList['Lucky_incense']   = new BattleItem(GameConstants.BattleItemType.Lucky_incense, '+50% Bonus to money gained for 30 seconds', 2000, undefined, 'Lucky Incense', 'money', 1.5);
+ItemList['Lucky_incense']   = new BattleItem(GameConstants.BattleItemType.Lucky_incense, '+50% Bonus to Pokédollars gained for 30 seconds', 2000, undefined, 'Lucky Incense', 'money', 1.5);

--- a/src/scripts/items/FluteItem.ts
+++ b/src/scripts/items/FluteItem.ts
@@ -56,7 +56,7 @@ class FluteItem extends Item {
         }
         if (FluteEffectRunner.getLowestGem(this.name) <= FluteEffectRunner.numActiveFlutes() + 1) {
             Notifier.notify({
-                message: 'You don\'t have enough gems to use this Flute',
+                message: 'You don\'t have enough gems to use this Flute.',
                 type: NotificationConstants.NotificationOption.danger,
             });
             return false;
@@ -69,7 +69,7 @@ class FluteItem extends Item {
 ItemList['Red_Flute']         = new FluteItem(GameConstants.FluteItemType.Red_Flute, 'Click Attack', ['Fighting', 'Fire', 'Poison'], 'clickAttack', 1.02);
 ItemList['White_Flute']       = new FluteItem(GameConstants.FluteItemType.White_Flute, 'Exp Yield', ['Normal', 'Bug', 'Rock'], 'exp', 1.02);
 ItemList['Black_Flute']       = new FluteItem(GameConstants.FluteItemType.Black_Flute, 'Item Drop Rate', ['Normal', 'Flying', 'Poison'], undefined, 1.02);
-ItemList['Yellow_Flute']      = new FluteItem(GameConstants.FluteItemType.Yellow_Flute, 'Pokedollar Yield', ['Dark', 'Electric', 'Steel'], 'money', 1.02);
+ItemList['Yellow_Flute']      = new FluteItem(GameConstants.FluteItemType.Yellow_Flute, 'Pokédollar Yield', ['Dark', 'Electric', 'Steel'], 'money', 1.02);
 ItemList['Blue_Flute']        = new FluteItem(GameConstants.FluteItemType.Blue_Flute, 'Dungeon Token Yield', ['Dark', 'Ghost', 'Ice'], 'dungeonToken', 1.02);
 ItemList['Poke_Flute']        = new FluteItem(GameConstants.FluteItemType.Poke_Flute, 'Pokémon Attack', ['Fighting', 'Ice', 'Fairy'], 'pokemonAttack', 1.02);
 ItemList['Azure_Flute']       = new FluteItem(GameConstants.FluteItemType.Azure_Flute, 'Shiny Chance', ['Dragon', 'Ghost', 'Steel'], 'shiny', 1.02);

--- a/src/scripts/items/Vitamin.ts
+++ b/src/scripts/items/Vitamin.ts
@@ -12,4 +12,4 @@ class Vitamin extends Item {
 }
 
 ItemList.RareCandy = new Vitamin(GameConstants.VitaminType.RareCandy, Infinity, undefined, undefined, 'Rare Candy', 'A rare-to-find candy that currently has no use.');
-ItemList.Protein   = new Vitamin(GameConstants.VitaminType.Protein, 1e4, GameConstants.Currency.money, { multiplier: 1.1, multiplierDecrease: false, saveName: `${GameConstants.VitaminType[GameConstants.VitaminType.Protein]}|${GameConstants.Currency[GameConstants.Currency.money]}` }, undefined, 'Increases Pokemon attack bonus.<br/><i>(attack gained per breeding cycle)</i>');
+ItemList.Protein   = new Vitamin(GameConstants.VitaminType.Protein, 1e4, GameConstants.Currency.money, { multiplier: 1.1, multiplierDecrease: false, saveName: `${GameConstants.VitaminType[GameConstants.VitaminType.Protein]}|${GameConstants.Currency[GameConstants.Currency.money]}` }, undefined, 'Increases Pokémon attack bonus.<br/><i>(attack gained per breeding cycle)</i>');


### PR DESCRIPTION
There were inconsistencies in-game of both Pokédollars and 'money' being used interchangeably. This just changes any player visible instances of 'money' to Pokédollars.

