### PR TITLE
Keeping attack achievements unlocked after reload

### DIFF
--- a/src/modules/achievements/Achievement.ts
+++ b/src/modules/achievements/Achievement.ts
@@ -22,6 +22,7 @@ export default class Achievement {
         public bonusWeight: number,
         public category: AchievementCategory,
         public achievableFunction: () => boolean | null = null,
+        public stored : boolean = false,
     ) {}
 
     public check() {

--- a/src/modules/achievements/Achievement.ts
+++ b/src/modules/achievements/Achievement.ts
@@ -1,5 +1,6 @@
 import {
     Computed as KnockoutComputed,
+    Observable as KnockoutObservable,
 } from 'knockout';
 import NotificationConstants from '../notifications/NotificationConstants';
 import Notifier from '../notifications/Notifier';
@@ -10,10 +11,10 @@ import { createLogContent } from '../logbook/helpers';
 import AchievementCategory from './AchievementCategory';
 
 export default class Achievement {
-    public isCompleted: KnockoutComputed<boolean> = ko.pureComputed(() => this.achievable() && (this.unlocked || this.property.isCompleted()));
+    public isCompleted: KnockoutComputed<boolean> = ko.pureComputed(() => this.achievable() && (this.unlocked() || this.property.isCompleted()));
     public getProgressText: KnockoutComputed<string> = ko.pureComputed(() => `${this.getProgress().toLocaleString('en-US')} / ${this.property.requiredValue.toLocaleString('en-US')}`);
     public bonus = 0;
-    public unlocked = false;
+    public unlocked : KnockoutObservable<boolean> = ko.observable(false);
 
     constructor(
         public name: string,
@@ -39,7 +40,7 @@ export default class Achievement {
                 LogBookTypes.ACHIEVE,
                 createLogContent.earnedAchievement({ name: this.name }),
             );
-            this.unlocked = true;
+            this.unlocked(true);
             // TODO: refilter within achievement bonus
             // AchievementHandler.filterAchievementList(true);
             // Track when users gains an achievement and their total playtime

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -57,16 +57,18 @@ class Game {
         const saveObject = JSON.parse(saveJSON || '{}');
 
         Object.keys(this).filter(key => this[key]?.saveKey).forEach(key => {
-            if (key !== "achievements") {
-                try {
-                    const saveKey = this[key].saveKey;
-                    // Load our save object or the default save data
-                    this[key].fromJSON(saveObject[saveKey] || this[key].toJSON());
-                } catch (error) {
-                    console.error('Unable to load sava data from JSON for:', key, '\nError:\n', error);
-                }
-            } else {
-                Object.keys(saveObject["achievements"]).forEach(achName => AchievementHandler.findByName(achName)?.unlocked = true);
+            try {
+                const saveKey = this[key].saveKey;
+                // Load our save object or the default save data
+                this[key].fromJSON(saveObject[saveKey] || this[key].toJSON());
+            } catch (error) {
+                console.error('Unable to load sava data from JSON for:', key, '\nError:\n', error);
+            }
+        });
+        saveObject.achievements?.forEach(achName => {
+            const ach = AchievementHandler.findByName(achName);
+            if (ach) {
+                ach.unlocked(true);
             }
         });
     }

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -57,12 +57,16 @@ class Game {
         const saveObject = JSON.parse(saveJSON || '{}');
 
         Object.keys(this).filter(key => this[key]?.saveKey).forEach(key => {
-            try {
-                const saveKey = this[key].saveKey;
-                // Load our save object or the default save data
-                this[key].fromJSON(saveObject[saveKey] || this[key].toJSON());
-            } catch (error) {
-                console.error('Unable to load sava data from JSON for:', key, '\nError:\n', error);
+            if (key !== "achievements") {
+                try {
+                    const saveKey = this[key].saveKey;
+                    // Load our save object or the default save data
+                    this[key].fromJSON(saveObject[saveKey] || this[key].toJSON());
+                } catch (error) {
+                    console.error('Unable to load sava data from JSON for:', key, '\nError:\n', error);
+                }
+            } else {
+                Object.keys(saveObject["achievements"]).forEach(achName => AchievementHandler.findByName(achName)?.unlocked = true);
             }
         });
     }

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -15,10 +15,15 @@ class Save {
     }
 
     public static getSaveObject() {
-        const saveObject = {};
+        const saveObject = {achievements : {}};
 
         Object.keys(App.game).filter(key => App.game[key].saveKey).forEach(key => {
             saveObject[App.game[key].saveKey] = App.game[key].toJSON();
+        });
+        AchievementHandler.achievementList.forEach(achievement => {
+            if (achievement.stored && achievement.unlocked) {
+                saveObject.achievements[achievement.name] = true;
+            }
         });
 
         return saveObject;

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -15,16 +15,19 @@ class Save {
     }
 
     public static getSaveObject() {
-        const saveObject = {achievements : {}};
+        const saveObject = {achievements : []};
 
         Object.keys(App.game).filter(key => App.game[key].saveKey).forEach(key => {
             saveObject[App.game[key].saveKey] = App.game[key].toJSON();
         });
         AchievementHandler.achievementList.forEach(achievement => {
-            if (achievement.stored && achievement.unlocked) {
-                saveObject.achievements[achievement.name] = true;
+            if (achievement.stored && achievement.unlocked()) {
+                saveObject.achievements.push(achievement.name);
             }
         });
+        if (!saveObject.achievements.length) {
+            delete saveObject.achievements;
+        }
 
         return saveObject;
     }

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -249,17 +249,17 @@ class AchievementHandler {
         AchievementHandler.addAchievement('The Cake Is a Lie, but the Grind Is Real', 'Defeat 100,000 Pokémon.', new DefeatedRequirement(100000), 0.25);
         AchievementHandler.addAchievement('Are There Any Left?', 'Defeat 1,000,000 Pokémon.', new DefeatedRequirement(1000000), 0.50);
 
-        AchievementHandler.addAchievement('Basic Trainer', 'Have 100 Attack.', new AttackRequirement(100), 0.05);
-        AchievementHandler.addAchievement('Improving', 'Have 1,000 Attack.', new AttackRequirement(1000), 0.10);
-        AchievementHandler.addAchievement('An Unrelenting Force', 'Have 5,000 Attack.', new AttackRequirement(5000), 0.15);
-        AchievementHandler.addAchievement('FUS DOH RAH', 'Have 10,000 Attack.', new AttackRequirement(10000), 0.20);
-        AchievementHandler.addAchievement('OK, I Have Enough Attack Already...', 'Have 25,000 Attack.', new AttackRequirement(25000), 0.25);
-        AchievementHandler.addAchievement('Silver Attack Button!', 'Have 100,000 Attack.', new AttackRequirement(100000), 0.30);
-        AchievementHandler.addAchievement('Pesky Roamers, I Need to One-Shot Routes for Them...', 'Have 250,000 Attack.', new AttackRequirement(250000), 0.35);
-        AchievementHandler.addAchievement('You Pressed F12 by Any Chance?', 'Have 500,000 Attack.', new AttackRequirement(500000), 0.40);
-        AchievementHandler.addAchievement('Left-Left-Right-Right-A-B-A-B - Hey, 1 Million!', 'Have 1,000,000 Attack.', new AttackRequirement(1000000), 0.40);
-        AchievementHandler.addAchievement('Can I Beat Diantha Yet?', 'Have 5,000,000 Attack.', new AttackRequirement(5000000), 0.45);
-        AchievementHandler.addAchievement('No One Can Challenge Me!', 'Have 20,000,000 Attack.', new AttackRequirement(20000000), 0.60);
+        AchievementHandler.addAchievement('Basic Trainer', 'Have 100 Attack.', new AttackRequirement(100), 0.05, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('Improving', 'Have 1,000 Attack.', new AttackRequirement(1000), 0.10, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('An Unrelenting Force', 'Have 5,000 Attack.', new AttackRequirement(5000), 0.15, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('FUS DOH RAH', 'Have 10,000 Attack.', new AttackRequirement(10000), 0.20, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('OK, I Have Enough Attack Already...', 'Have 25,000 Attack.', new AttackRequirement(25000), 0.25, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('Silver Attack Button!', 'Have 100,000 Attack.', new AttackRequirement(100000), 0.30, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('Pesky Roamers, I Need to One-Shot Routes for Them...', 'Have 250,000 Attack.', new AttackRequirement(250000), 0.35, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('You Pressed F12 by Any Chance?', 'Have 500,000 Attack.', new AttackRequirement(500000), 0.40, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('Left-Left-Right-Right-A-B-A-B - Hey, 1 Million!', 'Have 1,000,000 Attack.', new AttackRequirement(1000000), 0.40, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('Can I Beat Diantha Yet?', 'Have 5,000,000 Attack.', new AttackRequirement(5000000), 0.45, GameConstants.ExtraAchievementCategories.global, null, true);
+        AchievementHandler.addAchievement('No One Can Challenge Me!', 'Have 20,000,000 Attack.', new AttackRequirement(20000000), 0.60, GameConstants.ExtraAchievementCategories.global, null, true);
 
         AchievementHandler.addAchievement('A Few Clicks In', 'Click Attack 10 times.', new ClickRequirement(10, 1), 0.02, GameConstants.ExtraAchievementCategories.global, () => !challenges.list.disableClickAttack.active());
         AchievementHandler.addAchievement('Clicking Pro', 'Click Attack 100 times.', new ClickRequirement(100, 1), 0.05, GameConstants.ExtraAchievementCategories.global, () => !challenges.list.disableClickAttack.active());

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -70,7 +70,7 @@ class AchievementHandler {
         this.achievementListFiltered(this.achievementList.filter((a) => (
             a.category.isUnlocked() &&
             a.achievable() &&
-            (this.filter.status() == -2 || a.unlocked === !!this.filter.status()) &&
+            (this.filter.status() == -2 || a.unlocked() === !!this.filter.status()) &&
             (this.filter.type()   == -2 || a.property.achievementType === this.filter.type()) &&
             (this.filter.category() == 'all' || a.category.name === this.filter.category())
         )));
@@ -113,19 +113,19 @@ class AchievementHandler {
     public static preCheckAchievements() {
         // Check if our achievements are completed, we don't want to re-notify if already done
         for (let i = 0; i < AchievementHandler.achievementList.length; i++) {
-            AchievementHandler.achievementList[i].unlocked = AchievementHandler.achievementList[i].isCompleted();
+            AchievementHandler.achievementList[i].unlocked(AchievementHandler.achievementList[i].isCompleted());
         }
     }
 
     public static checkAchievements() {
         for (let i = 0; i < AchievementHandler.achievementList.length; i++) {
-            if (!AchievementHandler.achievementList[i].unlocked) {
+            if (!AchievementHandler.achievementList[i].unlocked()) {
                 AchievementHandler.achievementList[i].check();
             }
         }
     }
 
-    public static addAchievement(name: string, description: string, property: AchievementRequirement, bonus: number, category: GameConstants.Region | GameConstants.ExtraAchievementCategories = GameConstants.ExtraAchievementCategories.global, achievableFunction: () => boolean | null = null) {
+    public static addAchievement(name: string, description: string, property: AchievementRequirement, bonus: number, category: GameConstants.Region | GameConstants.ExtraAchievementCategories = GameConstants.ExtraAchievementCategories.global, achievableFunction: () => boolean | null = null, stored = false) {
         let categoryObj : AchievementCategory;
         // ExtraAchievementCategory always starts at finals index
         if (category >= GameConstants.Region.final) {
@@ -134,7 +134,7 @@ class AchievementHandler {
             categoryObj = AchievementHandler.getAchievementCategoryByRegion(category as GameConstants.Region);
         }
         categoryObj.totalWeight += bonus;
-        AchievementHandler.achievementList.push(new Achievement(name, description, property, bonus, categoryObj, achievableFunction));
+        AchievementHandler.achievementList.push(new Achievement(name, description, property, bonus, categoryObj, achievableFunction, stored));
     }
 
     public static calculateBonus(): void {


### PR DESCRIPTION
I have provided a generic solution to ephemeral achievements. Only used on attack achievements for now.

I had to change `unlocked` from boolean to observable\<boolean\> or the computed `isCompleted` kept overwriting it anyway. I changed that attribute calls anywhere I could find them but tell me if I missed some.