### PR TITLE
Fixed that the dungeon trainer icon was always the default trainer

### DIFF
--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -30,6 +30,7 @@ export default class Profile implements Saveable {
     ) {
         this.name = ko.observable(name);
         this.trainer = ko.observable(trainer).extend({ numeric: 0 });
+        this.trainer.subscribe((t) => document.documentElement.style.setProperty('--trainer-image', `url('../assets/images/profile/trainer-${t}.png')`));
         this.pokemon = ko.observable(pokemon).extend({ numeric: 2 });
         this.pokemonShiny = ko.observable(false).extend({ boolean: null });
         this.background = ko.observable(background).extend({ numeric: 0 });


### PR DESCRIPTION
We have a feature, where your selected profile guy is the one showing up in dungeons. This broke in the latest patch. This PR should fix that.
The problem was that a subscribe was removed in some refactoring.
Closes #2512