### PR TITLE
Update client notice text

### DIFF
--- a/src/components/saveSelector.html
+++ b/src/components/saveSelector.html
@@ -14,8 +14,8 @@
                 <img alt="Check out the Wiki!" src="https://img.shields.io/badge/wiki-link-blue?logo=wikimedia-commons&style=for-the-badge">
             </a>
         </div>
-        <div id="use-our-client-message" style="color: white; display: none;">
-            To help reduce server load, please download our desktop client <b><a href="https://github.com/RedSparr0w/Pokeclicker-desktop/releases/latest" target="_blank">here</a></b>.
+        <div id="use-our-client-message" style="color: white; display: none; font-size: .875em;">
+            Play offline & improve performance by downloading our desktop client <b><a href="https://github.com/RedSparr0w/Pokeclicker-desktop/releases/latest" target="_blank">here</a></b>.
             You can even find a Pokémon exclusive to the client when you reach the Sevii Islands!<br/><br/>
         </div>
         <div class="save-container justify-content-center container row"></div>


### PR DESCRIPTION
As discussed in discord, update the client notice text on the save selector to remove mention of the dreaded _server_ word. Also reduced the font size slightly to keep it on one line for most resolutions.