### PR TITLE
Fix real evolution challenge

### DIFF
--- a/src/modules/pokemons/evolutions/Base.ts
+++ b/src/modules/pokemons/evolutions/Base.ts
@@ -1,6 +1,4 @@
-import { Observable as KnockoutObservable } from 'knockout';
 import { StoneType } from '../../GameConstants';
-import CustomRequirement from '../../requirements/CustomRequirement';
 import LazyRequirementWrapper from '../../requirements/LazyRequirementWrapper';
 import MaxRegionRequirement from '../../requirements/MaxRegionRequirement';
 import ObtainedPokemonRequirement from '../../requirements/ObtainedPokemonRequirement';
@@ -22,7 +20,6 @@ export interface EvoData {
 }
 
 export interface LevelEvoData extends EvoData {
-    triggered: KnockoutObservable<boolean>;
 }
 
 export interface StoneEvoData extends EvoData {
@@ -30,10 +27,7 @@ export interface StoneEvoData extends EvoData {
 }
 
 export const beforeEvolve: Partial<Record<EvoTrigger, (data: EvoData) => boolean>> = {
-    [EvoTrigger.LEVEL]: (data: LevelEvoData) => {
-        data.triggered(true);
-        return true;
-    },
+    [EvoTrigger.LEVEL]: () => true,
 };
 
 export const Evo = (basePokemon: PokemonNameType, evolvedPokemon: PokemonNameType, trigger: EvoTrigger): EvoData => ({
@@ -56,15 +50,11 @@ export const restrict = <T extends EvoData>(evo: T, ...restrictions: EvoData['re
     return evo;
 };
 
-export const LevelEvolution = (basePokemon: PokemonNameType, evolvedPokemon: PokemonNameType, level: number): LevelEvoData => {
-    const triggered = ko.observable(false);
-    return restrict(
-        { ...Evo(basePokemon, evolvedPokemon, EvoTrigger.LEVEL), triggered },
-        new CustomRequirement(triggered, false, 'The evolution can\'t have already happened'),
-        new PokemonLevelRequirement(basePokemon, level),
-        new ObtainedPokemonRequirement(evolvedPokemon, true),
-    );
-};
+export const LevelEvolution = (basePokemon: PokemonNameType, evolvedPokemon: PokemonNameType, level: number): LevelEvoData => restrict(
+    { ...Evo(basePokemon, evolvedPokemon, EvoTrigger.LEVEL) },
+    new PokemonLevelRequirement(basePokemon, level),
+    new ObtainedPokemonRequirement(evolvedPokemon, true),
+);
 
 export const StoneEvolution = (basePokemon: PokemonNameType, evolvedPokemon: PokemonNameType, stone: StoneType): StoneEvoData => ({
     ...Evo(basePokemon, evolvedPokemon, EvoTrigger.STONE),

--- a/src/modules/requirements/ObtainedPokemonRequirement.ts
+++ b/src/modules/requirements/ObtainedPokemonRequirement.ts
@@ -1,6 +1,5 @@
 import { AchievementOption } from '../GameConstants';
 import Requirement from './Requirement';
-import P from '../pokemons/mapProvider';
 import { PokemonNameType } from '../pokemons/PokemonNameType';
 
 export default class ObtainedPokemonRequirement extends Requirement {
@@ -9,7 +8,7 @@ export default class ObtainedPokemonRequirement extends Requirement {
     }
 
     public getProgress() {
-        return Math.min(App.game?.statistics?.pokemonCaptured[P.pokemonMap[this.pokemon].id](), this.requiredValue);
+        return App.game.party.alreadyCaughtPokemonByName(this.pokemon) ? 1 : 0;
     }
 
     public hint(): string {

--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -121,9 +121,6 @@ class Egg implements Saveable {
 
             // If breeding (not store egg), reset level, reset evolution check
             if (partyPokemon.breeding) {
-                if (partyPokemon.evolutions !== undefined) {
-                    partyPokemon.evolutions.forEach(evo => evo.trigger === EvoTrigger.LEVEL ? (evo as LevelEvoData).triggered(false) : undefined);
-                }
                 partyPokemon.exp = 0;
                 partyPokemon.level = 1;
                 partyPokemon.breeding = false;

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -378,25 +378,9 @@ class PartyPokemon implements Saveable {
         if (json[PartyPokemonSaveKeys.megaStone]) {
             this.giveMegastone(false);
         }
-
-        if (this.evolutions != null) {
-            for (const evolution of this.evolutions) {
-                if (evolution.trigger === EvoTrigger.LEVEL) {
-                    (evolution as LevelEvoData).triggered(json[PartyPokemonSaveKeys.levelEvolutionTriggered] ?? this.defaults.levelEvolutionTriggered);
-                }
-            }
-        }
     }
 
     public toJSON() {
-        let levelEvolutionTriggered = false;
-        if (this.evolutions != null) {
-            for (const evolution of this.evolutions) {
-                if (evolution.trigger === EvoTrigger.LEVEL && (evolution as LevelEvoData).triggered()) {
-                    levelEvolutionTriggered = true;
-                }
-            }
-        }
         const output = {
             id: this.id,
             [PartyPokemonSaveKeys.attackBonusPercent]: this.attackBonusPercent,
@@ -405,7 +389,6 @@ class PartyPokemon implements Saveable {
             [PartyPokemonSaveKeys.exp]: this.exp,
             [PartyPokemonSaveKeys.breeding]: this.breeding,
             [PartyPokemonSaveKeys.shiny]: this.shiny,
-            [PartyPokemonSaveKeys.levelEvolutionTriggered]: levelEvolutionTriggered,
             [PartyPokemonSaveKeys.category]: this.category,
             [PartyPokemonSaveKeys.pokerus]: this.pokerus,
             [PartyPokemonSaveKeys.effortPoints]: this.effortPoints,


### PR DESCRIPTION
If a evolution chain has 3 pokemon, you would be locked out of the middle one, because we saved "triggered" on level evolutions. I have no idea why. We already checked on obtainedPokemon. And it even reset on breeding, for no reason...

I also changed ObtainedPokemon requirement to look at party instead of statistics, to work with this