### PR TITLE
Shop updates

### DIFF
--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -46,6 +46,12 @@ const pokeLeagueShop = () => new Shop([
 ]);
 
 //Kanto Shops
+const ViridianCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['xAttack'],
+    ItemList['xClick'],
+    ItemList['Dungeon_ticket'],
+]);
 const PewterCityShop = new Shop([
     ItemList['Pokeball'],
     ItemList['Token_collector'],
@@ -56,14 +62,23 @@ const Route3Shop = new Shop([
     ItemList['Magikarp'],
 ]);
 const CeruleanCityShop = new Shop([
-    ItemList['Water_stone'],
+    ItemList['Pokeball'],
     ItemList['xAttack'],
     ItemList['Water_egg'],
+    ItemList['Water_stone'],
 ]);
 const VermilionCityShop = new Shop([
-    ItemList['Thunder_stone'],
+    ItemList['Pokeball'],
     ItemList['Lucky_egg'],
     ItemList['Electric_egg'],
+    ItemList['Thunder_stone'],
+]);
+const LavenderTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Item_magnet'],
+    ItemList['Lucky_incense'],
+    ItemList['Grass_egg'],
 ]);
 const CeladonCityShop = new Shop([
     ItemList['Eevee'],
@@ -83,37 +98,32 @@ const CeladonDepartmentStoreShop = new Shop([
     ItemList['Lucky_incense'],
 ], 'Department Store');
 const SaffronCityShop = new Shop([
-    ItemList['Moon_stone'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
     ItemList['xClick'],
-    ItemList['Leaf_stone'],
     ItemList['Fighting_egg'],
+    ItemList['Leaf_stone'],
+    ItemList['Moon_stone'],
 ]);
 const FuchsiaCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
     ItemList['Ultraball'],
-    ItemList['Trade_stone'],
     ItemList['Lucky_egg'],
     ItemList['Dragon_egg'],
+    ItemList['Trade_stone'],
 ]);
 const CinnabarIslandShop = new Shop([
-    ItemList['Fire_stone'],
-    ItemList['Fire_egg'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
     ItemList['SmallRestore'],
+    ItemList['Fire_egg'],
+    ItemList['Fire_stone'],
     ItemList['Explorer_kit'],
     ItemList['Explosive_Charge'],
     ItemList['Treasure_Scanner'],
     ItemList['HatcheryHelperKris'],
-]);
-const ViridianCityShop = new Shop([
-    ItemList['Pokeball'],
-    ItemList['xAttack'],
-    ItemList['xClick'],
-    ItemList['Dungeon_ticket'],
-]);
-const LavenderTownShop = new Shop([
-    ItemList['Greatball'],
-    ItemList['Item_magnet'],
-    ItemList['Lucky_incense'],
-    ItemList['Grass_egg'],
 ]);
 
 // Kanto NPCs
@@ -204,6 +214,15 @@ TownList['Pallet Town'] = new Town(
     [],
     {
         npcs: [PalletProfOak, PalletMom],
+    }
+);
+TownList['Viridian City'] = new Town(
+    'Viridian City',
+    GameConstants.Region.kanto,
+    [ViridianCityShop],
+    {
+        requirements: [new RouteKillRequirement(10, GameConstants.Region.kanto, 1)],
+        npcs: [ViridianCityOldMan],
     }
 );
 TownList['Pewter City'] = new Town(
@@ -301,15 +320,6 @@ TownList['Cinnabar Island'] = new Town(
         npcs: [CinnabarIslandResearcher],
     }
 );
-TownList['Viridian City'] = new Town(
-    'Viridian City',
-    GameConstants.Region.kanto,
-    [ViridianCityShop],
-    {
-        requirements: [new RouteKillRequirement(10, GameConstants.Region.kanto, 1)],
-        npcs: [ViridianCityOldMan],
-    }
-);
 TownList['Indigo Plateau Kanto'] = new Town(
     'Indigo Plateau Kanto',
     GameConstants.Region.kanto,
@@ -401,18 +411,22 @@ TownList['Cerulean Cave'] = new DungeonTown(
 );
 
 //Johto Shops
-const NewBarkTownShop = new Shop([
+const CherrygroveCityShop = new Shop([
     ItemList['Pokeball'],
+    ItemList['SmallRestore'],
 ]);
 const VioletCityShop = new Shop([
-    ItemList['MediumRestore'],
-    ItemList['Togepi'],
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Mystery_egg'],
+    ItemList['Togepi'],
 ]);
 const AzaleaTownShop = new Shop([
-    ItemList['Kings_rock'],
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Grass_egg'],
     ItemList['Leaf_stone'],
+    ItemList['Kings_rock'],
 ]);
 const GoldenrodDepartmentStoreShop = new Shop([
     ItemList['Pokeball'],
@@ -428,33 +442,53 @@ const GoldenrodDepartmentStoreShop = new Shop([
     ItemList['MediumRestore'],
 ], 'Department Store');
 const EcruteakCityShop = new Shop([
+    ItemList['Pokeball'],
     ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Fire_egg'],
-    ItemList['Soothe_bell'],
     ItemList['Fire_stone'],
+    ItemList['Soothe_bell'],
 ]);
 const OlivineCityShop = new Shop([
-    ItemList['Metal_coat'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Water_egg'],
     ItemList['Electric_egg'],
     ItemList['Water_stone'],
     ItemList['Thunder_stone'],
+    ItemList['Metal_coat'],
     ItemList['HatcheryHelperCarey'],
 ]);
 const CianwoodCityShop = new Shop([
-    ItemList['Ultraball'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Fighting_egg'],
+    ItemList['Moon_stone'],
     ItemList['Sun_stone'],
 ]);
 const MahoganyTownShop = new Shop([
-    ItemList['Upgrade'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Trade_stone'],
+    ItemList['Upgrade'],
     ItemList['HatcheryHelperDakota'],
 ]);
 const BlackthornCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['LargeRestore'],
-    ItemList['Dragon_scale'],
     ItemList['Dragon_egg'],
+    ItemList['Dragon_scale'],
 ]);
 
 // Johto NPCs
@@ -553,7 +587,7 @@ const ProfElm = new ProfNPC('Prof. Elm',
 TownList['New Bark Town'] = new Town(
     'New Bark Town',
     GameConstants.Region.johto,
-    [NewBarkTownShop],
+    [],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_KantoChampion)],
         npcs: [ProfElm, NewBarkTechnologyEnthusiast],
@@ -562,7 +596,7 @@ TownList['New Bark Town'] = new Town(
 TownList['Cherrygrove City'] = new Town(
     'Cherrygrove City',
     GameConstants.Region.johto,
-    [],
+    [CherrygroveCityShop],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.johto, 29)],
         npcs: [CherrygroveMrPokemon],
@@ -736,58 +770,113 @@ TownList['Mt. Silver'] = new DungeonTown(
 );
 
 //Hoenn Shops
-const LittleRootTownShop = new Shop([
+const OldaleTownShop = new Shop([
     ItemList['Pokeball'],
+    ItemList['SmallRestore'],
 ]);
 const PetalburgCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Kings_rock'],
 ]);
 const RustboroCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Mystery_egg'],
 ]);
 const DewfordTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Fighting_egg'],
 ]);
 const SlateportCityShop = new Shop([
+    ItemList['Pokeball'],
     ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Water_egg'],
     ItemList['Trade_stone'],
 ]);
 const MauvilleCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Electric_egg'],
     ItemList['Thunder_stone'],
     ItemList['Metal_coat'],
     ItemList['HatcheryHelperJasmine'],
 ]);
 const VerdanturfTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Grass_egg'],
     ItemList['Soothe_bell'],
 ]);
 const LavaridgeTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Fire_egg'],
     ItemList['Fire_stone'],
 ]);
 const FallarborTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Moon_stone'],
     ItemList['Sun_stone'],
 ]);
 const FortreeCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
     ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Leaf_stone'],
 ]);
 const MossdeepCityShop = new Shop([
-    ItemList['Beldum'],
-    ItemList['Prism_scale'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Upgrade'],
+    ItemList['Prism_scale'],
+    ItemList['Beldum'],
 ]);
 const SootopolisCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Water_stone'],
 ]);
 const PacifidlogTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Deepsea_tooth'],
     ItemList['Deepsea_scale'],
 ]);
 const EverGrandeCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Dragon_egg'],
     ItemList['Dragon_scale'],
 ]);
