### PR TITLE
Add Pokerus status indicator to shops & Safari Zone

### DIFF
--- a/src/components/berryMasterModal.html
+++ b/src/components/berryMasterModal.html
@@ -50,11 +50,17 @@
                                     </td>
                                     <td class='vertical-middle' data-bind='attr: { rowspan: $parent.berries.length }'>
                                         <span data-bind='text: $parent.item.amount + " × " + $parent.item.itemType.displayName'></span>
-                                        <knockout data-bind="if: ($parent.item.itemType instanceof CaughtIndicatingItem)">
-                                            <span style="float:right; margin-right: 5px"
-                                                  data-bind="template: { name: 'caughtStatusTemplate', data: {'status': $parent.item.itemType.getCaughtStatus()}}">
-                                            </span>
-                                        </knockout>
+                                        <span style="float: right; margin-right: 5px">
+                                            <knockout data-bind="if: ($parent.item.itemType instanceof CaughtIndicatingItem)">
+                                                <span data-bind="template: { name: 'caughtStatusTemplate', data: {'status': $parent.item.itemType.getCaughtStatus()}}"></span>
+                                            </knockout>
+                                            <knockout data-bind="if: ($parent.item.itemType instanceof PokemonItem)">
+                                                <span style="position: relative; top: -1px;"
+                                                    data-bind="template: { name: 'pokerusStatusTemplate',
+                                                        data: { 'pokerus': $parent.item.itemType.getPokerusStatus(), 'width': '32px' }}">
+                                                </span>
+                                            </knockout>
+                                        </span>
                                     </td>
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.berries.length }">
                                         <div class="btn-group btn-block" data-bind="let: { tradeAmount: ko.observable(1) }">

--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -6,9 +6,8 @@
                 <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': DungeonBattle.enemyPokemon() } }">Pokémon name</knockout>
                 <!-- ko if: !DungeonBattle.trainer() -->
                 <knockout data-bind="template: { name: 'caughtStatusTemplate', data: {'status': PartyController.getCaughtStatus(DungeonBattle.enemyPokemon().id)}}"></knockout>
-                <knockout data-bind="if: App.game.party.getPokemonByName(Battle.enemyPokemon().name)?.pokerus > GameConstants.Pokerus.Uninfected">
-                   <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[App.game.party.getPokemonByName(Battle.enemyPokemon().name)?.pokerus] + '.png'}"
-                  src=""/>
+                <knockout style="position: relative; top: -1px;"
+                    data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(DungeonBattle.enemyPokemon().id) }}">
                 </knockout>
                 <!-- /ko -->
             </knockout>

--- a/src/components/safariBattleModal.html
+++ b/src/components/safariBattleModal.html
@@ -13,6 +13,9 @@
                           <knockout>
                                 <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': SafariBattle.enemy } }">Pokémon name</knockout>
                                 <knockout data-bind="template: { name: 'caughtStatusTemplate', data: {'status': PartyController.getCaughtStatus(SafariBattle.enemy.id)}}"></knockout>
+                                <knockout style="position: relative; top: -1px;"
+                                    data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(SafariBattle.enemy.id) }}">
+                                </knockout>
                           </knockout>
 
                           <knockout class="right">

--- a/src/components/shopModal.html
+++ b/src/components/shopModal.html
@@ -81,6 +81,11 @@
                   placement:'bottom',
                   html: true
                 }">
+               <knockout data-bind="if: ($data instanceof PokemonItem)">
+                    <span style="position: absolute; top: 12px; left: 20px;"
+                        data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': $data.getPokerusStatus(), 'width': '32px' }}">
+                    </span>
+               </knockout>
                <knockout data-bind="if: ($data instanceof CaughtIndicatingItem)">
                    <span style="position: absolute; top: 15px; right: 20px;"
                          data-bind="template: { name: 'caughtStatusTemplate', data: {'status': $data.getCaughtStatus()}}">

