### PR TITLE
Force thousand separator in Pokemon List

### DIFF
--- a/src/components/pokemonListContainer.html
+++ b/src/components/pokemonListContainer.html
@@ -70,7 +70,7 @@
                                 <span data-bind="text: name">Name</span>
                                 <sup data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)">✨</sup>
                             </div>
-                            <div class="pokemonAttack" data-bind="text: attack.toLocaleString()"></div>
+                            <div class="pokemonAttack" data-bind="text: attack.toLocaleString('en-US')"></div>
                             <div class="pokemonLevel" data-bind="text: level"></div>
                         </div>
                     </td>


### PR DESCRIPTION
Just forces 'en-US' in PokemonList attack numbers string for consistency with other numbers.