### PR TITLE
Now displaying EV bonus on hover over

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -105,8 +105,8 @@ aria-labelledby="pokedexModalLabel">
                                         <br/>Catch Rate: <strong>${PokemonFactory.catchRateHelper($data.catchRate, true)}%</strong>
                                         <br/>Hatch Steps: <strong>${App.game.breeding.getSteps($data.eggCycles).toLocaleString('en-US')}</strong>` +
                                         (App.game.party.getPokemon($data.id)?.pokerus ?
-                                            `<br/>EVs: <strong>${App.game.party.getEffortValues(App.game.party.getPokemon($data.id))()}</strong>
-                                            <br/>EV bonus: <strong>x${App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data.id))}</strong>`
+                                            `<br/>EVs: <strong>${App.game.party.getEffortValues(App.game.party.getPokemon($data.id))().toLocaleString('en-US')}</strong>
+                                            <br/>EV bonus: <strong>x${App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data.id)).toLocaleString('en-US')}</strong>`
                                             : ''),
                                     trigger: 'hover',
                                     placement:'bottom'

--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -100,13 +100,12 @@ aria-labelledby="pokedexModalLabel">
                                 tooltip: {
                                     html: true,
                                     title: `<u>Information:</u>
-                                        <br/>Base Attack:
-                                        <strong>${$data.attack}</strong>
+                                        <br/>Base Attack: <strong>${$data.attack}</strong>
                                         <br/>Catch Rate: <strong>${PokemonFactory.catchRateHelper($data.catchRate, true)}%</strong>
                                         <br/>Hatch Steps: <strong>${App.game.breeding.getSteps($data.eggCycles).toLocaleString('en-US')}</strong>` +
                                         (App.game.party.getPokemon($data.id)?.pokerus ?
                                             `<br/>EVs: <strong>${App.game.party.getEffortValues(App.game.party.getPokemon($data.id))().toLocaleString('en-US')}</strong>
-                                            <br/>EV bonus: <strong>x${App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data.id)).toLocaleString('en-US')}</strong>`
+                                            <br/>EV bonus: <strong>×${App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data.id)).toLocaleString('en-US')}</strong>`
                                             : ''),
                                     trigger: 'hover',
                                     placement:'bottom'

--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -106,7 +106,7 @@ aria-labelledby="pokedexModalLabel">
                                         <br/>Hatch Steps: <strong>${App.game.breeding.getSteps($data.eggCycles).toLocaleString('en-US')}</strong>` +
                                         (App.game.party.getPokemon($data.id)?.pokerus ?
                                             `<br/>EVs: <strong>${App.game.party.getEffortValues(App.game.party.getPokemon($data.id))()}</strong>
-                                            <br/>EV bonus: <strong>${App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data.id))}</strong>`
+                                            <br/>EV bonus: <strong>x${App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data.id))}</strong>`
                                             : ''),
                                     trigger: 'hover',
                                     placement:'bottom'

--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -90,13 +90,27 @@ aria-labelledby="pokedexModalLabel">
                             <div data-bind="visible: App.game.party.alreadyCaughtPokemonByName(name)" style="position: absolute;right: 2px;top: -15px;">
                                 <img width="18px" src="" data-bind="attr: { src: `assets/images/pokeball/Pokeball${App.game.party.alreadyCaughtPokemon($data.id, true) ? '-shiny' : ''}.svg`}"/>
                             </div>
-                            <div data-bind="visible: App.game.party.alreadyCaughtPokemonByName(name) && App.game.party.getPokemon($data.id).pokerus" style="position: absolute;left: 2px;top: -15px;">
+                            <div data-bind="visible: App.game.party.getPokemon($data.id)?.pokerus" style="position: absolute;left: 2px;top: -15px;">
                                 <img width="30px" src="" data-bind="attr: { src: `assets/images/breeding/Pokerus.png`}"/>
                             </div>
                             <img src="" width="80px" data-bind="css: { 'pokemon-not-seen': !PokedexHelper.pokemonSeen($data.id)() }, attr:{ src: PokedexHelper.getImage($data.id)}">
                             <!-- ko if: PokedexHelper.pokemonSeen($data.id) -->
                             <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: $data.name">name</span>
