### PR TITLE
Fix dungeon counters

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -356,11 +356,11 @@
                 <div class="card-header p-0">
                     <div style="position: absolute; left: 2px">
                         <img title="Chests opened in current dungeon" src="assets/images/dungeons/chest.png" height="25px" />
-                        <span data-bind="text: `${DungeonRunner.chestsOpened()}/${DungeonRunner.map.size}`"></span>
+                        <span data-bind="text: `${DungeonRunner.chestsOpened()}/${DungeonRunner.map.totalChests()}`"></span>
                     </div>
                     <div style="position: absolute; right: 4px">
                         <img title="Encounters won in current dungeon" src="assets/images/dungeons/encounter.png" height="25px" />
-                        <span data-bind="text: `${DungeonRunner.encountersWon()}/${DungeonRunner.map.size * 2 + 3}`"></span>
+                        <span data-bind="text: `${DungeonRunner.encountersWon()}/${DungeonRunner.map.totalFights()}`"></span>
                     </div>
                     <span data-bind="text: `${DungeonRunner.dungeon.name}`"></span>
                 </div>
@@ -442,7 +442,7 @@
                         <div class='col-12'>
                             <i>NOTE: These colors can be customized in the settings menu</i>
                         </div>
-                    </div>" 
+                    </div>"
                     data-placement="bottom">ⓘ</button>
                     <button class='btn btn-sm' style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px;"
                     data-bind='style: { background: Weather.color() },

--- a/src/scripts/dungeons/DungeonMap.ts
+++ b/src/scripts/dungeons/DungeonMap.ts
@@ -2,6 +2,8 @@ class DungeonMap {
     board: KnockoutObservable<DungeonTile[][]>;
     playerPosition: KnockoutObservable<Point>;
     playerMoved: KnockoutObservable<boolean>;
+    totalFights: KnockoutObservable<number>;
+    totalChests: KnockoutObservable<number>;
 
     constructor(
         public size: number,
@@ -27,6 +29,8 @@ class DungeonMap {
         if (this.flash) {
             this.nearbyTiles(this.playerPosition()).forEach(t => t.isVisible = true);
         }
+        this.totalFights = ko.observable(this.board().flat().filter((t) => t.type() == GameConstants.DungeonTile.enemy).length);
+        this.totalChests = ko.observable(this.board().flat().filter((t) => t.type() == GameConstants.DungeonTile.chest).length);
     }
 
     public moveToCoordinates(x: number, y: number) {


### PR DESCRIPTION
Closes  #2753
Code is weird, so chests and enemies can be placed on the entrance, which led to there being less enemies/chests than expected.
The solution is to count how many there are, instead of calculating it.