### PR TITLE
Fixed Alola island 3 blocked

### DIFF
--- a/src/modules/requirements/TemporaryBattleRequirement.ts
+++ b/src/modules/requirements/TemporaryBattleRequirement.ts
@@ -2,7 +2,7 @@ import Requirement from './Requirement';
 import * as GameConstants from '../GameConstants';
 
 export default class TemporaryBattleRequirement extends Requirement {
-    constructor(public battleName: string, defeatsRequired = 1, option = GameConstants.AchievementOption.equal) {
+    constructor(public battleName: string, defeatsRequired = 1, option = GameConstants.AchievementOption.more) {
         super(defeatsRequired, option);
     }
 


### PR DESCRIPTION
So... this bug is weird...
When Ultra wormhole was turned from a temp battle, into a gym, we just moved the "completed" count over... So a lot of old players had defeated it more than once...
And for some reason, the default was changed from GameConstants.AchievementOption.more to equal in the latest update for TemporaryBattleRequirement, which broke the ultra wormhole