### PR TITLE
Allow Enigma hint to be displayed in Berrydex once unlocked

### DIFF
--- a/src/scripts/farming/mutation/mutationTypes/EnigmaMutation.ts
+++ b/src/scripts/farming/mutation/mutationTypes/EnigmaMutation.ts
@@ -114,8 +114,9 @@ class EnigmaMutation extends GrowMutation {
         }
 
         const hints = [];
+        const unlocked = App.game.farming.unlockedBerries[this.mutatedBerry]();
         this.hintsSeen.forEach((hintSeen, idx) => {
-            if (!hintSeen()) {
+            if (!hintSeen() && !unlocked) {
                 return false;
             }
             hints.push(this.getHint(idx));


### PR DESCRIPTION
(I dedicate this PR to tater in discord)

Currently if a player unlocks the Enigma berry without receiving all 4 hints from the Kanto berry master the hint in the Berrydex will be incomplete or missing entirely and the berry master will no longer give the hints, making it difficult to mutate again in the future if needed. This change will allow the full hint to be displayed if the berry has been unlocked and mutated previously.