### PR TITLE
Add styling to Farm SafeLocks to improve visibility

### DIFF
--- a/src/styles/farm.less
+++ b/src/styles/farm.less
@@ -111,6 +111,16 @@
           right: 5px;
           height: 16px;
           width: 16px;
+          -webkit-filter:
+                drop-shadow(0.2px 0.2px 0 black)
+                drop-shadow(-0.2px 0.2px 0 black)
+                drop-shadow(0.2px -0.2px 0 black)
+                drop-shadow(-0.2px -0.2px 0 black);
+          filter:
+                drop-shadow(0.2px 0.2px 0 black)
+                drop-shadow(-0.2px 0.2px 0 black)
+                drop-shadow(0.2px -0.2px 0 black)
+                drop-shadow(-0.2px -0.2px 0 black);
       }
   }
 


### PR DESCRIPTION
The added drop-shadow filters give the locks a black stroke/outline look on plots. Mostly useful for visibility against the white Freeze Mulch plots. 