### PR TITLE
Increase mega evo requirement

### DIFF
--- a/src/scripts/party/Megastone.ts
+++ b/src/scripts/party/Megastone.ts
@@ -5,7 +5,7 @@ class MegaStone {
     private attackRequired: number;
 
     constructor(public pokemonId: number, pokemonBaseAttack: number, private pokemonAttack: KnockoutObservable<number>) {
-        this.attackRequired = pokemonBaseAttack * 100;
+        this.attackRequired = pokemonBaseAttack * 500;
     }
 
     public getImage() {


### PR DESCRIPTION
Devs are in conclusion that the attack threshold required to Mega Evolve Pokemon with the Key Stone was too low, resulting in a requirement that many later game players wouldn't even notice.

The previous requirement was to increase the Pokemon's attack to `100x` its base. The requirement is now `500x`.