@@ -876,7 +965,7 @@ const ProfBirch = new ProfNPC('Prof. Birch',
 TownList['Littleroot Town'] = new Town(
     'Littleroot Town',
     GameConstants.Region.hoenn,
-    [LittleRootTownShop],
+    [],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_JohtoChampion)],
         npcs: [ProfBirch, LittlerootAide],
@@ -885,7 +974,7 @@ TownList['Littleroot Town'] = new Town(
 TownList['Oldale Town'] = new Town(
     'Oldale Town',
     GameConstants.Region.hoenn,
-    [],
+    [OldaleTownShop],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.hoenn, 101)],
         npcs: [OldaleTrackingScientist],
@@ -1149,41 +1238,81 @@ TownList['Sealed Chamber'] = new DungeonTown(
 );
 
 //Sinnoh Shops
-const TwinleafTownShop = new Shop([
+const SandgemTownShop = new Shop([
     ItemList['Pokeball'],
+    ItemList['SmallRestore'],
 ]);
 const JubilifeCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Moon_stone'],
     ItemList['Sun_stone'],
 ]);
 const OreburghCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Mystery_egg'],
 ]);
 const FloaromaTownShop = new Shop([
-    ItemList['Kings_rock'],
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Trade_stone'],
+    ItemList['Kings_rock'],
 ]);
 const EternaCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Grass_egg'],
     ItemList['Leaf_stone'],
 ]);
 const HearthomeCityShop = new Shop([
+    ItemList['Pokeball'],
     ItemList['Greatball'],
-    ItemList['Soothe_bell'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Fire_egg'],
     ItemList['Fire_stone'],
+    ItemList['Soothe_bell'],
 ]);
 const SolaceonTownShop = new Shop([
-    ItemList['Dawn_stone'],
-    ItemList['Dusk_stone'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Shiny_stone'],
+    ItemList['Dusk_stone'],
+    ItemList['Dawn_stone'],
     ItemList['Spiritomb'],
 ]);
+const PastoriaShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
+    ItemList['Water_egg'],
+    ItemList['Water_stone'],
+    ItemList['Prism_scale'],
+    ItemList['Skorupi'],
+]);
 const CelesticTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Dragon_egg'],
     ItemList['Dragon_scale'],
 ]);
 const CanalaveCityShop = new Shop ([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Fighting_egg'],
     ItemList['Metal_coat'],
 ]);
