### PR TITLE
Move player away from Distortion World

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -752,6 +752,7 @@ class QuestLineHelper {
 
         const DistortionWorldReward = () => {
             App.game.pokeballs.gainPokeballs(GameConstants.Pokeball.Masterball, 1, false);
+            MapHelper.moveToTown('Mt. Coronet');
             Notifier.notify({
                 title: galacticSinnohQuestLine.name,
                 message: 'You found a Master Ball!',


### PR DESCRIPTION
Move player away from Distortion World during A New World Questline as it should no longer be accsesible till clearing Sendoff Spring once.