### PR TITLE
Berrydex : display « Total Life Span » instead of « Total Growth Time »

### DIFF
--- a/src/components/berryDexModal.html
+++ b/src/components/berryDexModal.html
@@ -27,8 +27,8 @@
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="text-left">Total Growth Time</td>
-                      <td class="text-left tight"><code data-bind="html: GameConstants.formatSecondsToTime(App.game.farming.berryData[$data].growthTime[3])">-</code></td>
+                      <td class="text-left">Total Life Span</td>
+                      <td class="text-left tight"><code data-bind="html: GameConstants.formatSecondsToTime(App.game.farming.berryData[$data].growthTime[4])">-</code></td>
                     </tr>
                     <tr>
                       <td class="text-left">Harvest Amount</td>


### PR DESCRIPTION
*Total Growth Time* is already presented along with stages anyway.
Therefore, this PR introduces the wither time in a nice manner, useful information that the player could not read in game.
![image](https://user-images.githubusercontent.com/68825215/198160106-98bb497c-fa3d-4a6e-94c7-a49e73e4b450.png)
