### PR TITLE
Add index number to Pokémon list in the profile modal

### DIFF
--- a/src/components/profileModal.html
+++ b/src/components/profileModal.html
@@ -16,8 +16,8 @@
                     <div class="form-group col-12">
                         <label>Pokemon</label>
                         <select autocomplete="off" class="custom-select" onchange="App.game.profile.pokemon(+this.value)">
-                            <!-- ko foreach: App.game.party.caughtPokemon -->
-                            <option data-bind="attr: { value: $data.id, selected: App.game.profile.pokemon() === $data.id }, text: $data.name">Pokemon</option>
+                            <!-- ko foreach: App.game.party.caughtPokemon.sort((a, b) => a.id - b.id) -->
+                            <option data-bind="attr: { value: $data.id, selected: App.game.profile.pokemon() === $data.id }, text: '#'+($data.id > 0 ? Math.floor($data.id) + '' : '???').padStart(3, 0)+' '+$data.name">Pokemon</option>
                             <!-- /ko -->
                         </select>
                     </div>


### PR DESCRIPTION
This PR will add the Pokémon index number to the list in the profile modal as well as sort it by said property:
![profile-index-number](https://user-images.githubusercontent.com/104547700/179323206-3b3a5c02-c332-4385-be60-a85e48be18f8.PNG)