@@ -1195,29 +1324,54 @@ const PalParkShop = new Shop([
     ItemList['Cherubi'],
 ]);
 const SnowpointCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Upgrade'],
 ]);
 const SunyshoreCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Electric_egg'],
     ItemList['Thunder_stone'],
-    ItemList['Deepsea_scale'],
     ItemList['Deepsea_tooth'],
+    ItemList['Deepsea_scale'],
+]);
+const FightAreaShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
 ]);
 const SurvivalAreaShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Electirizer'],
     ItemList['Magmarizer'],
 ]);
 const ResortAreaShop = new Shop([
-    ItemList['Reaper_cloth'],
-    ItemList['Dubious_disc'],
-    ItemList['Protector'],
-]);
-const PastoriaShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
     ItemList['Ultraball'],
-    ItemList['Skorupi'],
-    ItemList['Water_egg'],
-    ItemList['Water_stone'],
-    ItemList['Prism_scale'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
+    ItemList['Protector'],
+    ItemList['Dubious_disc'],
+    ItemList['Reaper_cloth'],
 ]);
 
 //Sinnoh Berry Master
@@ -1312,7 +1466,7 @@ const ProfRowan = new ProfNPC('Prof. Rowan',
 TownList['Twinleaf Town'] = new Town(
     'Twinleaf Town',
     GameConstants.Region.sinnoh,
-    [TwinleafTownShop],
+    [],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion)],
         npcs: [TwinleafContestChampion],
