### PR TITLE
Update handling of negative quest items after loading

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -232,8 +232,17 @@ class Game {
         // Check that none of our quest are less than their initial value
         App.game.quests.questLines().filter(q => q.state() == 1).forEach(questLine => {
             const quest = questLine.curQuestObject();
-            if (quest.initial() > quest.focus()) {
-                quest.initial(quest.focus());
+            if (quest instanceof MultipleQuestsQuest) {
+                quest.quests.forEach((q) => {
+                    if (q.initial() > q.focus()) {
+                        q.initial(q.focus());
+                    }
+                });
+            } else {
+                if (quest.initial() > quest.focus()) {
+                    quest.initial(quest.focus());
+                    questLine.curQuestInitial(quest.initial());
+                }
             }
         });
         // Check for breeding pokemons not in queue


### PR DESCRIPTION
Updates the quest line section of  `checkAndFix()` to _actually_ fix negative quest progression, specifically underground items. Previously it would "fix" the display but a refresh before completing the quest would undo progress because the updated `initial` wasn't persisted to the save file. It will also handle `MultipleQuestsQuest` quests now, previously it wouldn't update them at all.

Of course this isn't a full solution but a temporary fix until a proper solution can be implemented.