### PR TITLE
Remove nativeRegion from event Pokemon

### DIFF
--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -81,7 +81,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 1.1,
         'name': 'Bulbasaur (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Grass, PokemonType.Poison],
         'levelType': LevelType.mediumslow,
@@ -100,7 +99,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 1.2,
         'name': 'Spooky Bulbasaur',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 25,
         'type': [PokemonType.Grass],
         'levelType': LevelType.mediumslow,
@@ -119,7 +117,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 1.3,
         'name': 'Bulbasaur (Rose)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 25,
         'type': [PokemonType.Grass, PokemonType.Fairy],
         'levelType': LevelType.mediumslow,
@@ -156,7 +153,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 2.1,
         'name': 'Ivysaur (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Grass, PokemonType.Poison],
         'levelType': LevelType.mediumslow,
@@ -175,7 +171,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 2.2,
         'name': 'Spooky Ivysaur',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Grass],
         'levelType': LevelType.mediumslow,
@@ -229,7 +224,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 3.1,
         'name': 'Venusaur (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Grass, PokemonType.Poison],
         'levelType': LevelType.mediumslow,
@@ -247,7 +241,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 3.2,
         'name': 'Spooky Venusaur',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Grass, PokemonType.Dark],
         'levelType': LevelType.mediumslow,
@@ -318,7 +311,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 4.1,
         'name': 'Charmander (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Fire],
         'levelType': LevelType.mediumslow,
@@ -355,7 +347,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 5.1,
         'name': 'Charmeleon (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Fire],
         'levelType': LevelType.mediumslow,
@@ -391,7 +382,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 6.1,
         'name': 'Charizard (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Fire, PokemonType.Flying],
         'levelType': LevelType.mediumslow,
@@ -445,7 +435,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 7.1,
         'name': 'Squirtle (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Water],
         'levelType': LevelType.mediumslow,
@@ -482,7 +471,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 8.1,
         'name': 'Wartortle (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Water],
         'levelType': LevelType.mediumslow,
@@ -518,7 +506,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 9.1,
         'name': 'Blastoise (Clone)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 45,
         'type': [PokemonType.Water],
         'levelType': LevelType.mediumslow,
@@ -1230,7 +1217,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 25.08,
         'name': 'Flying Pikachu',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 50,
         'type': [PokemonType.Electric, PokemonType.Flying],
         'levelType': LevelType.mediumfast,
@@ -1248,7 +1234,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 25.09,
         'name': 'Surfing Pikachu',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 50,
         'type': [PokemonType.Electric, PokemonType.Water],
         'levelType': LevelType.mediumfast,
@@ -1266,7 +1251,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 25.10,
         'name': 'Pikachu (Gengar)',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 50,
         'type': [PokemonType.Electric],
         'levelType': LevelType.mediumfast,
@@ -1284,7 +1268,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 25.11,
         'name': 'Let\'s Go Pikachu',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 50,
         'type': [PokemonType.Electric],
         'levelType': LevelType.mediumfast,
@@ -4328,7 +4311,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 133.1,
         'name': 'Let\'s Go Eevee',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 50,
         'type': [PokemonType.Normal],
         'levelType': LevelType.mediumfast,
@@ -4537,7 +4519,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 143.1,
         'name': 'Santa Snorlax',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 25,
         'type': [PokemonType.Normal],
         'levelType': LevelType.slow,
@@ -4751,7 +4732,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 150.1,
         'name': 'Armored Mewtwo',
-        'nativeRegion': GameConstants.Region.kanto,
         'catchRate': 2,
         'type': [PokemonType.Psychic],
         'levelType': LevelType.slow,
@@ -5234,7 +5214,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 175.1,
         'name': 'Spooky Togepi',
-        'nativeRegion': GameConstants.Region.johto,
         'catchRate': 30,
         'type': [PokemonType.Fairy],
         'levelType': LevelType.fast,
@@ -5252,7 +5231,6 @@ const pokemonList = createPokemonArray(
     {
         'id': 175.2,
         'name': 'Surprise Togepi',
-        'nativeRegion': GameConstants.Region.johto,
         'catchRate': 30,
         'type': [PokemonType.Fairy],
         'levelType': LevelType.fast,


### PR DESCRIPTION
Removing as it is useless code, since it assigns the native region they would be automatically assigned to. Presumably a leftover from when they had negative IDs