### PR TITLE
Use all battle items

### DIFF
--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -71,9 +71,9 @@
     <div data-bind="visible: App.game.badgeCase.hasBadge(BadgeEnums.Heat)">
         <button type="button" class="btn btn-sm btn-primary"
                 style="position: absolute; left: 0px; width: auto; height: 41px"
-                onclick="ItemHandler.activateAllFlutes()"
-                oncontextmenu="ItemHandler.deactivateAllFlutes(); return false"
-                title="Enable all Flutes"
+                onclick="ItemHandler.useAllFlutes(true)"
+                oncontextmenu="ItemHandler.useAllFlutes(false); return false"
+                title="Activate/Deactivate all Flutes"
                 data-toggle="popover"
                 data-html="true"
                 data-content="Left/right click to deactivate/activate all Flutes at once"

--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -71,23 +71,14 @@
     <div data-bind="visible: App.game.badgeCase.hasBadge(BadgeEnums.Heat)">
         <button type="button" class="btn btn-sm btn-primary"
                 style="position: absolute; left: 0px; width: auto; height: 41px"
-                onclick="ItemHandler.useAllFlutes('enable')"
+                onclick="ItemHandler.activateAllFlutes()"
+                oncontextmenu="ItemHandler.desactivateAllFlutes(); return false"
                 title="Enable all Flutes"
                 data-toggle="popover"
                 data-html="true"
-                data-content="Click to enable all Flutes at once"
+                data-content="Left/right click to desactivate/activate all Flutes at once"
                 data-placement="left"
-                data-trigger="hover">Enable all
-        </button>
-        <button type="button" class="btn btn-sm btn-danger"
-                style="position: absolute; right: 0px; width: auto; height: 41px;"
-                onclick="ItemHandler.useAllFlutes('disable')"
-                title="Disable all Flutes"
-                data-toggle="popover"
-                data-html="true"
-                data-content="Click to disable all Flutes at once"
-                data-placement="right"
-                data-trigger="hover">Disable all
+                data-trigger="hover">Activate all
         </button>
         <div class="card-header p-0" data-toggle="collapse" href="#fluteItemContainerBody">
             <span>Flutes</span>

--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -72,11 +72,11 @@
         <button type="button" class="btn btn-sm btn-primary"
                 style="position: absolute; left: 0px; width: auto; height: 41px"
                 onclick="ItemHandler.activateAllFlutes()"
-                oncontextmenu="ItemHandler.desactivateAllFlutes(); return false"
+                oncontextmenu="ItemHandler.deactivateAllFlutes(); return false"
                 title="Enable all Flutes"
                 data-toggle="popover"
                 data-html="true"
-                data-content="Left/right click to desactivate/activate all Flutes at once"
+                data-content="Left/right click to deactivate/activate all Flutes at once"
                 data-placement="left"
                 data-trigger="hover">Activate all
         </button>

--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -1,4 +1,14 @@
 <div id="battleItemContainer" class="card sortable border-secondary mb-3" data-bind="visible: !(Settings.getSetting('hideChallengeRelatedModules').observableValue() && App.game.challenges.list.disableBattleItems.active())">
+    <button type="button" class="btn btn-sm btn-primary"
+            style="position: absolute; left: 0px; top: 0px; width: auto; height: 41px;"
+            onclick="ItemHandler.useAllBattleItems()"
+            title="Using all Battle Items"
+            data-toggle="popover"
+            data-html="true"
+            data-content="Click to use all items at the same time"
+            data-placement="left"
+            data-trigger="hover">Use all
+    </button>
     <div class="card-header p-0" data-toggle="collapse" href="#battleItemContainerBody">
       <span>Battle Items</span>
     </div>
@@ -58,8 +68,30 @@
         </tbody>
       </table>
     </div>
-    <div class="card-header p-0" data-toggle="collapse" href="#fluteItemContainerBody" data-bind="visible: App.game.badgeCase.hasBadge(BadgeEnums.Heat)">
-      <span>Flutes</span>
+    <div data-bind="visible: App.game.badgeCase.hasBadge(BadgeEnums.Heat)">
+        <button type="button" class="btn btn-sm btn-primary"
+                style="position: absolute; left: 0px; width: auto; height: 41px"
+                onclick="ItemHandler.useAllFlutes('enable')"
+                title="Enable all Flutes"
+                data-toggle="popover"
+                data-html="true"
+                data-content="Click to enable all Flutes at once"
+                data-placement="left"
+                data-trigger="hover">Enable all
+        </button>
+        <button type="button" class="btn btn-sm bg-danger"
+                style="position: absolute; right: 0px; width: auto; height: 41px;"
+                onclick="ItemHandler.useAllFlutes('disable')"
+                title="Disable all Flutes"
+                data-toggle="popover"
+                data-html="true"
+                data-content="Click to disable all Flutes at once"
+                data-placement="right"
+                data-trigger="hover">Disable all
+        </button>
+        <div class="card-header p-0" data-toggle="collapse" href="#fluteItemContainerBody">
+            <span>Flutes</span>
+        </div>
     </div>
     <div id="fluteItemContainerBody" class="card-body p-0 show">
       <p data-bind="visible: (App.game.challenges.list.disableBattleItems.active() || App.game.challenges.list.disableGems.active()) && App.game.badgeCase.hasBadge(BadgeEnums.Heat)" class="bg-danger my-0">

