### PR TITLE
Pimp my biker gang

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -197,8 +197,15 @@ class QuestLineHelper {
         const talktoGameCornerOwner1 = new TalkToNPCQuest(TwoIslandGameCornerOwner1, 'Ask the Game Corner owner on Two Island about the meteorite.');
         billSeviiQuestLine.addQuest(talktoGameCornerOwner1);
 
-        const clearBikerGangTemporaryBattle = new CustomQuest(1, 0, 'A biker gang has invaded Three island. They will not let you continue to Berry Forest. You\'ll have to take out all the Biker Goons before you can get to their leader.', () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Cue Ball Paxton')]());
-        billSeviiQuestLine.addQuest(clearBikerGangTemporaryBattle);
+        const clearBikerGangTemporaryBattles = new CustomQuest(3, 0, 'A biker gang has invaded Three island. They will not let you continue to Berry Forest. Defeat the Biker Goons.', () =>
+            App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Biker Goon 1')]() +
+            App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Biker Goon 2')]() +
+            App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Biker Goon 3')]()
+        );
+        billSeviiQuestLine.addQuest(clearBikerGangTemporaryBattles);
+
+        const clearCueBallPaxtonTemporaryBattle = new CustomQuest(1, 0, 'Defeat the biker gang\'s leader.', () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Cue Ball Paxton')]());
+        billSeviiQuestLine.addQuest(clearCueBallPaxtonTemporaryBattle);
 
         const clearBerryForest = new CustomQuest(1, 0, 'Find Lostelle. Clear Berry Forest.', () => App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Berry Forest')]());
         billSeviiQuestLine.addQuest(clearBerryForest);

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -33,19 +33,31 @@ TemporaryBattleList['Biker Goon 1'] = new TemporaryBattle(
         new GymPokemon('Grimer', 198477, 37),
     ],
     'Wha... What is this kid?!',
-    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 1)]
+    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 1)],
+    undefined,
+    {
+        displayName: 'Biker Goon',
+    }
 );
 TemporaryBattleList['Biker Goon 2'] = new TemporaryBattle(
     'Biker Goon 2',
     [new GymPokemon('Koffing', 396954, 38)],
     'Stop fooling around!',
-    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 1)]
+    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 1)],
+    undefined,
+    {
+        displayName: 'Biker Goon',
+    }
 );
 TemporaryBattleList['Biker Goon 3'] = new TemporaryBattle(
     'Biker Goon 3',
     [new GymPokemon('Grimer', 396954, 38)],
     '... ... ... ... ... ...',
-    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 1)]
+    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 1)],
+    undefined,
+    {
+        displayName: 'Biker Goon',
+    }
 );
 TemporaryBattleList['Cue Ball Paxton'] = new TemporaryBattle(
     'Cue Ball Paxton',

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -269,7 +269,7 @@ const OneIslandCelio2 = new NPC ('Celio', [
     'I\'m glad to hear Lostelle is all right. You can hand the meteorite to me. Bill, thank you for your assistance, I\'ll take it from here. I can see that your friend is eager to get back to Kanto and challenge the Pokémon League.',
     'Thank you both very much.',
 ],
-{ requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Bill\'s Errand', 4), new QuestLineCompletedRequirement('Bill\'s Errand', GameConstants.AchievementOption.less )]) });
+{ requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Bill\'s Errand', 5), new QuestLineCompletedRequirement('Bill\'s Errand', GameConstants.AchievementOption.less )]) });
 const OneIslandCelio3 = new NPC ('Celio', [
     'You\'ve been a great help. Thanks again. Maybe we\'ll meet again some day...',
 ],
@@ -283,18 +283,18 @@ const TwoIslandGameCornerOwner1 = new NPC ('Game Corner Owner', [
     'What? The meteorite for Celio? Yes, I can give that to you. But I need you to do something for me first.',
     'My daughter Lostelle is missing. She likes to pick berries in the Berry Forest on Three Island. She does it all the time. But this time she hasn\'t come back. Please go find her.',
 ],
-{ requirement: new QuestLineStepCompletedRequirement('Bill\'s Errand', 3, GameConstants.AchievementOption.less ) });
+{ requirement: new QuestLineStepCompletedRequirement('Bill\'s Errand', 4, GameConstants.AchievementOption.less ) });
 const TwoIslandGameCornerOwner2 = new NPC ('Game Corner Owner', [
     'My sweet Lostelle! I\'m so glad you\'re all right.',
     'Thank you very much kind stranger. Please take the Meteorite.',
 ],
-{ requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Bill\'s Errand', 3), new QuestLineCompletedRequirement('Bill\'s Errand', GameConstants.AchievementOption.less)]) });
+{ requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Bill\'s Errand', 4), new QuestLineCompletedRequirement('Bill\'s Errand', GameConstants.AchievementOption.less)]) });
 const ThreeIslandBiker = new NPC ('Biker', [
     'You know what sucks? The other islands are off limits for some arbitrary reason. There is no explanation. Just can\'t go there.',
     'Alright, you want the real truth? Some weird old dude told me this: "The other islands don\'t exist. Yet. Gotta wait for the devs to put them in."',
     'I don\'t know what half those words mean. All I know is I can\'t go back to Kanto with the rest of the gang. This sucks.',
 ],
-{ requirement: new QuestLineStepCompletedRequirement('Bill\'s Errand', 2) });
+{ requirement: new QuestLineStepCompletedRequirement('Bill\'s Errand', 3) });
 
 //Kanto Towns
 TownList['Pallet Town'] = new Town(

--- a/src/scripts/wildBattle/RouteData.ts
+++ b/src/scripts/wildBattle/RouteData.ts
@@ -332,7 +332,7 @@ Routes.add(new RegionRoute(
         land: ['Pidgey', 'Pidgeotto', 'Oddish', 'Gloom', 'Venonat', 'Meowth', 'Persian', 'Psyduck', 'Bellsprout', 'Weepinbell', 'Slowpoke'],
         water: ['Tentacool', 'Tentacruel', 'Krabby', 'Horsea', 'Magikarp'],
     }),
-    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 2)],
+    [new QuestLineStepCompletedRequirement('Bill\'s Errand', 3)],
     21.4,
     GameConstants.KantoSubRegions.Sevii123,
     true,


### PR DESCRIPTION
Added an extra quest for the Sevii questline to defeat the 3 biker goons, rather than just having the quest for the biker gang leader say you need to beat the goons to get to the leader.
Updated questlinestepcompletedrequirements to account for this extra quest.
Changed Biker Goon display names to Biker Goon, instead of Biker Goon 1, Biker Goon 2, Biker Goon 3.