### PR TITLE
Battle Frontier timer adjust

### DIFF
--- a/src/components/battleFrontierView.html
+++ b/src/components/battleFrontierView.html
@@ -17,7 +17,7 @@
             <div class="progress timer">
                 <div class="progress-bar bg-danger" role="progressbar"
                         data-bind="attr:{ style: 'width:' + BattleFrontierRunner.timeLeftPercentage() + '%' },
-                        css: { 'bg-danger': BattleFrontierRunner.timeLeftSeconds() < 20, 'bg-primary': BattleFrontierRunner.timeLeftSeconds() >= 20 }"
+                        css: { 'bg-danger': BattleFrontierRunner.timeLeftSeconds() < 10, 'bg-primary': BattleFrontierRunner.timeLeftSeconds() >= 10 }"
                         aria-valuemin="0" aria-valuemax="100">
                         <span data-bind="text: BattleFrontierRunner.timeLeftSeconds() + 's'" style="font-size: 12px;"></span>
                 </div>


### PR DESCRIPTION
Changed the timer bar in Battle Frontier to turn red ("danger") when there is 10 seconds left (1/3rd of the time left) instead of 20 seconds left (2/3rd of the time left).
This is more intuitive and consistent with the proportions on dungeon timers.