### PR TITLE
Remove Kalos Route 1 (make it visual only)

### DIFF
--- a/src/components/KalosSVG.html
+++ b/src/components/KalosSVG.html
@@ -8,15 +8,6 @@
     <!-- ROUTES -->
     <!-- ------ -->
 
-    <!--Route 1-->
-    <%- include('templates/mapRoute',
-        { route: 1, region: 5
-        , width: 4.5, height: 3
-        , x: 53, y: 47
-        , rotate: true
-        })
-    %>
-
     <!--Route 2-->
     <%- include('templates/mapRoute',
         { route: 2, region: 5
@@ -644,6 +635,18 @@
         , x: 32, y: 12
         , width: 3, height: 4
         , databind: "click:function(){MapHelper.openShipModal()}, attr: { class: MapHelper.calculateTownCssClass('Coumarine City') }"
+        })
+    %>
+
+    <%- include('templates/mapPOI',
+        { name: "Route 1"
+        , width: 4.5, height: 3
+        , x: 53, y: 47
+        , rotate: true
+        , databind: `attr: { class: MapHelper.accessToTown("Aquacorde Town") ? 'unlockedTown' : 'lockedTown' },
+            click: () => {
+                Notifier.notify({message: 'This sure is a route'});
+            }`
         })
     %>
 

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3477,7 +3477,7 @@ TownList['Aquacorde Town'] = new Town(
     GameConstants.Region.kalos,
     [AquacordeTownShop],
     {
-        requirements: [new RouteKillRequirement(10, GameConstants.Region.kalos, 1)],
+        requirements: [new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)],
     }
 );
 TownList['Santalune City'] = new Town(

--- a/src/scripts/wildBattle/RouteData.ts
+++ b/src/scripts/wildBattle/RouteData.ts
@@ -1513,18 +1513,11 @@ Routes.add(new RegionRoute(
 KALOS
 */
 Routes.add(new RegionRoute(
-    'Kalos Route 1', GameConstants.Region.kalos, 1,
-    new RoutePokemon({
-        land: ['Rattata'],
-    }),
-    [new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)]
-));
-Routes.add(new RegionRoute(
     'Kalos Route 2', GameConstants.Region.kalos, 2,
     new RoutePokemon({
         land: ['Caterpie', 'Weedle', 'Pidgey', 'Zigzagoon', 'Fletchling', 'Bunnelby', 'Scatterbug'],
     }),
-    [new RouteKillRequirement(10, GameConstants.Region.kalos, 1)]
+    [new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)]
 ));
 Routes.add(new RegionRoute(
     'Kalos Route 3', GameConstants.Region.kalos, 3,


### PR DESCRIPTION
I saw #3062 and I wondered "why is kalos route 1 even in the game in the first place?"
So I did this. This makes kalos route 1 only visual, there are no encounters. Its a lot like Skyarrow Bridge.