### PR TITLE
Fix nested/stacked modals not appearing on top

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // preventing us from getting into that messy situation.
 // Copied from https://stackoverflow.com/questions/19305821/multiple-modals-overlay#answer-24914782
 $(document).on('show.bs.modal', '.modal', function () {
-    const zIndex = 1040 + (10 * $('.modal:visible').length);
+    const zIndex = Math.max(1040, Math.max(...$('.modal:visible').get().map(e => +e.style.zIndex)) + 10);
     $(this).css('z-index', zIndex);
     // setTimeout with 0 delay because the backdrop doesn't exist yet
     setTimeout(() => {


### PR DESCRIPTION
Using a hotkey to switch to a modal while another is open will cause any nested/stacked modals to appear behind the current modal due to the z-index values being the same. (eg switching from the farm to the underground using the underground hotkey then clicking the Skip button)

This changes the z-index calculation to use the highest modal z-index (if any) rather than calculating it based on number of visible modals.


Reported on discord by BobTheDragon#4638
Closes #2483