### PR TITLE
Fixed trainer images randomly floating

### DIFF
--- a/src/components/gymView.html
+++ b/src/components/gymView.html
@@ -37,7 +37,7 @@
           </div>
         </div>
 
-        <div style="position:absolute; left:65%;">
+        <div style="position:absolute; left:65%; top: 25%;">
             <img data-bind="attr:{ src: GymBattle.gym.imagePath }" onerror="this.src='assets/images/trainers/Mysterious Trainer.png';"/>
         </div>
 

--- a/src/components/temporaryBattleView.html
+++ b/src/components/temporaryBattleView.html
@@ -38,7 +38,7 @@
           </div>
         </div>
 
-        <div style="position:absolute; left:65%;" data-bind="if: !TemporaryBattleRunner.battleObservable().optionalArgs.hideTrainer">
+        <div style="position:absolute; left:65%; top: 25%;" data-bind="if: !TemporaryBattleRunner.battleObservable().optionalArgs.hideTrainer">
             <img data-bind="attr:{ src: TemporaryBattleRunner.battleObservable().getImage() }" onerror="this.src='assets/images/trainers/Mysterious Trainer.png';"/>
         </div>
 


### PR DESCRIPTION
With jks changes for the pokerus icons, the background image got shifted, which made the trainers randomly float.
I like how the images look after they have been shifted, so i have just moved the trainers to fit the background.
For some reason, it did not affect dungeons. I will maybe look into that later, but because they look like they did before, i have not done anything to them.

Current patch:
![image](https://user-images.githubusercontent.com/2961347/196887772-6756a579-c914-4b83-b082-e63e5939bd31.png)

Before my change:
![image](https://user-images.githubusercontent.com/2961347/196888105-32781553-a4d3-4118-be4c-057674aa3645.png)

After my change:
![image](https://user-images.githubusercontent.com/2961347/196887967-692bebfb-7b97-4299-bd5d-4db054c0b9c1.png)
