### PR TITLE
Fix protein searchbar on reopen

### DIFF
--- a/src/components/pokemonSelectorModal.html
+++ b/src/components/pokemonSelectorModal.html
@@ -62,8 +62,7 @@
             <div class="form-group col-md-6 col-6 p-0">
                 <label for="protein-search">Search</label>
                 <input id="protein-search" autocomplete="off" class="form-control" placeholder="search here"
-                    oninput="ProteinFilters.search.value(this.value)"
-                    data-bind="value: ProteinFilters.search.value()"
+                    data-bind="textInput: ProteinFilters.search.value"
                 />
             </div>
             <div class="form-group col-md-3 col-3 p-0">

--- a/src/components/pokemonSelectorModal.html
+++ b/src/components/pokemonSelectorModal.html
@@ -61,7 +61,10 @@
           <div class="form-row m-0" id="protein-filter">
             <div class="form-group col-md-6 col-6 p-0">
                 <label for="protein-search">Search</label>
-                <input id="protein-search" autocomplete="off" class="form-control" oninput="ProteinFilters.search.value(new RegExp(`(${this.value})`, 'i'))" placeholder="search here"/>
+                <input id="protein-search" autocomplete="off" class="form-control" placeholder="search here"
+                    oninput="ProteinFilters.search.value(this.value)"
+                    data-bind="value: ProteinFilters.search.value()"
+                />
             </div>
             <div class="form-group col-md-3 col-3 p-0">
                 <label for="protein-region-filter">Region</label>

--- a/src/modules/settings/ProteinFilters.ts
+++ b/src/modules/settings/ProteinFilters.ts
@@ -5,9 +5,9 @@ import SettingOption from './SettingOption';
 import Settings from './Settings';
 
 const ProteinFilters: Record<string, FilterOption> = {
-    search: new FilterOption<RegExp>(
+    search: new FilterOption<string>(
         'Search',
-        ko.observable(new RegExp('', 'i')),
+        ko.observable(''),
     ),
     type: new FilterOption<number>(
         'Type',

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -168,7 +168,7 @@ class PartyPokemon implements Saveable {
 
     public hideFromProteinList = (): boolean => {
         const hidden = ko.pureComputed(() => {
-            if (!ProteinFilters.search.value().test(this.name)) {
+            if (!new RegExp(ProteinFilters.search.value(), 'i').test(this.name)) {
                 return true;
             }
 


### PR DESCRIPTION
- Open the protein window
- Write something in the searchbar
- Close the window
- Open it again
- The searchbar is empty, but the filter still applies
There is an if around the modal, so everything is reset, each time it closes down. In this PR, the value is now reapplied on reopen.