### PR TITLE
Add timeout to lazyloader requestIdleCallback

### DIFF
--- a/src/modules/utilities/LazyLoader.ts
+++ b/src/modules/utilities/LazyLoader.ts
@@ -12,7 +12,7 @@ function createObserver(loader: HTMLElement, options: IntersectionObserverInit):
 
             // keep loading more in case we don't push the loader off screen
             // @ts-ignore
-            requestIdleCallback(loadMore);
+            requestIdleCallback(loadMore, { timeout: 100 });
         }
     };
 


### PR DESCRIPTION
Instead of waiting forever until the browser has some cpu cycles to spare, we will now only wait up to 100ms before demanding a new page is loaded. Makes sure the hatchery continues loading even when the player's computer is not having a good time.

I've asked the person who reported this problem on discord to check this helps out, and they confirmed it did. I also tested myself by throttling my cpu - I wasn't able to get the minutes of lag reported on discord, but this change did make things load better with the lag I was able to get.