### PR TITLE
Fixed Cue Ball Paxton's team

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -97,8 +97,8 @@ TemporaryBattleList['Biker Goon 3'] = new TemporaryBattle(
 TemporaryBattleList['Cue Ball Paxton'] = new TemporaryBattle(
     'Cue Ball Paxton',
     [
-        new GymPokemon('Koffing', 221664, 39),
-        new GymPokemon('Grimer', 221664, 39),
+        new GymPokemon('Weezing', 221664, 39),
+        new GymPokemon('Muk', 221664, 39),
     ],
     'All right, enough! We\'ll leave like you wanted! We\'ll be happy to see the last of this boring island!',
     [


### PR DESCRIPTION
Change to a temporary battle for accurateness. Changed Cue Ball Paxton's Pokémon team to Weezing + Muk following the information found on this page https://bulbapedia.bulbagarden.net/wiki/Three_Island_(town).