### PR TITLE
Translate setting display names

### DIFF
--- a/src/modules/settings/Setting.ts
+++ b/src/modules/settings/Setting.ts
@@ -8,10 +8,13 @@ export default class Setting<T> {
     value: T;
     observableValue: KnockoutObservable<T>;
 
+    // We can't set this up in the constructor because App.translation doesn't exist yet
+    private cachedTranslatedName: KnockoutComputed<string>;
+
     // Leave options array empty to allow all options.
     constructor(
         public name: string,
-        public displayName: string,
+        private defaultDisplayName: string,
         public options: SettingOption<T>[],
         public defaultValue: T,
     ) {
@@ -53,5 +56,16 @@ export default class Setting<T> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
     isUnlocked(value: T): boolean {
         return true;
+    }
+
+    get displayName(): string {
+        if (!this.cachedTranslatedName) {
+            this.cachedTranslatedName = App.translation.get(
+                this.name,
+                'settings',
+                { defaultValue: this.defaultDisplayName },
+            );
+        }
+        return this.cachedTranslatedName();
     }
 }

--- a/src/modules/translation/Translation.ts
+++ b/src/modules/translation/Translation.ts
@@ -48,7 +48,7 @@ export default class Translate {
             .use(LanguageDetector)
             .init({
                 debug: true,
-                ns: ['pokemon', 'logbook'],
+                ns: ['pokemon', 'logbook', 'settings'],
                 fallbackLng: 'en',
                 backend: {
                     // Two backend sources - tries the TRANSLATION_URL first, falls back to copy taken at build time


### PR DESCRIPTION
Translations for setting display names added in:
- pokeclicker/pokeclicker-translations#22

I've left all of the strings we currently have where they are, and they are now used as a backup value in case a translation can't be found.