### PR TITLE
Fix protein filter dropdowns "resetting"

### DIFF
--- a/src/components/pokemonSelectorModal.html
+++ b/src/components/pokemonSelectorModal.html
@@ -69,7 +69,7 @@
                 <label for="protein-region-filter">Region</label>
                 <select id="protein-region-filter" name="proteinRegionFilter" autocomplete="off" class="custom-select" onchange="ProteinFilters.region.value(+this.value), Settings.setSettingByName(this.name, this.value)">
                     <!-- ko foreach: Settings.getSetting('proteinRegionFilter').options.filter(r => r.value <= player.highestRegion()) -->
-                    <option data-bind="attr: { value: $data.value }, text: $data.text">Region</option>
+                    <option data-bind="attr: { value: $data.value, selected: Settings.getSetting('proteinRegionFilter').value === $data.value }, text: $data.text">Region</option>
                     <!-- /ko -->
                 </select>
             </div>
@@ -77,7 +77,7 @@
                 <label for="protein-type-filter">Type</label>
                 <select id="protein-type-filter" name="proteinTypeFilter" autocomplete="off" class="custom-select" onchange="ProteinFilters.type.value(+this.value), Settings.setSettingByName(this.name, this.value)">
                     <!-- ko foreach: Settings.getSetting('proteinTypeFilter').options -->
-                    <option data-bind="attr: { value: $data.value }, text: $data.text">Type</option>
+                    <option data-bind="attr: { value: $data.value, selected: Settings.getSetting('proteinTypeFilter').value === $data.value }, text: $data.text">Type</option>
                     <!-- /ko -->
                 </select>
             </div>

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -38,8 +38,6 @@ class Party implements Feature {
             }, new Map());
         });
 
-        ProteinFilters.region.value(+Settings.getSetting('proteinRegionFilter').value);
-        ProteinFilters.type.value(+Settings.getSetting('proteinTypeFilter').value);
     }
 
     gainPokemonById(id: number, shiny = false, suppressNotification = false) {

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -38,6 +38,8 @@ class Party implements Feature {
             }, new Map());
         });
 
+        ProteinFilters.region.value(+Settings.getSetting('proteinRegionFilter').value);
+        ProteinFilters.type.value(+Settings.getSetting('proteinTypeFilter').value);
     }
 
     gainPokemonById(id: number, shiny = false, suppressNotification = false) {


### PR DESCRIPTION
Fixes the protein Region & Type dropdown filters resetting when closing and re-opening the modal. Additionally these values were already persisted in the settings but were not getting set upon load.