### PR TITLE
[FEATURE?] Dummy evolutions

### DIFF
--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -23,7 +23,7 @@ import {
     Region, StoneType, Genders, MaxIDPerRegion,
 } from '../GameConstants';
 import BagItem from '../interfaces/BagItem';
-import { EvoData, LevelEvolution, StoneEvolution } from './evolutions/Base';
+import { EvoData, DummyEvolution, LevelEvolution, StoneEvolution } from './evolutions/Base';
 import LevelType from '../party/LevelType';
 import GenericProxy from '../utilities/GenericProxy';
 import Rand from '../utilities/Rand';
@@ -780,9 +780,9 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 15,
         'evolutions': [
             LevelEvolution('Metapod', 'Butterfree', 10),
-            LevelEvolution('Metapod', 'Valencian Butterfree', 10000),
-            LevelEvolution('Metapod', 'Pink Butterfree', 10000),
-            LevelEvolution('Metapod', 'Ash\'s Butterfree', 10000),
+            DummyEvolution('Metapod', 'Valencian Butterfree'),
+            DummyEvolution('Metapod', 'Pink Butterfree'),
+            DummyEvolution('Metapod', 'Ash\'s Butterfree'),
         ],
         'base': {
             'hitpoints': 50,
@@ -1095,7 +1095,7 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 15,
         'evolutions': [
             LevelEvolution('Rattata', 'Raticate', 20),
-            LevelEvolution('Rattata', 'Valencian Raticate', 20000),
+            DummyEvolution('Rattata', 'Valencian Raticate'),
         ],
         'base': {
             'hitpoints': 30,
@@ -1286,7 +1286,7 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 20,
         'evolutions': [
             LevelEvolution('Ekans', 'Arbok', 22),
-            LevelEvolution('Ekans', 'Pinkan Arbok', 22000),
+            DummyEvolution('Ekans', 'Pinkan Arbok'),
         ],
         'base': {
             'hitpoints': 35,
@@ -1636,7 +1636,7 @@ export const pokemonList = createPokemonArray(
         'levelType': LevelType.mediumfast,
         'exp': 112,
         'eggCycles': 10,
-        'evolutions': [LevelEvolution('Detective Pikachu', 'Detective Raichu', 1234)],
+        'evolutions': [DummyEvolution('Detective Pikachu', 'Detective Raichu')],
         'base': {
             'hitpoints': 35,
             'attack': 55,
@@ -1909,7 +1909,7 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 20,
         'evolutions': [
             StoneEvolution('Nidorino', 'Nidoking', StoneType.Moon_stone),
-            LevelEvolution('Nidorino', 'Pinkan Nidoking', 33000),
+            DummyEvolution('Nidorino', 'Pinkan Nidoking'),
         ],
         'base': {
             'hitpoints': 61,
@@ -2218,8 +2218,8 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 20,
         'evolutions': [
             StoneEvolution('Gloom', 'Vileplume', StoneType.Leaf_stone),
-            LevelEvolution('Gloom', 'Valencian Vileplume', 44000),
-            LevelEvolution('Gloom', 'Pinkan Vileplume', 44000),
+            DummyEvolution('Gloom', 'Valencian Vileplume'),
+            DummyEvolution('Gloom', 'Pinkan Vileplume'),
             StoneEvolution('Gloom', 'Bellossom', StoneType.Sun_stone),
         ],
         'base': {
@@ -2766,7 +2766,7 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 20,
         'evolutions': [
             LevelEvolution('Poliwag', 'Poliwhirl', 25),
-            LevelEvolution('Poliwag', 'Pinkan Poliwhirl', 25000),
+            DummyEvolution('Poliwag', 'Pinkan Poliwhirl'),
         ],
         'base': {
             'hitpoints': 40,
@@ -3006,7 +3006,7 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 20,
         'evolutions': [
             LevelEvolution('Bellsprout', 'Weepinbell', 21),
-            LevelEvolution('Bellsprout', 'Valencian Weepinbell', 21000),
+            DummyEvolution('Bellsprout', 'Valencian Weepinbell'),
         ],
         'base': {
             'hitpoints': 50,
@@ -3519,7 +3519,7 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 20,
         'evolutions': [
             LevelEvolution('Doduo', 'Dodrio', 31),
-            LevelEvolution('Doduo', 'Pinkan Dodrio', 31000),
+            DummyEvolution('Doduo', 'Pinkan Dodrio'),
         ],
         'base': {
             'hitpoints': 35,
@@ -3985,7 +3985,7 @@ export const pokemonList = createPokemonArray(
         'evolutions': [
             RegionStoneEvolution(allButAlola, 'Exeggcute', 'Exeggutor', StoneType.Leaf_stone),
             RegionStoneEvolution(alolaOnly, 'Exeggcute', 'Alolan Exeggutor', StoneType.Leaf_stone),
-            LevelEvolution('Exeggcute', 'Pinkan Exeggutor', 31000),
+            DummyEvolution('Exeggcute', 'Pinkan Exeggutor'),
         ],
         'base': {
             'hitpoints': 60,
@@ -4193,7 +4193,7 @@ export const pokemonList = createPokemonArray(
         'evolutions': [
             RegionLevelEvolution(allButGalar, 'Koffing', 'Weezing', 35),
             RegionLevelEvolution(galarOnly, 'Koffing', 'Galarian Weezing', 35),
-            LevelEvolution('Koffing', 'Pinkan Weezing', 35000),
+            DummyEvolution('Koffing', 'Pinkan Weezing'),
         ],
         'base': {
             'hitpoints': 40,
@@ -14536,8 +14536,8 @@ export const pokemonList = createPokemonArray(
         'eggCycles': 40,
         'levelType': LevelType.slow,
         'exp': 216,
-        // 69420 to prevent evolution ingame, evolution needed for baby form to be obtainable
-        'evolutions': [LevelEvolution('Phione', 'Manaphy', 69420)],
+        // evolution needed for baby form to be obtainable
+        'evolutions': [DummyEvolution('Phione', 'Manaphy')],
         'baby': true,
         'catchRate': 30,
         'base': {
@@ -16168,7 +16168,7 @@ export const pokemonList = createPokemonArray(
         'catchRate': 120,
         'evolutions': [
             LevelEvolution('Darumaka', 'Darmanitan', 35),
-            LevelEvolution('Darumaka', 'Darmanitan (Zen)', 1234),
+            DummyEvolution('Darumaka', 'Darmanitan (Zen)'),
         ],
         'base': {
             'hitpoints': 70,
@@ -16190,7 +16190,7 @@ export const pokemonList = createPokemonArray(
         'catchRate': 120,
         'evolutions': [
             StoneEvolution('Galarian Darumaka', 'Galarian Darmanitan', StoneType.Ice_stone),
-            LevelEvolution('Galarian Darumaka', 'Galarian Darmanitan (Zen)', 1234),
+            DummyEvolution('Galarian Darumaka', 'Galarian Darmanitan (Zen)'),
         ],
         'base': {
             'hitpoints': 70,
@@ -19691,7 +19691,7 @@ export const pokemonList = createPokemonArray(
         'catchRate': 90,
         'evolutions': [
             StoneEvolution('Doublade', 'Aegislash (Shield)', StoneType.Dusk_stone),
-            LevelEvolution('Doublade', 'Aegislash (Blade)', 4777),
+            DummyEvolution('Doublade', 'Aegislash (Blade)'),
         ],
         'base': {
             'hitpoints': 59,

--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -23,7 +23,9 @@ import {
     Region, StoneType, Genders, MaxIDPerRegion,
 } from '../GameConstants';
 import BagItem from '../interfaces/BagItem';
-import { EvoData, DummyEvolution, LevelEvolution, StoneEvolution } from './evolutions/Base';
+import {
+    EvoData, DummyEvolution, LevelEvolution, StoneEvolution,
+} from './evolutions/Base';
 import LevelType from '../party/LevelType';
 import GenericProxy from '../utilities/GenericProxy';
 import Rand from '../utilities/Rand';

--- a/src/modules/pokemons/evolutions/Base.ts
+++ b/src/modules/pokemons/evolutions/Base.ts
@@ -8,6 +8,7 @@ import { calcNativeRegion } from '../PokemonHelper';
 import { PokemonNameType } from '../PokemonNameType';
 
 export enum EvoTrigger {
+    NONE,
     LEVEL,
     STONE,
 }
@@ -17,6 +18,9 @@ export interface EvoData {
     evolvedPokemon: PokemonNameType;
     trigger: EvoTrigger;
     restrictions: Array<Requirement>;
+}
+
+export interface DummyEvoData extends EvoData {
 }
 
 export interface LevelEvoData extends EvoData {
@@ -49,6 +53,10 @@ export const restrict = <T extends EvoData>(evo: T, ...restrictions: EvoData['re
     evo.restrictions.push(...restrictions);
     return evo;
 };
+
+export const DummyEvolution = (basePokemon: PokemonNameType, evolvedPokemon: PokemonNameType): DummyEvoData => ({
+    ...Evo(basePokemon, evolvedPokemon, EvoTrigger.NONE),
+});
 
 export const LevelEvolution = (basePokemon: PokemonNameType, evolvedPokemon: PokemonNameType, level: number): LevelEvoData => restrict(
     { ...Evo(basePokemon, evolvedPokemon, EvoTrigger.LEVEL) },

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -221,6 +221,10 @@ class PokemonHelper extends TmpPokemonHelper {
         const prevolutionPokemon = pokemonList.filter((p: PokemonListData) => p.evolutions?.find(e => e.evolvedPokemon == pokemonName));
         prevolutionPokemon.forEach((p: PokemonListData) => p.evolutions.forEach(e => {
             if (e.evolvedPokemon == pokemonName) {
+                // ignore dummy evolutions
+                if (e.trigger === EvoTrigger.NONE) {
+                    return false;
+                }
                 if (maxRegion != GameConstants.Region.none && p.nativeRegion > maxRegion) {
                     return false;
                 }


### PR DESCRIPTION
This PR implements dummy evolutions. These evolutions have a new evolution trigger: `EvoTrigger.NONE`.
They are skipped by `PokemonHelper.getPokemonPrevolution` and should therefore not show up in the bot's data.
However, this would also remove them from the bot quiz. If this is not wanted, I can look for an alternative solution.

This closes #3494.