### PR TITLE
Update function to auto-start Suicune quest for people in the middle of the Legendary Beasts quest

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -1874,6 +1874,22 @@ class Update implements Saveable {
                     saveData.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('The Darkest Day')] = 0;
                 }
             }
+            // Suicune Quest autostart for players too far in Legendary Beasts quest
+            const johtoBeastsQuestLine = saveData.quests.questLines.find((q) => q.name == 'The Legendary Beasts');
+            const johtoSuicuneQuestLine = saveData.quests.questLines.find((q) => q.name == 'Eusine\'s Chase');
+            if (johtoBeastsQuestLine?.state == 4 || (johtoBeastsQuestLine?.state == 1 && johtoBeastsQuestLine?.quest >= 4)) {
+                if (!johtoSuicuneQuestLine) {
+                // add to array
+                    saveData.quests.questLines.push({
+                        state: 1,
+                        name: 'Eusine\'s Chase',
+                        quest: 0,
+                    });
+                } else if (johtoSuicuneQuestLine.state == 0) {
+                // activate quest
+                    johtoSuicuneQuestLine.state = 1;
+                }
+            }
         },
     };
 


### PR DESCRIPTION
This update function will ensure that if people have gone too far in the Legendary Beasts to trigger the auto-start of the Suicune quest without having started said quest, the update will start it for them.

Tested on every step of hte Legendary Beasts questline to ensure it starts at the right time, and tested on saves that have completed both to make sure it doesn't auto start the quest for a second time.