### PR TITLE
eslint rule no-sparse-arrays

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,5 +48,6 @@ module.exports = {
         'quotes': ['error', 'single'],
         'prefer-arrow-callback': 'error',
         'no-alert': 'error',
+        'no-sparse-arrays': 'error',
     },
 };

--- a/src/modules/.eslintrc.js
+++ b/src/modules/.eslintrc.js
@@ -52,5 +52,6 @@ module.exports = {
         '@typescript-eslint/lines-between-class-members': ['error', { exceptAfterSingleLine: true }],
         '@typescript-eslint/member-ordering': ['error'],
         'no-alert': 'error',
+        'no-sparse-arrays': 'error',
     },
 };


### PR DESCRIPTION
This should stop us adding extra `,` within arrays by accident.

For example shops, even though we have the typing of `Item` it still allows empty items in the array, which broke the shops in `0.9.6`.