### PR TITLE
Move Battle Item Tooltips to Left

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -40,7 +40,7 @@
                             tooltip: {
                               title: ItemList[$data].displayName + '<br/>' + ItemList[$data].description,
                               trigger: 'hover',
-                              placement:'bottom',
+                              placement:'left',
                               html: true
                             }">
                 <img src="" class="clickable" data-bind="attr: { src: ItemList[$data].image }" width="26px">
@@ -87,7 +87,7 @@
                             tooltip: {
                               title: ItemList[$data].displayName + '<br/>' + ItemList[$data].getDescription() + '<br/>' + 'Consumes: ' + ItemList[$data].gemTypes[0] + ', ' + ItemList[$data].gemTypes[1] + ', and ' + ItemList[$data].gemTypes[2] + ' Gems',
                               trigger: 'hover',
-                              placement:'bottom',
+                              placement:'left',
                               html: true
                             }">
                 <img src="" class="clickable" data-bind="attr: { src: ItemList[$data].image }" width="26px">


### PR DESCRIPTION
Moves the hover tooltip on battle items/flutes container to left. This way the tooltip doesn't cover up either the timer or the item quantity while hovering over/using it. 

Closes #2470 