### PR TITLE
Browser sync - Disable sync'd clicks, scroll etc

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -119,6 +119,7 @@ gulp.task('browserSync', () => {
         server: {
             baseDir: dests.base,
         },
+        ghostMode: false,
     });
     gulp.watch(srcs.html, gulp.series('compile-html'));
     gulp.watch(srcs.ejsTemplates, gulp.series('compile-html'));


### PR DESCRIPTION
This disables Browser Sync having clicks and scrolling sync'd between tabs/devices enabled by default.