### PR TITLE
Eternamax Region.none

### DIFF
--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -22018,6 +22018,7 @@ const pokemonList = createPokemonArray(
     {
         'id': 890.1,
         'name': 'Eternamax Eternatus',
+        'nativeRegion': GameConstants.Region.none,
         'type': [
             PokemonType.Poison,
             PokemonType.Dragon,


### PR DESCRIPTION
Eternamax is currently galar native, which makes him appear in battle frontier. This PR makes it none native, to be consistent with the gigantamax pokemon