--- a/src/components/templates/pokerusStatusTemplate.html
+++ b/src/components/templates/pokerusStatusTemplate.html
@@ -1,0 +1,7 @@
+<script type="text/html" id="pokerusStatusTemplate">
+    <knockout style="display: inline;">
+        <!-- ko if: $data.pokerus -->
+        <img width="" src="" data-bind="attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[$data.pokerus]}.png`, width: $data.width }"/>
+        <!-- /ko -->
+    </knockout>
+</script>

--- a/src/index.html
+++ b/src/index.html
@@ -110,6 +110,7 @@
 <!--Templates -->
 @import "templates/currencyTemplate.html"
 @import "templates/caughtStatusTemplate.html"
+@import "templates/pokerusStatusTemplate.html"
 @import "templates/eggSVGTemplate.html"
 @import "templates/multiOptionTemplate.html"
 @import "templates/pokemonNameTemplate.html"
@@ -232,9 +233,8 @@
                                 <knockout>
                                     <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': Battle.enemyPokemon() } }">Pokémon name</knockout>
                                     <knockout data-bind="template: { name: 'caughtStatusTemplate', data: {'status': PartyController.getCaughtStatus(Battle.enemyPokemon().id)}}"></knockout>
-                                    <knockout data-bind="if: App.game.party.getPokemonByName(Battle.enemyPokemon().name)?.pokerus > GameConstants.Pokerus.Uninfected">
-                                        <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[App.game.party.getPokemonByName(Battle.enemyPokemon().name)?.pokerus] + '.png'}"
-                                      src=""/>
+                                    <knockout style="position: relative; top: -1px;"
+                                        data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(Battle.enemyPokemon().id) }}">
                                     </knockout>
                                 </knockout>
                             </h2>

--- a/src/scripts/items/PokemonItem.ts
+++ b/src/scripts/items/PokemonItem.ts
@@ -56,6 +56,10 @@ class PokemonItem extends CaughtIndicatingItem {
         return PartyController.getCaughtStatusByName(this.name as PokemonNameType);
     }
 
+    getPokerusStatus(): GameConstants.Pokerus {
+        return PartyController.getPokerusStatusByName(this.name as PokemonNameType);
+    }
+
     get image() {
         const subDirectory = this.imageDirectory ? `${this.imageDirectory}/` : '';
         return `assets/images/items/${subDirectory}${this.name.replace(/[^\s\w.()-]/g, '')}.png`;

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -18,6 +18,14 @@ class PartyController {
         return CaughtStatus.NotCaught;
     }
 
+    static getPokerusStatusByName(name: PokemonNameType): GameConstants.Pokerus {
+        return this.getPokerusStatus(PokemonHelper.getPokemonByName(name).id);
+    }
+
+    static getPokerusStatus(id: number): GameConstants.Pokerus {
+        return App.game.party.getPokemon(id)?.pokerus ?? GameConstants.Pokerus.Uninfected;
+    }
+
     static getStoneEvolutionsCaughtData(id: number, evoType?: GameConstants.StoneType): { status: CaughtStatus, locked: boolean, lockHint: string }[] {
         const pokemon = App.game.party.caughtPokemon.find(p => p.id == id);
         if (pokemon) {


### PR DESCRIPTION
Added pokerus status indicator to:
- Shops
- Safari Zone battles
- Berry exchanges (Pinkan)

Also updated the following to use the pokerus status template added in this PR:
- Route battle view
- Dungeon battle view

Closes #3382 

![image](https://user-images.githubusercontent.com/672420/204130325-24e00162-ba0d-455c-8dd5-1bc78c24c917.png)
![image](https://user-images.githubusercontent.com/672420/204130332-e3a9275c-6fd7-4e27-9c9b-d6ee626acd9d.png)
![image](https://user-images.githubusercontent.com/672420/204130334-cdd307fe-3322-43e6-9e05-12d8918da087.png)