@@ -1321,7 +1475,7 @@ TownList['Twinleaf Town'] = new Town(
 TownList['Sandgem Town'] = new Town(
     'Sandgem Town',
     GameConstants.Region.sinnoh,
-    [],
+    [SandgemTownShop],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 201)],
         npcs: [ProfRowan, SandgemBeachcomber],
@@ -1462,7 +1616,7 @@ TownList['Pokémon League Sinnoh'] = new Town(
 TownList['Fight Area'] = new Town(
     'Fight Area',
     GameConstants.Region.sinnoh,
-    [],
+    [FightAreaShop],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion)],
         npcs: [FightAreaAceTrainer],
@@ -1635,75 +1789,160 @@ TownList['Snowpoint Temple'] = new DungeonTown(
 );
 
 //Unova Shops
-const AspertiaCityShop = new Shop([
-    ItemList['Pokeball'],
-]);
 const FloccesyTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Mystery_egg'],
 ]);
 const VirbankCityShop = new Shop([
+    ItemList['Pokeball'],
     ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
 ]);
 const CasteliaCityShop = new Shop([
-    ItemList['Trade_stone'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Water_egg'],
+    ItemList['Trade_stone'],
     ItemList['Kings_rock'],
 ]);
 const NimbasaCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Grass_egg'],
     ItemList['Electric_egg'],
     ItemList['Metal_coat'],
 ]);
 const DriftveilCityShop = new Shop([
-    ItemList['Zorua'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Razor_claw'],
     ItemList['Razor_fang'],
+    ItemList['Zorua'],
 ]);
 const MistraltonCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
     ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Thunder_stone'],
     ItemList['Upgrade'],
 ]);
 const LentimasTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Fire_egg'],
 ]);
 const UndellaTownShop = new Shop([
-    ItemList['Deepsea_scale'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Deepsea_tooth'],
+    ItemList['Deepsea_scale'],
 ]);
 const LacunosaTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Fighting_egg'],
 ]);
 const OpelucidCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Dragon_egg'],
     ItemList['Dragon_scale'],
 ]);
 const HumilauCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Prism_scale'],
 ]);
 const IcirrusCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
+    ItemList['Protector'],
     ItemList['Dubious_disc'],
     ItemList['Reaper_cloth'],
-    ItemList['Protector'],
 ]);
 const BlackAndWhiteParkShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Moon_stone'],
     ItemList['Sun_stone'],
 ]);
 const NacreneCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Soothe_bell'],
 ]);
 const StriatonCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Leaf_stone'],
-    ItemList['Water_stone'],
     ItemList['Fire_stone'],
+    ItemList['Water_stone'],
 ]);
 const AccumulaTownShop = new Shop([
-    ItemList['Dusk_stone'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Shiny_stone'],
+    ItemList['Dusk_stone'],
     ItemList['Dawn_stone'],
 ]);
 const NuvemaTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Electirizer'],
     ItemList['Magmarizer'],
 ]);
@@ -1752,7 +1991,7 @@ const ProfJuniper = new ProfNPC('Prof. Juniper',
 TownList['Aspertia City'] = new Town(
     'Aspertia City',
     GameConstants.Region.unova,
-    [AspertiaCityShop],
+    [],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion)],
         npcs: [],
@@ -2108,10 +2347,13 @@ TownList['P2 Laboratory'] = new DungeonTown(
 );
 
 //Kalos Shops
