### PR TITLE
Fix pokedex breaking on uncaught pokemon

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -41,7 +41,7 @@ export enum Region {
     final = 8,
 }
 
-export const MAX_AVAILABLE_REGION = Region.alola;
+export const MAX_AVAILABLE_REGION = Region.galar;
 
 export const MaxIDPerRegion = [
     151, // 151 - Kanto

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -72,13 +72,13 @@ class PokemonHelper {
         return PokemonType[id];
     }
 
-    public static getImage(pokemonId: number, shiny = undefined, gender = undefined): string {
+    public static getImage(pokemonId: number, shiny: boolean = undefined, gender: boolean = undefined): string {
         let src = 'assets/images/';
         if (shiny === undefined) {
             shiny = App.game.party.alreadyCaughtPokemon(pokemonId, true);
         }
         if (gender === undefined) {
-            gender = App.game.party.getPokemon(pokemonId).defaultFemaleSprite();
+            gender = App.game.party.getPokemon(pokemonId)?.defaultFemaleSprite() ?? false;
         }
 
         if (shiny) {


### PR DESCRIPTION
After the gender code was added, the pokedex broke when it needed to find the image of a uncaught pokemon. This PR fixes that.