-                            <a class="overlay" href="#pokemonStatisticsModal" data-toggle="modal" data-bind="click: ()=>{App.game.statistics.selectedPokemonID($data.id)}, tooltip: { html: true, title: `<u>Information:</u><br/>Base Attack: <strong>${$data.attack}</strong><br/>Catch Rate: <strong>${PokemonFactory.catchRateHelper($data.catchRate, true)}%</strong><br/>Hatch Steps: <strong>${App.game.breeding.getSteps($data.eggCycles).toLocaleString('en-US')}</strong>`, trigger: 'hover', placement:'bottom' }"></a>
+                            <a class="overlay" href="#pokemonStatisticsModal" data-toggle="modal" data-bind="click: ()=>{App.game.statistics.selectedPokemonID($data.id)},
+                                tooltip: {
+                                    html: true,
+                                    title: `<u>Information:</u>
+                                        <br/>Base Attack:
+                                        <strong>${$data.attack}</strong>
+                                        <br/>Catch Rate: <strong>${PokemonFactory.catchRateHelper($data.catchRate, true)}%</strong>
+                                        <br/>Hatch Steps: <strong>${App.game.breeding.getSteps($data.eggCycles).toLocaleString('en-US')}</strong>` +
+                                        (App.game.party.getPokemon($data.id)?.pokerus ?
+                                            `<br/>EVs: <strong>${App.game.party.getEffortValues(App.game.party.getPokemon($data.id))()}</strong>
+                                            <br/>EV bonus: <strong>${App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data.id))}</strong>`
+                                            : ''),
+                                    trigger: 'hover',
+                                    placement:'bottom'
+                                }"></a>
                             <!-- /ko -->
                    </li>
                </ul>

--- a/src/components/pokemonStatisticsModal.html
+++ b/src/components/pokemonStatisticsModal.html
@@ -33,6 +33,16 @@
                       <td class="text-left">Proteins Used</td>
                       <td class="text-left tight"><code data-bind="text: (App.game.party.getPokemon($data) ? App.game.party.getPokemon($data).proteinsUsed() : 0).toLocaleString('en-US')">-</code></td>
                     </tr>
+                    <!-- ko if: App.game.party.getPokemon($data)?.pokerus -->
+                      <tr>
+                        <td class="text-left">EVs</td>
+                        <td class="text-left tight"><code data-bind="text: App.game.party.getEffortValues(App.game.party.getPokemon($data))().toLocaleString('en-US')">-</code></td>
+                      </tr>
+                      <tr>
+                        <td class="text-left">EV bonus</td>
+                        <td class="text-left tight"><code data-bind="text: '×' + App.game.party.calculateEVAttackBonus(App.game.party.getPokemon($data)).toLocaleString('en-US')">-</code></td>
+                      </tr>
+                    <!-- /ko -->
                     <tr>
                       <td class="text-left">Type</td>
                       <td class="text-left tight">

--- a/src/components/pokemonStatisticsModal.html
+++ b/src/components/pokemonStatisticsModal.html
@@ -100,7 +100,7 @@
                       <td class="text-left">Shinies Hatched</td>
                       <td class="text-left tight"><code data-bind="text: App.game.statistics.shinyPokemonHatched[$data]().toLocaleString('en-US')">-</code></td>
                     </tr>
-                    <!-- ko if: App.game.party.caughtPokemon.length > 0 && App.game.party.getPokemon($data) && App.game.party.getPokemon($data).pokerus -->
+                    <!-- ko if: App.game.party.getPokemon($data)?.pokerus -->
                     <tr>
                       <td class="text-left">Effort Values</td>
                       <td class="text-left tight"><code data-bind="text: App.game.party.getEffortValues(App.game.party.getPokemon($data))().toLocaleString('en-US')">-</code></td>


### PR DESCRIPTION
Now people can more easily see the pokemons EVs AND they can actually see the bonus it gives!
I am hoping this solution is enough, because we don't want the pokedex to be more cluttered, but let's release this with the hotpatch, and if people don't like it, we can change it in the EVs fixes patch.
![image](https://user-images.githubusercontent.com/2961347/176005392-985acbfe-e1e7-49aa-9e7f-8df1696d4899.png)

I want to also add the bonus in the pokemon statistics window, but the bonus is not an observable, and i don't feel like doing the EVs code rewrite on this side of the hotpatch.