### PR TITLE
Questline not starting fix

### DIFF
--- a/src/scripts/gym/GymList.ts
+++ b/src/scripts/gym/GymList.ts
@@ -454,7 +454,7 @@ GymList['Mauville City'] = new Gym(
     'Wahahahah! Fine, I lost! You ended up giving me a thrill! Take this Badge!',
     [new GymBadgeRequirement(BadgeEnums.Knuckle)],
     () => {
-        App.game.quests.getQuestLine('Land vs Water').beginQuest();
+        App.game.quests.getQuestLine('Land vs. Water').beginQuest();
     }
 );
 GymList['Lavaridge Town'] = new Gym(


### PR DESCRIPTION
Land vs. Water now starting after clearing Watson.

Also is seems that any savefile that cleared Watson before v0.8.14 did **not** get this quest correctly.
They did get "Land vs Water" not "Land vs. Water".