### PR TITLE
Add currency lost/spent animation

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -36,6 +36,7 @@
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('hideHatchery')}"></tr>
                                 <tr data-bind="template: { name: 'MultipleChoiceSettingTemplate', data: Settings.getSetting('farmDisplay')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showCurrencyGainedAnimation')}"></tr>
+                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showCurrencyLostAnimation')}"></tr>
                                 <tr data-bind="visible: Object.values(App.game.challenges.list).filter(c => c.active()).length > 0, template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('hideChallengeRelatedModules')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('currencyMainDisplayReduced')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('currencyMainDisplayExtended')}"></tr>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -62,6 +62,7 @@ Settings.add(new Setting<string>('shopButtons', 'Shop amount buttons:',
     'original'));
 Settings.add(new BooleanSetting('resetShopAmountOnPurchase', 'Reset buy quantity after each purchase', true));
 Settings.add(new BooleanSetting('showCurrencyGainedAnimation', 'Show currency gained animation', true));
+Settings.add(new BooleanSetting('showCurrencyLostAnimation', 'Show currency lost animation', true));
 Settings.add(new BooleanSetting('hideChallengeRelatedModules', 'Hide challenge related modules', false));
 Settings.add(new Setting<string>('backgroundImage', 'Background image:',
     [

--- a/src/modules/utilities/UI.ts
+++ b/src/modules/utilities/UI.ts
@@ -23,8 +23,8 @@ export function animateCurrency({ amount, currency }: Amount) {
     // Add some randomness to where it appears
     const left = (target.position().left + Rand.float(target.width() - 25)).toFixed(2);
     const aniElement = document.createElement('p');
-    aniElement.className = amount > 0 ? '' : 'text-danger';
-    aniElement.style.cssText = `${amount > 0 ? 'bottom: -20px;' : 'bottom: -30px;'} pointer-events: none; opacity: 1; z-index: 50; position: absolute; left: ${left}px; font-size: ${10 + 0.5 * Math.log(Math.abs(amount))}px;`;
+    aniElement.className = `${amount > 0 ? '' : 'text-danger'} animated-currency`;
+    aniElement.style.cssText = `${amount > 0 ? 'bottom: -20px;' : 'bottom: -30px;'} left: ${left}px; font-size: ${10 + 0.5 * Math.log(Math.abs(amount))}px;`;
     aniElement.innerText = `${amount > 0 ? '+' : ''}${amount.toLocaleString('en-US')}`;
 
     const animationDirection = amount > 0 ? { bottom: 100 } : { bottom: -80 };

--- a/src/modules/utilities/UI.ts
+++ b/src/modules/utilities/UI.ts
@@ -32,3 +32,32 @@ export function animateCurrency({ amount, currency }: Amount) {
         $(aniElement).remove();
     });
 }
+
+// Animates lost/spent currency
+// eslint-disable-next-line import/prefer-default-export
+export function animateCurrencyLost({ amount, currency }: Amount) {
+    // Check if animations have been disabled
+    if (!Settings.getSetting('showCurrencyLostAnimation').observableValue()) {
+        return;
+    }
+    const target = $(`#animateCurrency-${Currency[currency]}`);
+    // If no target for this currency, return
+    if (!target.length || !target.is(':visible')) {
+        return;
+    }
+
+    // Add some randomness to where it appears
+    const left = (target.position().left + Rand.float(target.width() - 25)).toFixed(2);
+    const aniElement = document.createElement('p');
+    aniElement.style.cssText = `z-index: 50; position: absolute; left: ${left}px; bottom: -20px; color: #dc3545; font-size: ${10 + 0.5 * Math.log(amount)}px;`;
+    aniElement.innerText = `-${amount.toLocaleString('en-US')}`;
+
+    // Append to parent container, animate and remove
+    $(aniElement).prependTo(target.parent()).animate({
+        bottom: 100,
+        opacity: 0,
+    }, 200 * Math.log(amount) + 1000, 'linear',
+    () => {
+        $(aniElement).remove();
+    });
+}

--- a/src/modules/utilities/UI.ts
+++ b/src/modules/utilities/UI.ts
@@ -6,9 +6,12 @@ import { Currency } from '../GameConstants';
 import Rand from './Rand';
 
 // eslint-disable-next-line import/prefer-default-export
-export function animateCurrency({ amount, currency }: Amount, gainCurrency: boolean) {
+export function animateCurrency({ amount, currency }: Amount) {
     // Check if animations have been disabled
-    if (!Settings.getSetting('showCurrencyGainedAnimation').observableValue() && !Settings.getSetting('showCurrencyLostAnimation').observableValue()) {
+    if (amount > 0 && !Settings.getSetting('showCurrencyGainedAnimation').observableValue()) {
+        return;
+    }
+    if (amount < 0 && !Settings.getSetting('showCurrencyLostAnimation').observableValue()) {
         return;
     }
     const target = $(`#animateCurrency-${Currency[currency]}`);
@@ -20,31 +23,19 @@ export function animateCurrency({ amount, currency }: Amount, gainCurrency: bool
     // Add some randomness to where it appears
     const left = (target.position().left + Rand.float(target.width() - 25)).toFixed(2);
     const aniElement = document.createElement('p');
-    // Gained Currency
-    if (gainCurrency && Settings.getSetting('showCurrencyGainedAnimation').observableValue()) {
-        aniElement.style.cssText = `z-index: 50; position: absolute; left: ${left}px; bottom: -20px; font-size: ${10 + 0.5 * Math.log(amount)}px;`;
-        aniElement.innerText = `+${amount.toLocaleString('en-US')}`;
+    aniElement.className = amount > 0 ? '' : 'text-danger';
+    aniElement.style.cssText = `${amount > 0 ? 'bottom: -20px;' : 'bottom: -30px;'} pointer-events: none; opacity: 1; z-index: 50; position: absolute; left: ${left}px; font-size: ${10 + 0.5 * Math.log(Math.abs(amount))}px;`;
+    aniElement.innerText = `${amount > 0 ? '+' : ''}${amount.toLocaleString('en-US')}`;
 
-        // Append to parent container, animate and remove
-        $(aniElement).prependTo(target.parent()).animate({
-            bottom: 100,
-            opacity: 0,
-        }, 200 * Math.log(amount) + 1000, 'linear',
-        () => {
-            $(aniElement).remove();
-        });
-    // Lost Currency
-    } else if (!gainCurrency && Settings.getSetting('showCurrencyLostAnimation').observableValue()) {
-        aniElement.style.cssText = `z-index: 50; position: absolute; left: ${left}px; color: #dc3545; font-size: ${10 + 0.5 * Math.log(amount)}px;`;
-        aniElement.innerText = `-${amount.toLocaleString('en-US')}`;
-
-        // Append to parent container, animate and remove
-        $(aniElement).prependTo(target.parent()).animate({
-            top: 100,
-            opacity: 0,
-        }, 200 * Math.log(amount) + 1000, 'linear',
-        () => {
-            $(aniElement).remove();
-        });
-    }
+    const animationDirection = amount > 0 ? { bottom: 100 } : { bottom: -80 };
+    // Shorter animation for currency lost
+    const animationTime = 200 * Math.log(Math.abs(amount)) + (amount > 0 ? 1000 : 600);
+    // Append to parent container, animate and remove
+    $(aniElement).prependTo(target.parent()).animate({
+        ...animationDirection,
+        opacity: 0,
+    }, animationTime, 'linear',
+    () => {
+        $(aniElement).remove();
+    });
 }

--- a/src/modules/utilities/UI.ts
+++ b/src/modules/utilities/UI.ts
@@ -6,9 +6,9 @@ import { Currency } from '../GameConstants';
 import Rand from './Rand';
 
 // eslint-disable-next-line import/prefer-default-export
-export function animateCurrency({ amount, currency }: Amount) {
+export function animateCurrency({ amount, currency }: Amount, gainCurrency: boolean) {
     // Check if animations have been disabled
-    if (!Settings.getSetting('showCurrencyGainedAnimation').observableValue()) {
+    if (!Settings.getSetting('showCurrencyGainedAnimation').observableValue() && !Settings.getSetting('showCurrencyLostAnimation').observableValue()) {
         return;
     }
     const target = $(`#animateCurrency-${Currency[currency]}`);
@@ -20,44 +20,31 @@ export function animateCurrency({ amount, currency }: Amount) {
     // Add some randomness to where it appears
     const left = (target.position().left + Rand.float(target.width() - 25)).toFixed(2);
     const aniElement = document.createElement('p');
-    aniElement.style.cssText = `z-index: 50; position: absolute; left: ${left}px; bottom: -20px; font-size: ${10 + 0.5 * Math.log(amount)}px;`;
-    aniElement.innerText = `+${amount.toLocaleString('en-US')}`;
+    // Gained Currency
+    if (gainCurrency && Settings.getSetting('showCurrencyGainedAnimation').observableValue()) {
+        aniElement.style.cssText = `z-index: 50; position: absolute; left: ${left}px; bottom: -20px; font-size: ${10 + 0.5 * Math.log(amount)}px;`;
+        aniElement.innerText = `+${amount.toLocaleString('en-US')}`;
 
-    // Append to parent container, animate and remove
-    $(aniElement).prependTo(target.parent()).animate({
-        bottom: 100,
-        opacity: 0,
-    }, 200 * Math.log(amount) + 1000, 'linear',
-    () => {
-        $(aniElement).remove();
-    });
-}
+        // Append to parent container, animate and remove
+        $(aniElement).prependTo(target.parent()).animate({
+            bottom: 100,
+            opacity: 0,
+        }, 200 * Math.log(amount) + 1000, 'linear',
+        () => {
+            $(aniElement).remove();
+        });
+    // Lost Currency
+    } else if (!gainCurrency && Settings.getSetting('showCurrencyLostAnimation').observableValue()) {
+        aniElement.style.cssText = `z-index: 50; position: absolute; left: ${left}px; color: #dc3545; font-size: ${10 + 0.5 * Math.log(amount)}px;`;
+        aniElement.innerText = `-${amount.toLocaleString('en-US')}`;
 
-// Animates lost/spent currency
-// eslint-disable-next-line import/prefer-default-export
-export function animateCurrencyLost({ amount, currency }: Amount) {
-    // Check if animations have been disabled
-    if (!Settings.getSetting('showCurrencyLostAnimation').observableValue()) {
-        return;
+        // Append to parent container, animate and remove
+        $(aniElement).prependTo(target.parent()).animate({
+            top: 100,
+            opacity: 0,
+        }, 200 * Math.log(amount) + 1000, 'linear',
+        () => {
+            $(aniElement).remove();
+        });
     }
-    const target = $(`#animateCurrency-${Currency[currency]}`);
-    // If no target for this currency, return
-    if (!target.length || !target.is(':visible')) {
-        return;
-    }
-
-    // Add some randomness to where it appears
-    const left = (target.position().left + Rand.float(target.width() - 25)).toFixed(2);
-    const aniElement = document.createElement('p');
-    aniElement.style.cssText = `z-index: 50; position: absolute; left: ${left}px; bottom: -20px; color: #dc3545; font-size: ${10 + 0.5 * Math.log(amount)}px;`;
-    aniElement.innerText = `-${amount.toLocaleString('en-US')}`;
-
-    // Append to parent container, animate and remove
-    $(aniElement).prependTo(target.parent()).animate({
-        bottom: 100,
-        opacity: 0,
-    }, 200 * Math.log(amount) + 1000, 'linear',
-    () => {
-        $(aniElement).remove();
-    });
 }

--- a/src/modules/wallet/Wallet.ts
+++ b/src/modules/wallet/Wallet.ts
@@ -6,7 +6,7 @@ import GameHelper from '../GameHelper';
 import { Currency } from '../GameConstants';
 import Multiplier from '../multiplier/Multiplier';
 import Amount from './Amount';
-import { animateCurrency, animateCurrencyLost } from '../utilities/UI';
+import { animateCurrency } from '../utilities/UI';
 
 export default class Wallet implements Feature {
     name = 'Wallet';
@@ -72,7 +72,7 @@ export default class Wallet implements Feature {
         }
 
         GameHelper.incrementObservable(this.currencies[amount.currency], amount.amount);
-        animateCurrency(amount);
+        animateCurrency(amount, true);
 
         switch (amount.currency) {
             case Currency.money:
@@ -116,7 +116,7 @@ export default class Wallet implements Feature {
         }
 
         GameHelper.incrementObservable(this.currencies[amount.currency], -amount.amount);
-        animateCurrencyLost(amount);
+        animateCurrency(amount, false);
 
         return true;
     }

--- a/src/modules/wallet/Wallet.ts
+++ b/src/modules/wallet/Wallet.ts
@@ -6,7 +6,7 @@ import GameHelper from '../GameHelper';
 import { Currency } from '../GameConstants';
 import Multiplier from '../multiplier/Multiplier';
 import Amount from './Amount';
-import { animateCurrency } from '../utilities/UI';
+import { animateCurrency, animateCurrencyLost } from '../utilities/UI';
 
 export default class Wallet implements Feature {
     name = 'Wallet';
@@ -116,6 +116,8 @@ export default class Wallet implements Feature {
         }
 
         GameHelper.incrementObservable(this.currencies[amount.currency], -amount.amount);
+        animateCurrencyLost(amount);
+
         return true;
     }
 

--- a/src/modules/wallet/Wallet.ts
+++ b/src/modules/wallet/Wallet.ts
@@ -72,7 +72,7 @@ export default class Wallet implements Feature {
         }
 
         GameHelper.incrementObservable(this.currencies[amount.currency], amount.amount);
-        animateCurrency(amount, true);
+        animateCurrency(amount);
 
         switch (amount.currency) {
             case Currency.money:
@@ -116,8 +116,7 @@ export default class Wallet implements Feature {
         }
 
         GameHelper.incrementObservable(this.currencies[amount.currency], -amount.amount);
-        animateCurrency(amount, false);
-
+        animateCurrency({ ...amount, amount: -amount.amount });
         return true;
     }
 

--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -67,10 +67,10 @@ class BattleFrontierRunner {
 
         Notifier.notify({
             title: 'Battle Frontier',
-            message: `You managed to beat stage ${stageBeaten}.\nYou received ${battlePointsEarned} BP`,
+            message: `You managed to beat stage ${stageBeaten}.\nYou received <img src="./assets/images/currency/battlePoint.svg" height="18px"/> ${battlePointsEarned.toLocaleString('en-US')}.\nYou received <img src="./assets/images/currency/money.svg" height="18px"/> ${moneyEarned.toLocaleString('en-US')}.`,
             type: NotificationConstants.NotificationOption.success,
             setting: NotificationConstants.NotificationSetting.General.battle_frontier,
-            timeout: 5 * GameConstants.MINUTE,
+            timeout: 30 * GameConstants.MINUTE,
         });
 
         // Award battle points

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -582,3 +582,10 @@ td.tight {
 .text-completed {
   color: var(--completed);
 }
+
+.animated-currency {
+  pointer-events: none;
+  position: absolute;
+  opacity: 1;
+  z-index: 50;
+}


### PR DESCRIPTION
This adds an option to display a currency lost animation. The main utilization of this is to better visualize currency spent on Helpers, and for people who struggle with reading, currency spent on auto-battling gyms. 

Tried to implement it into the existing animateCurrency function, but couldn't figure it out, so I just made a new function replicating it. Could probably be implemented in a cleaner way within UI.ts.