### PR TITLE
Fix pokerus display for uncaught pokemon eggs

### DIFF
--- a/src/components/breedingDisplay.html
+++ b/src/components/breedingDisplay.html
@@ -39,8 +39,8 @@
                 <!-- /ko -->
                 <!-- ko ifnot: $data.type == EggType.Fossil -->
                 <div data-bind="template: { name: 'eggSVGTemplate', data: $data}, class: BreedingController.getEggCssClass($data)"></div>
-                <div data-bind="visible: App.game.party.getPokemon(PokemonHelper.getPokemonByName($data.pokemon).id)?.pokerus > GameConstants.Pokerus.None" style="position: absolute;right: 2px;top: -3px;">
-                    <img width="14px" src="" data-bind="attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[App.game.party.getPokemon(PokemonHelper.getPokemonByName($data.pokemon).id).pokerus]}.png`}"/>
+                <div data-bind="if: $data.partyPokemon?.pokerus > GameConstants.Pokerus.None" style="position: absolute;right: 2px;top: -3px;">
+                    <img width="14px" src="" data-bind="attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[$data.partyPokemon?.pokerus]}.png`}"/>
                 </div>
                 <!-- /ko -->
 


### PR DESCRIPTION
`visible` binding on these shop/fossil egg pokerus image doesn't prevent knockout from evaluating the html/code, resulting in console errors when we try to access properties on undefined.
Changed to `if` binding, and replaced some `party.getPokemon` with just accessing the partyPokemon from the egg since it should already be there.