--- a/src/components/battleItemContainer.html
+++ b/src/components/battleItemContainer.html
@@ -79,7 +79,7 @@
                 data-placement="left"
                 data-trigger="hover">Enable all
         </button>
-        <button type="button" class="btn btn-sm bg-danger"
+        <button type="button" class="btn btn-sm btn-danger"
                 style="position: absolute; right: 0px; width: auto; height: 41px;"
                 onclick="ItemHandler.useAllFlutes('disable')"
                 title="Disable all Flutes"

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -31,12 +31,20 @@ class ItemHandler {
         });
     }
 
-    public static useAllFlutes(action: string) {
+    public static activateAllFlutes() {
         GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'FluteItem')).forEach((item,index) => {
             item.forEach((x) => {
-                if (this.hasItem(x) && action == 'enable' && !FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
+                if (this.hasItem(x) && !FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
                     ItemHandler.useItem(x);
-                } else if (action == 'disable' && FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
+                }
+            });
+        });
+    }
+
+    public static desactivateAllFlutes() {
+        GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'FluteItem')).forEach((item,index) => {
+            item.forEach((x) => {
+                if (FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
                     ItemHandler.useItem(x);
                 }
             });

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -31,21 +31,13 @@ class ItemHandler {
         });
     }
 
-    public static activateAllFlutes() {
-        GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'FluteItem')).forEach((item,index) => {
-            item.forEach((x) => {
-                if (this.hasItem(x) && !FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
-                    ItemHandler.useItem(x);
-                }
-            });
-        });
-    }
-
-    public static deactivateAllFlutes() {
-        GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'FluteItem')).forEach((item,index) => {
-            item.forEach((x) => {
-                if (FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
-                    ItemHandler.useItem(x);
+    public static useAllFlutes(enable: boolean) {
+        GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'FluteItem')).forEach((items,index) => {
+            items.forEach((item) => {
+                if (enable && this.hasItem(item) && !FluteEffectRunner.isActive(GameConstants.FluteItemType[item])()) {
+                    ItemHandler.useItem(item);
+                } else if (!enable && FluteEffectRunner.isActive(GameConstants.FluteItemType[item])()) {
+                    ItemHandler.useItem(item);
                 }
             });
         });

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -23,6 +23,26 @@ class ItemHandler {
         return result == undefined ? true : result;
     }
 
+    public static useAllBattleItems() {
+        GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'BattleItem')).forEach((item,index) => {
+            item.forEach((x) => {
+                ItemHandler.useItem(x, EffectEngineRunner.amountToUse());
+            });
+        });
+    }
+
+    public static useAllFlutes(action: string) {
+        GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'FluteItem')).forEach((item,index) => {
+            item.forEach((x) => {
+                if (this.hasItem(x) && action == 'enable' && !FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
+                    ItemHandler.useItem(x);
+                } else if (action == 'disable' && FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {
+                    ItemHandler.useItem(x);
+                }
+            });
+        });
+    }
+
     public static hasItem(name: string): boolean {
         return player.itemList[name] ? !!player.itemList[name]() : false;
     }

--- a/src/scripts/items/ItemHandler.ts
+++ b/src/scripts/items/ItemHandler.ts
@@ -41,7 +41,7 @@ class ItemHandler {
         });
     }
 
-    public static desactivateAllFlutes() {
+    public static deactivateAllFlutes() {
         GameHelper.chunk(6, Object.keys(ItemList).filter(i => ItemList[i].constructor.name == 'FluteItem')).forEach((item,index) => {
             item.forEach((x) => {
                 if (FluteEffectRunner.isActive(GameConstants.FluteItemType[x])()) {


### PR DESCRIPTION
I added new buttons to use battle items and flutes with one click (closes #2581)
The "BI" button just uses all items according to the multiplier, even if some of them are empty.
The "Flute" button activates all non-activated flutes with a right click, and deactivates all activated flutes with a left click. 
I wasn't sure which file to use for the functions, so I will move them if needed.

![image](https://user-images.githubusercontent.com/7288322/179439584-51c60d64-ad9e-4028-b7a3-a138edd797de.png)
