### PR TITLE
No longer giving out infinit free fighting eggs

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -461,15 +461,13 @@ dungeonList['Mt. Moon'] = new Dungeon('Mt. Moon',
     ],
     75, 4,
     () => {
-        if (App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Mt. Moon')]() <= 1) {
-            const item = Rand.boolean() ? 'Dome Fossil' : 'Helix Fossil';
-            Underground.gainMineItem(Underground.getMineItemByName(item).id, 1);
-            Notifier.notify({
-                message: `You were awarded a ${GameConstants.humanifyString(item)} for defeating the Super Nerd`,
-                type: NotificationConstants.NotificationOption.success,
-                setting: NotificationConstants.NotificationSetting.Items.dungeon_item_found,
-            });
-        }
+        const item = Rand.boolean() ? 'Dome Fossil' : 'Helix Fossil';
+        Underground.gainMineItem(Underground.getMineItemByName(item).id, 1);
+        Notifier.notify({
+            message: `You were awarded a ${GameConstants.humanifyString(item)} for defeating the Super Nerd`,
+            type: NotificationConstants.NotificationOption.success,
+            setting: NotificationConstants.NotificationSetting.Items.dungeon_item_found,
+        });
     });
 
 dungeonList['Diglett\'s Cave'] = new Dungeon('Diglett\'s Cave',

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -222,10 +222,11 @@ class DungeonRunner {
     public static dungeonWon() {
         if (!DungeonRunner.dungeonFinished()) {
             DungeonRunner.dungeonFinished(true);
+            if (!App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]()) {
+                DungeonRunner.dungeon.rewardFunction();
+            }
             GameHelper.incrementObservable(App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]);
             MapHelper.moveToTown(DungeonRunner.dungeon.name);
-            DungeonRunner.dungeon.rewardFunction();
-            // TODO award loot with a special screen
             Notifier.notify({
                 message: 'You have successfully completed the dungeon',
                 type: NotificationConstants.NotificationOption.success,


### PR DESCRIPTION
Dungeon clear rewards was given on each clear, which does not work well, when we are trying to give a fighting egg on the first clear.
The mt. moon dungeon had it's own check in the reward function, but i think it's cleaner, if we just have the check for all rewards. Right now, it's fighting eggs, fossils and gym badges, all which should only be given on first clear.

The argument against this solution, is that we might want to give an reward for grinding a dungeon, in the future. But i think that we always want dungeon loot for that. So if the clear reward can give more than one reward, code contributors might think that we think it's a good idea.
And if we find a good use for it, it's a 2 liner change.