-const VanivilleTownShop = new Shop([
+const AquacordeTownShop = new Shop([
     ItemList['Pokeball'],
+    ItemList['SmallRestore'],
 ]);
 const SantaluneCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Mystery_egg'],
 ]);
 const FriseurFurfrouShop = new Shop([
@@ -2123,55 +2365,111 @@ const FriseurFurfrouShop = new Shop([
     ItemList['Furfrou (Pharaoh)'],
 ], 'Friseur Furfrou');
 const CamphrierTownShop = new Shop([
+    ItemList['Pokeball'],
     ItemList['Greatball'],
-    ItemList['Thunder_stone'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Electric_egg'],
+    ItemList['Thunder_stone'],
 ]);
 const AmbretteTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Water_egg'],
     ItemList['Water_stone'],
 ]);
+const CyllageCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['Upgrade'],
+    ItemList['Prism_scale'],
+]);
 const GeosengeTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Fire_egg'],
     ItemList['Fire_stone'],
     ItemList['Kings_rock'],
 ]);
 const ShalourCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Fighting_egg'],
-    ItemList['Metal_coat'],
     ItemList['Trade_stone'],
+    ItemList['Metal_coat'],
 ]);
 const CoumarineCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
     ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Grass_egg'],
     ItemList['Leaf_stone'],
     ItemList['Electirizer'],
     ItemList['Magmarizer'],
 ]);
 const LaverreCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
+    ItemList['Deepsea_tooth'],
+    ItemList['Deepsea_scale'],
     ItemList['Sachet'],
     ItemList['Whipped_dream'],
-    ItemList['Deepsea_scale'],
-    ItemList['Deepsea_tooth'],
 ]);
 const DendemilleTownShop = new Shop([
-    ItemList['Dusk_stone'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Shiny_stone'],
+    ItemList['Dusk_stone'],
     ItemList['Dawn_stone'],
-    ItemList['Upgrade'],
 ]);
 const AnistarCityShop = new Shop([
-    ItemList['Sun_stone'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Moon_stone'],
+    ItemList['Sun_stone'],
     ItemList['Razor_claw'],
     ItemList['Razor_fang'],
 ]);
 const CouriwayTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Dragon_egg'],
     ItemList['Dragon_scale'],
-    ItemList['Prism_scale'],
 ]);
 const SnowbelleCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Protector'],
     ItemList['Reaper_cloth'],
     ItemList['Dubious_disc'],
@@ -2219,7 +2517,7 @@ const ProfSycamore = new ProfNPC('Prof. Sycamore',
 TownList['Vaniville Town'] = new Town(
     'Vaniville Town',
     GameConstants.Region.kalos,
-    [VanivilleTownShop],
+    [],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)],
         npcs: [],
@@ -2228,7 +2526,7 @@ TownList['Vaniville Town'] = new Town(
 TownList['Aquacorde Town'] = new Town(
     'Aquacorde Town',
     GameConstants.Region.kalos,
-    [],
+    [AquacordeTownShop],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.kalos, 1)],
     }
