### PR TITLE
Fixup starter shown in Hall of fame modal

### DIFF
--- a/src/components/hallOfFame.html
+++ b/src/components/hallOfFame.html
@@ -13,7 +13,7 @@ aria-labelledby="hallOfFameModalLabel" aria-hidden="true">
                 <p data-bind="visible: player.region == GameConstants.Region.kanto">
                     So, you won! Congratulations!<br/>
                     You are the new Pokémon League champion!<br/>
-                    You have grown up so much since you first left with <span data-bind="text: PokemonHelper.getPokemonById(GameConstants.RegionalStarters[GameConstants.Region.kanto][this.starterPicked]).name">starter</span>!<br/>
+                    You have grown up so much since you first left with <span data-bind="text: PokemonHelper.getPokemonById(GameConstants.RegionalStarters[GameConstants.Region.kanto][player.regionStarters[GameConstants.Region.kanto]()]).name">starter</span>!<br/>
                     <br/>
                     There are many more regions to explore!
                 </p>


### PR DESCRIPTION
This PR should resolve the issue of the Hall of fame modal saying you started with `MissingNo.`
![image](https://user-images.githubusercontent.com/7288322/203214383-f0249389-ae0a-4f62-9ab6-5206c3ba02aa.png)

Discord bug thread: https://discord.com/channels/450412847017754644/1044048653435813898/1044048653435813898