### PR TITLE
Default starter selection as Grass in StarterRequirement

### DIFF
--- a/src/modules/requirements/StarterRequirement.ts
+++ b/src/modules/requirements/StarterRequirement.ts
@@ -10,7 +10,8 @@ export default class StarterRequirement extends Requirement {
     }
 
     public getProgress() {
-        return player.regionStarters[this.region]();
+        const starter = player.regionStarters[this.region]();
+        return starter === Starter.None ? Starter.Grass : starter;
     }
 
     public hint(): string {

--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -61,7 +61,7 @@ class Player {
             if (savedPlayer.regionStarters && savedPlayer.regionStarters[i] != undefined) {
                 this.regionStarters.push(ko.observable(savedPlayer.regionStarters[i]));
             } else if (i < (savedPlayer.highestRegion ?? 0)) {
-                this.regionStarters.push(ko.observable(0));
+                this.regionStarters.push(ko.observable(GameConstants.Starter.Grass));
             } else if (i == (savedPlayer.highestRegion ?? 0)) {
                 this.regionStarters.push(ko.observable(GameConstants.Starter.None));
                 if (i != GameConstants.Region.kanto) { // Kanto has it's own starter code


### PR DESCRIPTION
We have a bunch of rival temp battles where all of the pokemon have a starter requirement, but no handling for none starter.
Having None starter selected means these temp battles have no pokemon and the game crashes because we expect at least 1.

<hr>

[Save file](https://discord.com/channels/450412847017754644/942364514400227358/1042240204322373682) for testing.
Fight Hugh 1 over at route 19 Unova, game crashes immediately on develop.