### PR TITLE
Change egg default setting to egg step instead of percentage 

### DIFF
--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -63,7 +63,7 @@ Settings.add(new Setting<string>('breedingDisplay', 'Breeding progress display',
         new SettingOption('Percentage', 'percentage'),
         new SettingOption('Step count', 'stepCount'),
     ],
-    'percentage'));
+    'stepCount'));
 Settings.add(new Setting<string>('shopButtons', 'Shop amount buttons',
     [
         new SettingOption('+10, +100', 'original'),


### PR DESCRIPTION
Right now egg is percentage by default. This setting give very few information and is confusing for new players (seen 2 confusions with it today) so if accepted this change set egg step as default

Was it what you mean pixl? XD