### PR TITLE
Make pokedex 'Hide shiny image' display the underlying observable state

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -68,7 +68,7 @@ aria-labelledby="pokedexModalLabel">
                             <div class="col-12">
                                 <label class="form-check-label">
                                     <input class="form-check-input" type="checkbox" id="pokedex-filter-held-item"
-                                        value="false" onclick="PokedexHelper.toggleAllShiny(!PokedexHelper.toggleAllShiny())"> Hide shiny image
+                                        data-bind="checked: PokedexHelper.hideShinyImages"> Hide shiny image
                                 </label>
                             </div>
                         </div>

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -2,7 +2,7 @@ import TypeColor = GameConstants.TypeColor;
 
 class PokedexHelper {
     public static toggleStatisticShiny = ko.observable(true);
-    public static toggleAllShiny = ko.observable(true);
+    public static hideShinyImages = ko.observable(false);
 
     public static getBackgroundColors(name: PokemonNameType): string {
         const pokemon = PokemonHelper.getPokemonByName(name);
@@ -157,7 +157,7 @@ class PokedexHelper {
 
     public static getImage(id: number) {
         let src = 'assets/images/';
-        if (App.game.party.alreadyCaughtPokemon(id, true) && this.toggleAllShiny()) {
+        if (App.game.party.alreadyCaughtPokemon(id, true) && !this.hideShinyImages()) {
             src += 'shiny';
         }
         src += `pokemon/${id}.png`;


### PR DESCRIPTION
Ties the checkbox to the state of the observable, instead of updating the observable on change.
Should prevent any weirdness with it getting out of sync and doing the opposite of what it claims (there have been a few reports in discord)