### PR TITLE
Show Poké balls if you have a quantity of them

### DIFF
--- a/src/components/pokeballSelectorModal.html
+++ b/src/components/pokeballSelectorModal.html
@@ -27,7 +27,7 @@
               <tr class="clickable"
                 data-bind="template: { name: 'pokeballSelectionTemplate', data: $data},
                   click: function(){App.game.pokeballs.selectedSelection()($data.type)},
-                  visible: $data.unlocked(),
+                  visible: $data.unlocked() || $data.quantity(),
                   css: {
                     'clickable': !($data.type === GameConstants.Pokeball.Masterball && App.game.challenges.list.disableMasterballs.active()),
                     'disabled no-click text-muted': ($data.type === GameConstants.Pokeball.Masterball && App.game.challenges.list.disableMasterballs.active()),


### PR DESCRIPTION
This is mostly for the Lure ball, which is awarded in Johto dungeons, but isn't shown in the list/unlocked until Hoenn.

If you have any, it will now show it as an option in the Poké ball selector list.