### PR TITLE
Fix starter not getting pokerus

### DIFF
--- a/src/modules/keyItems/KeyItems.ts
+++ b/src/modules/keyItems/KeyItems.ts
@@ -4,7 +4,7 @@ import Information from '../utilities/Information';
 import KeyItemController from './KeyItemController';
 import { Feature } from '../DataStore/common/Feature';
 import {
-    getDungeonIndex, Region, ROUTE_KILLS_NEEDED, Pokerus,
+    getDungeonIndex, Region, RegionalStarters, ROUTE_KILLS_NEEDED, Pokerus,
 } from '../GameConstants';
 
 export default class KeyItems implements Feature {
@@ -56,7 +56,7 @@ export default class KeyItems implements Feature {
             new KeyItem(KeyItemType.Reins_of_unity, 'Reins that people presented to the king. They enhance Calyrex’s power over bountiful harvests and unite Calyrex with its beloved steeds.', undefined, undefined, undefined, 'Reins of Unity'),
             new KeyItem(KeyItemType.Pokerus_virus, 'A virus sample collected from the Hatchery.',
                 () => App.game.statistics.dungeonsCleared[getDungeonIndex('Distortion World')]() > 0,
-                undefined, () => { App.game.party.getPokemonById(player.regionStarters[Region.kanto]).pokerus = Pokerus.Contagious; }, 'Pokérus Virus'),
+                undefined, () => { App.game.party.getPokemon(RegionalStarters[Region.kanto][player.regionStarters[Region.kanto]()]).pokerus = Pokerus.Contagious; }, 'Pokérus Virus'),
         ];
     }
 

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -1536,6 +1536,28 @@ class Update implements Saveable {
             saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 108);
             saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 109);
             saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 110);
+
+            // Update starter pokerus status if it wasn't infected after unlocking the key item
+            if (saveData.keyItems.Pokerus_virus) {
+                let starter;
+                switch (playerData.regionStarters[0]) {
+                    case 0:
+                        starter = saveData.party.caughtPokemon.find(p => p.id == 1);
+                        break;
+                    case 1:
+                        starter = saveData.party.caughtPokemon.find(p => p.id == 4);
+                        break;
+                    case 2:
+                        starter = saveData.party.caughtPokemon.find(p => p.id == 7);
+                        break;
+                    case 3:
+                        starter = saveData.party.caughtPokemon.find(p => p.id == 25);
+                        break;
+                }
+                if (starter && (!starter[8] || starter[8] == 0)) {
+                    starter[8] = 2;
+                }
+            }
         },
     };
 


### PR DESCRIPTION
A change in #2583 broke giving the starter pokerus upon completing Distortion World the first time.

Specific change: https://github.com/pokeclicker/pokeclicker/commit/f02f836c5ace9c0a7e4a7c8b63ccb1e6beda84b8#diff-8b22427261d6967d148b73f90064b83bca790d94035dbaa69e37f6a526d86882

Bug on discord: https://discord.com/channels/450412847017754644/1044137259756179547