### PR TITLE
Player icon on map ignore mouse

### DIFF
--- a/src/styles/map.less
+++ b/src/styles/map.less
@@ -58,7 +58,8 @@
 
   .iconLocation {
     transform-box: fill-box;
-    transform-origin:center;
+    transform-origin: center;
+    pointer-events: none;
   }
 
 }


### PR DESCRIPTION
This PR makes it so that the player icon ignores mouse events.
This way when you hover the player icon it will still show the towns name etc.
![image](https://user-images.githubusercontent.com/7288322/177028789-9bb4a466-d4ca-49a2-a774-280ce806ca49.png)
