### PR TITLE
Fix double escaping translated text

### DIFF
--- a/src/modules/translation/Translation.ts
+++ b/src/modules/translation/Translation.ts
@@ -62,6 +62,7 @@ export default class Translate {
                 interpolation: {
                     nestingPrefix: '[[',
                     nestingSuffix: ']]',
+                    escapeValue: false,
                 },
             });
 


### PR DESCRIPTION
Fixes translations passing in values with apostrophes, like "Let's Go Eevee" logbook entries, and having that apostrophe displayed as the raw html escaped version.

Knockout text bindings I think are doing a second round of escaping, so we don't need to be doing it when translating too.