### PR TITLE
Hide save selector challenge mode tooltips when clicked

### DIFF
--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -7,6 +7,9 @@ class App {
     static game: Game;
 
     static start() {
+        // Hide tooltips that stay on game load
+        $('.tooltip').tooltip('hide');
+
         if (!App.debug) {
             Object.freeze(GameConstants);
         }


### PR DESCRIPTION
Currently if you click a save on the challenge icon, the tooltip stays visible.
![image](https://user-images.githubusercontent.com/7288322/182260609-6778f1d9-7581-4744-8d76-4410afbd51ab.png)

This should now be fixed.