### PR TITLE
Refactor code to other visibilitychange listener, only hide game element

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -332,12 +332,16 @@ class Game {
             // use a setTimeout to queue the event
             this.worker?.addEventListener('message', () => Settings.getSetting('useWebWorkerForGameTicks').value ? this.gameTick() : null);
 
-            // Let our worker know if the page is visible or not
             document.addEventListener('visibilitychange', () => {
+                // Let our worker know if the page is visible or not
                 if (pageHidden != document.hidden) {
                     pageHidden = document.hidden;
                     this.worker.postMessage({'pageHidden': pageHidden});
                 }
+
+                // Save resources by not displaying updates if game is not currently visible
+                const gameEl = document.getElementById('game');
+                document.hidden ? gameEl.classList.add('hidden') : gameEl.classList.remove('hidden');
             });
             this.worker.postMessage({'pageHidden': pageHidden});
             if (this.worker) {

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -20,13 +20,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     // Load list of saves
     SaveSelector.loadSaves();
-
-    // Save resources by not displaying updates if game is not currently visible
-    try {
-        document.addEventListener('visibilitychange', () => {
-            document.hidden ? document.body.classList.add('hidden') : document.body.classList.remove('hidden');
-        });
-    } catch (e) {}
 });
 
 // Nested modals can be opened while they are in the middle of hiding.


### PR DESCRIPTION
Instead of hiding everything, this will only hide the main game element,
So it should be less jarring when tabbing back into the game.
![image](https://user-images.githubusercontent.com/7288322/206937504-87544e61-80f8-403e-9fa4-790837d26eb1.png)
