### PR TITLE
Fix current location icon for megadungeons in Alola, Sinnoh and Sevii Island

### DIFF
--- a/src/components/AlolaSVG.html
+++ b/src/components/AlolaSVG.html
@@ -1375,6 +1375,33 @@
             })
         %>
 
+        <!--Verdant Cavern-->
+        <%- include('templates/mapDungeon',
+            { name: "Verdant Cavern"
+            , x: 28, y: 13
+            , width: 14, height: 3
+            , invisible: true
+            })
+        %>
+
+        <!--Melemele Meadow-->
+        <%- include('templates/mapDungeon',
+            { name: "Melemele Meadow"
+            , x: 28, y: 13
+            , width: 14, height: 3
+            , invisible: true
+            })
+        %>
+
+        <!--Ruins of Conflict-->
+        <%- include('templates/mapDungeon',
+            { name: "Ruins of Conflict"
+            , x: 28, y: 13
+            , width: 14, height: 3
+            , invisible: true
+            })
+        %>
+
         <!--Seaward Cave-->
         <%- include('templates/mapDungeon',
             { name: "Seaward Cave"
@@ -3017,6 +3044,25 @@
             { name: "Vast Poni Canyon"
             , x: 29, y: 31
             , width: 4, height: 4
+            })
+        %>
+
+
+        <!--Mina's Houseboat-->
+        <%- include('templates/mapDungeon',
+            { name: "Mina's Houseboat"
+            , x: 15, y: 41.5
+            , width: 5, height: 4.5
+            ,invisible: true
+            })
+        %>
+
+        <!--Exeggutor Island Hill-->
+        <%- include('templates/mapDungeon',
+            { name: "Exeggutor Island Hill"
+            , x: 5, y: 43
+            , width: 4, height: 4
+            ,invisible: true
             })
         %>
 

--- a/src/components/KantoSVG.html
+++ b/src/components/KantoSVG.html
@@ -312,7 +312,7 @@
             , width: 1, height: 3
             , isExtension: true
             })
-        %>	  
+        %>
 
         <!--Pewter City-->
         <%- include('templates/mapTown',
@@ -328,7 +328,7 @@
             , width: 7, height: 3
             , isExtension: true
             })
-        %>	 
+        %>
 
         <!--Cerulean City-->
         <%- include('templates/mapTown',
@@ -350,7 +350,7 @@
         <%- include('templates/mapTown',
             { name: "Lavender Town"
             , x: 85, y: 19
-            , width: 4, height: 5		 
+            , width: 4, height: 5
             })
         %>
 
@@ -424,7 +424,7 @@
             , width: 8, height: 1
             , isExtension: true
             })
-        %>	 
+        %>
         <!--Cinnabar Island extension-->
         <%- include('templates/mapTown',
             { name: "Cinnabar Island"
@@ -432,8 +432,8 @@
             , width: 7, height: 3
             , isExtension: true
             })
-        %>	 	 
-	 
+        %>
+
         <!--Indigo Plateau Kanto-->
         <%- include('templates/mapTown',
             { name: "Indigo Plateau Kanto"
@@ -736,7 +736,7 @@
         <!--Mt. Ember-->
         <%- include('templates/mapTown',
             { name: "Mt. Ember"
-            , x: 9, y: 1		
+            , x: 9, y: 1
             , width: 7, height: 6
             })
         %>
@@ -761,17 +761,26 @@
         <!-- DUNGEONS -->
         <!-- -------- -->
 
+        <!--Mt. Ember Summit-->
+        <%- include('templates/mapDungeon',
+            { name: "Mt. Ember Summit"
+            , x: 9, y: 1
+            , width: 7, height: 6
+            ,invisible: true
+            })
+        %>
+
         <!--Berry Forest-->
         <%- include('templates/mapDungeon',
             { name: "Berry Forest"
-            , x: 65, y: 39		
+            , x: 65, y: 39
             , width: 8, height: 5
             })
         %>
         <!--Berry Forest extension-->
         <%- include('templates/mapDungeon',
             { name: "Berry Forest"
-            , x: 64, y: 39		
+            , x: 64, y: 39
             , width: 1, height: 3
             , isExtension: true
             })
@@ -779,7 +788,7 @@
         <!--Berry Forest extension-->
         <%- include('templates/mapDungeon',
             { name: "Berry Forest"
-            , x: 65, y: 38		
+            , x: 65, y: 38
             , width: 7, height: 1
             , isExtension: true
             })

--- a/src/components/SinnohSVG.html
+++ b/src/components/SinnohSVG.html
@@ -468,6 +468,16 @@
         })
     %>
 
+    <!--Team Galactic Eterna Building-->
+    <%- include('templates/mapDungeon',
+        { name: "Team Galactic Eterna Building"
+        , x: 31, y: 26
+        , height: 4, width: 4
+        , invisible: true
+        })
+    %>
+
+
     <!--Mt. Coronet-->
     <%- include('templates/mapDungeon',
         { name: "Mt. Coronet"

--- a/src/components/SinnohSVG.html
+++ b/src/components/SinnohSVG.html
@@ -796,6 +796,15 @@
         })
     %>
 
+    <!--Team Galactic HQ-->
+    <%- include('templates/mapDungeon',
+        { name: "Team Galactic HQ"
+        , x: 64, y: 29
+        , height: 4, width: 9
+        ,invisible: true
+        })
+    %>
+
     <!--Fullmoon Island-->
     <%- include('templates/mapDungeon',
         { name: "Fullmoon Island"


### PR DESCRIPTION
I fix the player icon for location in town map for some megadungeons or invisible dungeons that I had forgotten in my first PR.
There was : 

- Eterna Building in Sinnoh
- Melemele Wood, Exeguttor Island and Mina's Houseboat in Alola
- Mt Ember in the new Sevii Island.

I hope I haven't forgotten anything this time.