### PR TITLE
Only show Silver 3 fight after clearing the burned tower quest step

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -1516,8 +1516,12 @@ class Update implements Saveable {
         },
         '0.10.3': ({ playerData, saveData }) => {
             const johtoBeastQL = saveData.quests.questLines.find((q) => q.name == 'The Legendary Beasts');
-            if (johtoBeastQL.state == 1 && johtoBeastQL.quest == 3 && johtoBeastQL.initial instanceof Array) {
+            if (johtoBeastQL && johtoBeastQL.state == 1 && johtoBeastQL.quest == 3 && johtoBeastQL.initial instanceof Array) {
                 johtoBeastQL.quest = 4;
+            }
+            // On the Rival fight, but already beat it before the quest
+            if (johtoBeastQL && johtoBeastQL.state == 1 && johtoBeastQL.quest == 2 && johtoBeastQL.initial > 0) {
+                johtoBeastQL.initial = 0;
             }
         },
     };

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -317,7 +317,7 @@ TemporaryBattleList['Silver 3'] = new TemporaryBattle(
         new GymPokemon('Bayleef', 251262, 22, new StarterRequirement(GameConstants.Region.johto, GameConstants.Starter.Water)),
     ],
     '...Humph! I\'m not fighting with another weakling ever again. It\'s just too much playing around.',
-    [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Burned Tower'))],
+    [new QuestLineStepCompletedRequirement('The Legendary Beasts', 1)],
     undefined,
     {
         displayName: 'Rival Silver',


### PR DESCRIPTION
If you had cleared Burned Tower before the RIvals update, you could beat silver 3 before that quest step and then get stuck at that step, because the fight disappears after clearing.

Changed Silver 3 temp battle to require the previous quest step, and fix softlocked saves by setting their initial to 0 (which should make it auto complete)

stuck save file example:
https://discord.com/channels/450412847017754644/1043508747689005066/1043609852980777030