### PR TITLE
Fixup pokemon item tooltip missing a space

### DIFF
--- a/src/scripts/items/PokemonItem.ts
+++ b/src/scripts/items/PokemonItem.ts
@@ -5,7 +5,7 @@ class PokemonItem extends CaughtIndicatingItem {
     type: PokemonNameType;
 
     constructor(pokemon: PokemonNameType, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.questPoint) {
-        super(pokemon, basePrice, currency, undefined, undefined, `Add ${pokemon}to your party.`, 'pokemonItem');
+        super(pokemon, basePrice, currency, undefined, undefined, `Add ${pokemon} to your party.`, 'pokemonItem');
         this.type = pokemon;
     }
 


### PR DESCRIPTION
There is a missing space on shop tooltips for pokémon items : 
![image](https://user-images.githubusercontent.com/11090416/192013810-e6429eee-c356-42f2-8ae0-0a879a9b494e.png)
