### PR TITLE
Update Kalos Route 1 encounters

### DIFF
--- a/src/scripts/wildBattle/RouteData.ts
+++ b/src/scripts/wildBattle/RouteData.ts
@@ -1515,7 +1515,7 @@ KALOS
 Routes.add(new RegionRoute(
     'Kalos Route 1', GameConstants.Region.kalos, 1,
     new RoutePokemon({
-        land: ['Rattata'],
+        land: ['Bunnelby', 'Fletchling'],
     }),
     [new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)]
 ));


### PR DESCRIPTION
Kalos Route 1 does not have any encounters in the base game. This changes the encounter list from the somewhat jarring 100% Rattata to a lore-friendly pair of regional mons.

This does not affect balance, as the added mons are in the very next route.