### PR TITLE
Update locked pokemon dungeon text

### DIFF
--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -85,7 +85,7 @@
             <img class="lock" src="assets/images/breeding/lock.svg" data-bind="
             hidden: !$data.lock,
             tooltip: {
-                title: 'Try talking to the locals. Sometimes they know more than you think.',
+                title: 'Try progressing in the story, catching new Pokémon, or talking to the locals!',
                 html: true,
                 placement: 'bottom',
                 trigger: 'hover'
@@ -101,7 +101,7 @@
             <sup class="shiny" data-bind="visible: $data.shiny">✨</sup>
             <img class="lock" src="assets/images/breeding/lock.svg" data-bind="hidden: !$data.lock,
             tooltip: {
-                title: 'Try talking to the locals. Sometimes they know more than you think.',
+                title: 'Try progressing in the story, catching new Pokémon, or talking to the locals!',
                 html: true,
                 placement: 'bottom',
                 trigger: 'hover'


### PR DESCRIPTION
Adjusts the text when you don't have access to a pokemon in a dungeon to suggest more than just talking to NPCs, as the way to unlock them in most cases is dungeon completion, story progression, or catching certain mons