### PR TITLE
Removes the certain Unown A from Ruins of Alph

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1806,10 +1806,6 @@ dungeonList['Ruins of Alph'] = new Dungeon('Ruins of Alph',
     },
     60600,
     [
-        new DungeonBossPokemon('Unown (A)', 280000, 14, {
-            hide: true,
-            requirement: new ObtainedPokemonRequirement(pokemonMap['Unown (A)'], true),
-        }),
         ...AlphUnownList.map((char) => new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 280000, 14, {
             hide: true,
             requirement: new SeededDateRequirement(() => SeededDateRand.fromArray(AlphUnownList) == char),


### PR DESCRIPTION
Unown A was added to be always be in Ruins of Alph if it was uncaught, due to people complaining the Pokedex still had an uncaught Pokemon. This is no longer necessary.