### PR TITLE
Pokémon seen but not caught being more noticeable in the Pokédex

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -95,7 +95,7 @@ aria-labelledby="pokedexModalLabel">
                                 <img width="18px" src="" data-bind="attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[App.game.party.getPokemon($data.id)?.pokerus]}.png`}"/>
                             </div>
                             <!-- /ko -->
-                            <img src="" width="80px" data-bind="css: { 'pokemon-not-seen': !PokedexHelper.pokemonSeen($data.id)() }, attr:{ src: PokedexHelper.getImage($data.id)}">
+                            <img src="" width="80px" data-bind="css: { 'pokemon-not-seen': !PokedexHelper.pokemonSeen($data.id)(), 'pokemon-seen-but-not-caught': !App.game.party.alreadyCaughtPokemonByName(name) && PokedexHelper.pokemonSeen($data.id)() }, attr:{ src: PokedexHelper.getImage($data.id)}">
                             <!-- ko if: PokedexHelper.pokemonSeen($data.id) -->
                             <span style="bottom: 0; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px" data-bind="text: $data.name">name</span>
                             <a class="overlay" href="#pokemonStatisticsModal" data-toggle="modal" data-bind="click: () => {App.game.statistics.selectedPokemonID($data.id)},

--- a/src/styles/pokedex.less
+++ b/src/styles/pokedex.less
@@ -43,3 +43,9 @@
   filter: brightness(0%);
   opacity: 0.6;
 }
+
+.pokemon-seen-but-not-caught {
+  -webkit-filter: brightness(0.5) grayscale(1) ; /* Safari 6.0 - 9.0 */
+  filter: brightness(0.5) grayscale(1);
+  opacity: 0.6;
+}


### PR DESCRIPTION
One of RedSparr0w requests, this will make Pokémon seen but not caught more noticeable (currently, they show full color for them).

Here's an example:
![seen-not-caught](https://user-images.githubusercontent.com/104547700/178657833-0c7c8c5c-d2fb-4cc8-b750-20ba2a704adc.PNG)

Never did a PR so tell me if something went wrong.