### PR TITLE
[FEATURE] Keep EXP/level in real evolution challenge

### DIFF
--- a/src/scripts/party/evolutions/EvolutionHandler.ts
+++ b/src/scripts/party/evolutions/EvolutionHandler.ts
@@ -43,6 +43,7 @@ class EvolutionHandler {
         const evolvedPartyPokemon = App.game.party.getPokemonByName(evolvedPokemon);
         if (newPokemon && App.game.challenges.list.realEvolutions.active()) {
             const basePartyPokemon = App.game.party.getPokemon(PokemonHelper.getPokemonByName(data.basePokemon).id);
+            evolvedPartyPokemon.exp = basePartyPokemon.exp;
             evolvedPartyPokemon.effortPoints = basePartyPokemon.effortPoints;
             evolvedPartyPokemon.pokerus = basePartyPokemon.pokerus;
             evolvedPartyPokemon.shiny = evolvedPartyPokemon.shiny || basePartyPokemon.shiny;


### PR DESCRIPTION
Transfers the EXP to the evolved Pokémon. According to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Experience#Relation_to_level), experience types are consistent within evolutionary families.
This closes #3439.