@@ -2270,7 +2568,7 @@ TownList['Ambrette Town'] = new Town(
 TownList['Cyllage City'] = new Town(
     'Cyllage City',
     GameConstants.Region.kalos,
-    [],
+    [CyllageCityShop],
     {
         requirements: [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Glittering Cave'))],
     }
@@ -2448,51 +2746,82 @@ TownList['Victory Road Kalos'] = new DungeonTown(
 
 //Alola Shops
 
-const IkiTownOutskirtsShop = new Shop([
+const IkiTownShop = new Shop([
     ItemList['Pokeball'],
+    ItemList['SmallRestore'],
 ]);
 const HauoliCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['SmallRestore'],
     ItemList['Mystery_egg'],
     ItemList['Shiny_stone'],
     ItemList['Dusk_stone'],
     ItemList['Dawn_stone'],
 ]);
 const HeaheaCityShop = new Shop([
+    ItemList['Pokeball'],
     ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Water_stone'],
-    ItemList['Metal_coat'],
     ItemList['Kings_rock'],
+    ItemList['Metal_coat'],
 ]);
 const PaniolaTownShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Grass_egg'],
     ItemList['Fire_egg'],
     ItemList['Water_egg'],
 ]);
 const KonikoniCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Fire_stone'],
-    ItemList['Soothe_bell'],
     ItemList['Trade_stone'],
+    ItemList['Soothe_bell'],
 ]);
 const AetherParadiseShop = new Shop([
-    ItemList['Type: Null'],
     ItemList['Upgrade'],
+    ItemList['Type: Null'],
 ]);
 const MalieCityShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
     ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Thunder_stone'],
     ItemList['Electric_egg'],
     ItemList['Magmarizer'],
     ItemList['Electirizer'],
 ]);
 const TapuVillageShop = new Shop([
-    ItemList['Ice_stone'],
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Razor_claw'],
     ItemList['Razor_fang'],
+    ItemList['Ice_stone'],
 ]);
 const SeafolkVillageShop = new Shop([
+    ItemList['Pokeball'],
+    ItemList['Greatball'],
+    ItemList['Ultraball'],
+    ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
+    ItemList['LargeRestore'],
     ItemList['Fighting_egg'],
-    ItemList['Deepsea_scale'],
     ItemList['Deepsea_tooth'],
+    ItemList['Deepsea_scale'],
     ItemList['Prism_scale'],
     ItemList['Sachet'],
     ItemList['Whipped_dream'],
@@ -2506,9 +2835,9 @@ const ExeggutorIslandShop = new Shop([
     ItemList['Reaper_cloth'],
 ]);
 const AltaroftheSunneandMooneShop = new Shop([
-    ItemList['Poipole'],
-    ItemList['Sun_stone'],
     ItemList['Moon_stone'],
+    ItemList['Sun_stone'],
+    ItemList['Poipole'],
 ]);
 
 //Alola NPCs
@@ -2580,7 +2909,7 @@ const ProfKukui = new ProfNPC('Prof. Kukui',
 TownList['Iki Town Outskirts'] = new Town(
     'Iki Town Outskirts',
     GameConstants.Region.alola,
-    [IkiTownOutskirtsShop],
+    [],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_KalosChampion)],
         npcs: [IkiOutskirtsMom],
@@ -2589,7 +2918,7 @@ TownList['Iki Town Outskirts'] = new Town(
 TownList['Iki Town'] = new Town(
     'Iki Town',
     GameConstants.Region.alola,
-    [],
+    [IkiTownShop],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.alola, 1)],
         npcs: [IkiKahuna],

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -414,11 +414,11 @@ TownList['Cerulean Cave'] = new DungeonTown(
 const CherrygroveCityShop = new Shop([
     ItemList['Pokeball'],
     ItemList['SmallRestore'],
-    ItemList['MediumRestore'],
 ]);
 const VioletCityShop = new Shop([
     ItemList['Pokeball'],
     ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
     ItemList['Mystery_egg'],
     ItemList['Togepi'],
 ]);

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -414,6 +414,7 @@ TownList['Cerulean Cave'] = new DungeonTown(
 const CherrygroveCityShop = new Shop([
     ItemList['Pokeball'],
     ItemList['SmallRestore'],
+    ItemList['MediumRestore'],
 ]);
 const VioletCityShop = new Shop([
     ItemList['Pokeball'],


### PR DESCRIPTION
All shops in towns now sell balls. Pokéballs, Greatballs and Ultraballs depending on where they would unlock in the main games.
Most shops now sell restores, _after_ they are first introduced.
Small Restores appear alongside Pokéballs.
Medium Restores now appear alongside Greatballs.
Large Restores now appear alongside Ultraballs.
Some exceptions. Medium and Large Restores don't appear in Kanto. Medium Restore appears in Violet City even though there are no Greatballs.
All home towns no longer have shops.
All other towns that didn't have shops now have shops. For example you can't buy balls in New Bark anymore, but you can now buy some in Cherrygrove. You can survive clearing one route without a shop surely?
Some towns still don't have the balls and restores treatment. Because they aren't actually towns. Places like Pal Park, Aether Paradise.

Created a consistent item order. After balls and restores it's battle items, eggs, stones, pokemonitems, other.
For eggs it's grass, fire, water, electric, fighting, dragon.
For stones it's leaf, fire, water, thunder, moon, trade. After that sorted by region and then by the dex number of the first mon it would be used on.

Also added Moon Stone to Cianwood because Johto didn't have any Moon Stone for sale for some reason.
Also moved Kalos' Upgrade and Prism Scale to Cyllage because that town just had nothing for some reason.