### PR TITLE
Updating Qualot to be Pink instead of Yellow

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -180,8 +180,8 @@ class Farming implements Feature {
             ['This Berry can be eaten as is or boiled to obtain an extract that adds a dash of flavor to food.'], undefined, ['Flabébé (Blue)']);
         this.berryData[BerryType.Qualot]    = new Berry(BerryType.Qualot,   [230, 1000, 2500, 4800, 9600],
             22, 0.2, 550, 10,
-            [10, 0, 10, 0, 10], BerryColor.Yellow,
-            ['Even in places of constant rain and high humidity, this Berry\'s plant grows healthy and strong.'], undefined, ['Flabébé (Yellow)', 'Oricorio (Pom-Pom)']);
+            [10, 0, 10, 0, 10], BerryColor.Pink,
+            ['Even in places of constant rain and high humidity, this Berry\'s plant grows healthy and strong.'], undefined, ['Oricorio (Pa\'u)']);
         this.berryData[BerryType.Hondew]    = new Berry(BerryType.Hondew,   [1000, 2000, 5000, 10800, 21600],
             23, 0.2, 2000, 10,
             [10, 10, 0, 10, 0], BerryColor.Green,


### PR DESCRIPTION
Small change to make Qualot's color value pink instead of yellow, as this makes more sense with it being one of the seven pink berries that is dropped in Pinkan Mountain and used to mutate Pinkan Berries. Also changed the wanderers it attracts to match the change in color.