### PR TITLE
Pokémon gender statistics to tooltips

### DIFF
--- a/src/components/pokemonStatisticsModal.html
+++ b/src/components/pokemonStatisticsModal.html
@@ -128,114 +128,129 @@
                   <tbody>
                     <tr>
                       <td class="text-left align-middle">Encountered</td>
-                      <td class="text-left align-middle tight">
-                        <code data-bind="text: 'Total: ' + App.game.statistics.pokemonEncountered[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.pokemonEncountered[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.malePokemonEncountered[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.femalePokemonEncountered[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.malePokemonEncountered[$data](),
+                                'femaleStat': App.game.statistics.femalePokemonEncountered[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout> 
                         <!-- /ko -->
                       </td>
                     </tr>
                     <tr>
                       <td class="text-left align-middle">Defeated</td>
-                      <td class="text-left align-middle tight"><code data-bind="text: 'Total: ' + App.game.statistics.pokemonDefeated[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.pokemonDefeated[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.malePokemonDefeated[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.femalePokemonDefeated[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.malePokemonDefeated[$data](),
+                                'femaleStat': App.game.statistics.femalePokemonDefeated[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout>
                         <!-- /ko -->
                       </td>
                     </tr>
                     <tr>
                       <td class="text-left align-middle">Captured</td>
-                      <td class="text-left align-middle tight"><code data-bind="text: 'Total: ' + App.game.statistics.pokemonCaptured[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.pokemonCaptured[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.malePokemonCaptured[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.femalePokemonCaptured[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.malePokemonCaptured[$data](),
+                                'femaleStat': App.game.statistics.femalePokemonCaptured[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout> 
                         <!-- /ko -->
                       </td>
                     </tr>
                     <tr>
                       <td class="text-left align-middle">Hatched</td>
-                      <td class="text-left align-middle tight"><code data-bind="text: 'Total: ' + App.game.statistics.pokemonHatched[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.pokemonHatched[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.malePokemonHatched[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.femalePokemonHatched[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.malePokemonHatched[$data](),
+                                'femaleStat': App.game.statistics.femalePokemonHatched[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout> 
                         <!-- /ko -->
                       </td>
                     </tr>
                     <tr>
                       <td class="text-left align-middle">Shinies Encountered</td>
-                      <td class="text-left align-middle tight"><code data-bind="text: 'Total: ' + App.game.statistics.shinyPokemonEncountered[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.shinyPokemonEncountered[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyMalePokemonEncountered[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyFemalePokemonEncountered[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.shinyMalePokemonEncountered[$data](),
+                                'femaleStat': App.game.statistics.shinyFemalePokemonEncountered[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout> 
                         <!-- /ko -->
                       </td>
                     </tr>
                     <tr>
                       <td class="text-left align-middle">Shinies Defeated</td>
-                      <td class="text-left align-middle tight"><code data-bind="text: 'Total: ' + App.game.statistics.shinyPokemonDefeated[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.shinyPokemonDefeated[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyMalePokemonDefeated[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyFemalePokemonDefeated[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.shinyMalePokemonDefeated[$data](),
+                                'femaleStat': App.game.statistics.shinyFemalePokemonDefeated[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout> 
                         <!-- /ko -->
                       </td>
                     </tr>
                     <tr>
                       <td class="text-left align-middle">Shinies Captured</td>
-                      <td class="text-left align-middle tight"><code data-bind="text: 'Total: ' + App.game.statistics.shinyPokemonCaptured[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.shinyPokemonCaptured[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyMalePokemonCaptured[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyFemalePokemonCaptured[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.shinyMalePokemonCaptured[$data](),
+                                'femaleStat': App.game.statistics.shinyFemalePokemonCaptured[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout> 
                         <!-- /ko -->
                       </td>
                     </tr>
                     <tr>
                       <td class="text-left align-middle">Shinies Hatched</td>
-                      <td class="text-left align-middle tight"><code data-bind="text: 'Total: ' + App.game.statistics.shinyPokemonHatched[$data]().toLocaleString('en-US')">-</code>
+                      <td class="text-left align-middle tight position-relative">
+                        <code data-bind="text: App.game.statistics.shinyPokemonHatched[$data]().toLocaleString('en-US')">-</code>
                         <!-- Gender Statistics -->
                         <!-- ko if: pokemonMap[$data].gender.type == GameConstants.Genders.MaleFemale && pokemonMap[$data].gender.femaleRatio != 0 && pokemonMap[$data].gender.femaleRatio != 1 -->
-                        <br />
-                        <code data-bind="html: '♂: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyMalePokemonHatched[$data]().toLocaleString('en-US')"></code>
-                        <br />
-                        <code data-bind="html: '♀: '"></code>
-                        <code data-bind="html: App.game.statistics.shinyFemalePokemonHatched[$data]().toLocaleString('en-US')"></code>
+                        <knockout data-bind="template: { 
+                            name: 'pokemonGenderStatisticTemplate', 
+                            data: { 
+                                'maleStat': App.game.statistics.shinyMalePokemonHatched[$data](),
+                                'femaleStat': App.game.statistics.shinyFemalePokemonHatched[$data](),
+                            } 
+                        }">Pokémon gender statistic</knockout> 
                         <!-- /ko -->
                       </td>
                     </tr>

--- a/src/components/templates/pokemonGenderStatisticTemplate.html
+++ b/src/components/templates/pokemonGenderStatisticTemplate.html
@@ -1,0 +1,22 @@
+<script type="text/html" id="pokemonGenderStatisticTemplate">
+    <div class="overlay" data-bind="tooltip: { 
+        title: `♂: ${$data.maleStat.toLocaleString('en-US')}
+                <br/>
+                ♀: ${$data.femaleStat.toLocaleString('en-US')}`,
+        html: true,
+        trigger: 'hover',
+        placement: 'top',
+        boundary: 'window'
+    }"></div>
+  </script>
+
+<!-- Example usage -->
+<!-- 
+<knockout data-bind="template: { 
+    name: 'pokemonGenderStatisticTemplate', 
+    data: { 
+        'maleStat': App.game.statistics.malePokemonEncountered[$data](),
+        'femaleStat': App.game.statistics.femalePokemonEncountered[$data](),
+    } 
+}">Pokémon gender statistic</knockout> 
+-->

--- a/src/index.html
+++ b/src/index.html
@@ -116,6 +116,7 @@
 @import "templates/pokemonSpriteTemplate.html"
 @import "templates/pokemonGenderTemplate.html"
 @import "templates/pokemonAttackTemplate.html"
+@import "templates/pokemonGenderStatisticTemplate.html"
 
 <div id="game" class="container loading" data-bind="css: {'container': Settings.getSetting('gameDisplayStyle').observableValue() === 'standard3', 'container-fluid': Settings.getSetting('gameDisplayStyle').observableValue() !== 'standard3'}">
     <div class="row justify-content-center">

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -736,3 +736,11 @@ i[class*="gender-icon-"] {
 .checkbox-disabled {
   opacity: .5;
 }
+
+.overlay {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width:100%;
+  height: 100%;
+}

--- a/src/styles/pokedex.less
+++ b/src/styles/pokedex.less
@@ -29,13 +29,7 @@
     content: 'Attack: ';
   }
 
-  .overlay {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    width:100%;
-    height: 100%;
-  }
+  
 }
 
 .pokemon-not-seen {


### PR DESCRIPTION
I think gender statistics are taking too much space in the Pokémon statistics modal, so, as a suggestion, I decided to make this PR.
![gender-stat-tooltip](https://user-images.githubusercontent.com/104547700/201005226-029cc883-1ecb-46bb-992e-36fdd43b23ab.PNG)
