### PR TITLE
gainPokemonEgg breeding property on success

### DIFF
--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -269,11 +269,13 @@ class Breeding implements Feature {
         }
         const egg = this.createEgg(pokemon.name);
 
-        if (pokemon instanceof PartyPokemon) {
+        const success = this.gainEgg(egg, isHelper);
+
+        if (success && pokemon instanceof PartyPokemon) {
             pokemon.breeding = true;
         }
 
-        return this.gainEgg(egg, isHelper);
+        return success;
     }
 
     public hatchPokemonEgg(index: number): void {


### PR DESCRIPTION
Breeding::gainPokemonEgg now only sets breeding property on success.
Please note that I have not been able to test this change yet.