### PR TITLE
Fix Pokémon having Pokérus early and gaining EP early

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "PokéClicker repository",
   "main": "index.js",
   "scripts": {

--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -158,7 +158,7 @@ class Battle {
         App.game.party.gainPokemonById(enemyPokemon.id, enemyPokemon.shiny);
         const partyPokemon = App.game.party.getPokemon(enemyPokemon.id);
         const epBonus = App.game.pokeballs.getEPBonus(this.pokeball());
-        partyPokemon.effortPoints += App.game.party.gainEffortPoints(partyPokemon, enemyPokemon.shiny, enemyPokemon.ep * epBonus);
+        partyPokemon.effortPoints += App.game.party.calculateEffortPoints(partyPokemon, enemyPokemon.shiny, enemyPokemon.ep * epBonus);
     }
 
     static gainItem() {

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -807,7 +807,7 @@ class Update implements Saveable {
             saveData.party.caughtPokemon.forEach(p => {
                 // If has pokerus, set to "contagious"
                 let status = (p[8]) ? 2 : 0;
-                // Get effort points (0 if not infected)
+                // Get effort points (0 if not infected), Multiply by 100 for finer control
                 const effortPoints = status ? saveData.statistics.effortPoints?.[p.id] * 100 || 0 : 0;
                 // Set to cured if reached required amount of EVs
                 const requiredForCured = saveData.challenges.list.slowEVs ? 500000 : 50000;

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -803,19 +803,20 @@ class Update implements Saveable {
             // Add names to oak item loadouts
             saveData.oakItemLoadouts = saveData.oakItemLoadouts?.map((list, index) => ({ name: `Loadout ${index + 1}`, loadout: list })) || [];
 
-            // Fix pokerus
+            // Fix pokerus & EVs moved from statistics
             saveData.party.caughtPokemon.forEach(p => {
+                // If has pokerus, set to "contagious"
                 let status = (p[8]) ? 2 : 0;
-                const requiredForCured = saveData.challenges.list.slowEVs ? 5000 : 500;
-                if (saveData.statistics.effortPoints?.[p.id] >= requiredForCured) {
+                // Get effort points (0 if not infected)
+                const effortPoints = status ? saveData.statistics.effortPoints?.[p.id] * 100 || 0 : 0;
+                // Set to cured if reached required amount of EVs
+                const requiredForCured = saveData.challenges.list.slowEVs ? 500000 : 50000;
+                if (effortPoints >= requiredForCured) {
                     status = 3;
                 }
+                // Update status and EVs
                 p[8] = status;
-            });
-
-            // Moved EVs from statistics
-            saveData.party.caughtPokemon.forEach(p => {
-                p[9] = saveData.statistics.effortPoints?.[p.id] * 100 || 0;
+                p[9] = effortPoints;
             });
 
             // Give the players Linking Cords in place of Trade Stones

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -887,6 +887,27 @@ class Update implements Saveable {
                 delete settingsData['notification.dungeon_item_found.desktop'];
             }
         },
+
+        '0.9.9': ({ playerData, saveData }) => {
+            // Fix pokemon having Pokérus early (key item not unlocked)
+            if (!saveData.keyItems.Pokerus_virus) {
+                saveData.party.caughtPokemon.forEach(p => {
+                    // Pokérus State
+                    p[8] = 0;
+                    // Effort Points
+                    p[9] = 0;
+                });
+            }
+
+            // If Pokémon doesn't have Pokérus yet, it shouldn't have Effort Points
+            saveData.party.caughtPokemon.forEach(p => {
+                // Check Pokérus state
+                if (p[8] == 0) {
+                    // Reset Effort Points
+                    p[9] = 0;
+                }
+            });
+        },
     };
 
     constructor() {

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -370,7 +370,7 @@ class Plot implements Saveable {
             // Gain Pokemon
             App.game.party.gainPokemonById(PokemonHelper.getPokemonByName(wanderPokemon).id, shiny, true);
             const partyPokemon = App.game.party.getPokemon(PokemonHelper.getPokemonByName(wanderPokemon).id);
-            partyPokemon.effortPoints += App.game.party.gainEffortPoints(partyPokemon, shiny, GameConstants.WANDERER_EP_YIELD);
+            partyPokemon.effortPoints += App.game.party.calculateEffortPoints(partyPokemon, shiny, GameConstants.WANDERER_EP_YIELD);
 
             // Check for Starf berry generation
             if (shiny) {

--- a/src/scripts/items/PokemonItem.ts
+++ b/src/scripts/items/PokemonItem.ts
@@ -25,7 +25,7 @@ class PokemonItem extends CaughtIndicatingItem {
         const pokemonID = PokemonHelper.getPokemonByName(pokemonName).id;
         App.game.party.gainPokemonById(pokemonID, shiny, true);
         const partyPokemon = App.game.party.getPokemon(pokemonID);
-        partyPokemon.effortPoints += App.game.party.gainEffortPoints(partyPokemon, shiny, GameConstants.SHOPMON_EP_YIELD);
+        partyPokemon.effortPoints += App.game.party.calculateEffortPoints(partyPokemon, shiny, GameConstants.SHOPMON_EP_YIELD);
     }
 
     getCaughtStatus(): CaughtStatus {

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -178,7 +178,7 @@ class Party implements Feature {
         return Math.min(1, Math.max(0.2, 0.1 + (highestRegion / 10)));
     }
 
-    public gainEffortPoints(pokemon: PartyPokemon, shiny: boolean, number = GameConstants.BASE_EP_YIELD): number {
+    public calculateEffortPoints(pokemon: PartyPokemon, shiny: boolean, number = GameConstants.BASE_EP_YIELD): number {
         let EPNum = number * App.game.multiplier.getBonus('ev');
 
         if (pokemon.pokerus < GameConstants.Pokerus.Contagious) {

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -179,11 +179,11 @@ class Party implements Feature {
     }
 
     public calculateEffortPoints(pokemon: PartyPokemon, shiny: boolean, number = GameConstants.BASE_EP_YIELD): number {
-        let EPNum = number * App.game.multiplier.getBonus('ev');
-
         if (pokemon.pokerus < GameConstants.Pokerus.Contagious) {
             return 0;
         }
+
+        let EPNum = number * App.game.multiplier.getBonus('ev');
 
         if (shiny) {
             EPNum *= GameConstants.SHINY_EP_MODIFIER;

--- a/src/scripts/party/evolutions/Evolution.ts
+++ b/src/scripts/party/evolutions/Evolution.ts
@@ -43,7 +43,7 @@ abstract class Evolution {
 
         // EVs
         const evolvedPartyPokemon = App.game.party.getPokemonByName(evolvedPokemon);
-        evolvedPartyPokemon.effortPoints += App.game.party.gainEffortPoints(evolvedPartyPokemon, shiny, GameConstants.STONE_EP_YIELD);
+        evolvedPartyPokemon.effortPoints += App.game.party.calculateEffortPoints(evolvedPartyPokemon, shiny, GameConstants.STONE_EP_YIELD);
         return shiny;
     }
 

--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -148,7 +148,7 @@ class SafariBattle {
         const pokemonID = PokemonHelper.getPokemonByName(SafariBattle.enemy.name).id;
         App.game.party.gainPokemonById(pokemonID, SafariBattle.enemy.shiny);
         const partyPokemon = App.game.party.getPokemon(pokemonID);
-        partyPokemon.effortPoints += App.game.party.gainEffortPoints(partyPokemon, SafariBattle.enemy.shiny, GameConstants.SAFARI_EP_YIELD);
+        partyPokemon.effortPoints += App.game.party.calculateEffortPoints(partyPokemon, SafariBattle.enemy.shiny, GameConstants.SAFARI_EP_YIELD);
 
     }
 


### PR DESCRIPTION
This PR should fix Pokémon gaining Pokérus early (before key item gained).
Should also remove any EP gained on Pokémon that do not currently have Pokérus.
Also fixed up previous update function.