### PR TITLE
Fix Hiker Lenny's pokemon

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -584,7 +584,7 @@ dungeonList['Rock Tunnel'] = new Dungeon('Rock Tunnel',
         new DungeonTrainer('Hiker',
             [
                 new GymPokemon('Geodude', 500, 19),
-                new GymPokemon('Onix', 500, 19),
+                new GymPokemon('Machop', 500, 19),
                 new GymPokemon('Geodude', 500, 19),
                 new GymPokemon('Geodude', 500, 19),
             ], { weight: 1 }, 'Lenny'),


### PR DESCRIPTION
Hiker Lenny in the Rock Tunnel Dungeon has 3 geodudes and 1 onix in Pokeclicker. As I was translating the Wiki page and looking for his french name, I saw on Pokepedia, Bulbapedia etc... That he in fact has 3 geodudes and 1 machop (in all versions or the pokemon games). So I changed Onix to Machop.