### PR TITLE
Disappearing egg bug

### DIFF
--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -211,7 +211,7 @@ class Breeding implements Feature {
                 partyPokemon.calculatePokerus();
             }
             egg.addSteps(amount, this.multiplier);
-            if (this.queueList().length && egg.progress() >= 100) {
+            if (this.queueList().length && egg.canHatch()) {
                 this.hatchPokemonEgg(index);
             }
         }

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -188,7 +188,7 @@ class HatcheryHelpers {
             egg.addSteps(steps, multiplier);
 
             // Check if the egg is ready to hatch
-            if (egg.progress() >= 100 || egg.isNone()) {
+            if (egg.canHatch()) {
                 egg.hatch(helper.attackEfficiency(), true);
                 this.hatchery.eggList[index](new Egg());
 


### PR DESCRIPTION
An attempt for fixing #2746.
I am not able to reproduce the bug (and no one so far have been able to tell me how), so i can only guess...
Only thing i could find in the code, is that we have two different ways of calculating if an egg is hatched or not. And if some rounding error does so only the first is true, the pokemon will be lost.
But yeah, the only way of testing it, is to release it and see if people still loses it.