### PR TITLE
More consistent underground sort

### DIFF
--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -314,14 +314,22 @@ class Underground implements Feature {
         }
 
         player.mineInventory.sort((a, b) => {
+            let result = 0;
             switch (prop) {
                 case 'Amount':
-                    return (a.amount() - b.amount()) * this.sortDirection;
+                    result = (a.amount() - b.amount()) * this.sortDirection;
+                    break;
                 case 'Value':
-                    return (a.value - b.value) * this.sortDirection;
+                    result = (a.value - b.value) * this.sortDirection;
+                    break;
                 case 'Item':
-                    return a.name > b.name ? 1 * this.sortDirection : -1 * this.sortDirection;
+                    result = a.name > b.name ? 1 * this.sortDirection : -1 * this.sortDirection;
+                    break;
             }
+            if (result == 0) {
+                return a.id - b.id;
+            }
+            return result;
         });
     }
 


### PR DESCRIPTION
Fixes #2815
When we sort the underground items, i have added a secondary sort for id.
I tried to add a default sort for id, but that is too much work for what i have time for right now.