### PR TITLE
Fix pokemonListContainer line breaks in full width (5)

### DIFF
--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -293,7 +293,10 @@ td {
   .pokemonLevel { text-align: right; }
 
   .col-lg-6 & {
-    .pokemonName { max-width: 55%; text-align: left; }
+    thead { line-height: 10px;
+      .pokemonName { margin-right: 15px; }
+     }
+    .pokemonName { width: 100%; }
     .pokemonAttack { text-align: left; }
   }
 }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -286,15 +286,15 @@ td {
   .pokemonName { flex-grow: 10; }
   .pokemonAttack, .pokemonLevel {
     flex-grow: 1;
-    min-width: 60px;
+    min-width: 45px;
   }
 
   .pokemonAttack { text-align: left; }
   .pokemonLevel { text-align: right; }
 
   .col-lg-6 & {
-    .pokemonName { width: auto; }
-    .pokemonAttack { text-align: right; }
+    .pokemonName { max-width: 55%; text-align: left; }
+    .pokemonAttack { text-align: left; }
   }
 }
 


### PR DESCRIPTION
Adjust stylesheet for the pokemonListContainer to fix line breaks in the full width (5 columns) view.

<details><summary>Current</summary>
<img src="https://i.imgur.com/O7omyNU.png"> <img src="https://i.imgur.com/QVM4iQ5.png">
</details>

<details><summary>Fixed</summary>
<img src="https://i.imgur.com/jypXYjp.png"> <img src="https://i.imgur.com/wV5ZCGd.png">
</details>

Closes #2743 