### PR TITLE
Add glow to the quest marker

### DIFF
--- a/src/styles/map.less
+++ b/src/styles/map.less
@@ -1,7 +1,5 @@
 @import "variables.less";
 
-
-
 #map {
   @keyframes faintLight {
     0% { filter:brightness(1) }

--- a/src/styles/map.less
+++ b/src/styles/map.less
@@ -1,6 +1,14 @@
 @import "variables.less";
 
+
+
 #map {
+  @keyframes faintLight {
+    0% { filter:brightness(1) }
+    50% { filter:brightness(2) }
+    100% { filter:brightness(1) }
+  }
+
   rect, path {
     cursor: pointer;
     fill: transparent;
@@ -28,6 +36,9 @@
   .questAtLocation {
     fill: var(--questAtLocation);
     opacity: 0.6;
+    animation-duration: 3s;
+    animation-name: faintLight;
+    animation-iteration-count: infinite;
   }
 
   .uncaughtPokemon {


### PR DESCRIPTION
Hello, 

A recurring complaint I've seen in a discord server playing Pokeclicker was the difficulty to locate quests spots, especially dungeons as they often "fuse" with the green of the background image. 

I've had the idea to add a simple "glowing" effect to the class "questAtLocation", which catch the eye a bit.
I tried to not overdo it. 

Here is a small sample :

https://user-images.githubusercontent.com/4422077/172954892-97ae8235-e528-4a99-a84d-8f809654209d.mp4


Thanks for reading !