### PR TITLE
Add confirmation when restarting Battle Frontier run

### DIFF
--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -27,7 +27,7 @@ class BattleFrontierRunner {
     public static async start(useCheckpoint: boolean) {
         if (!useCheckpoint && this.hasCheckpoint()) {
             if (!await Notifier.confirm({
-                title: 'Battle Frontier',
+                title: 'Restart Battle Frontier?',
                 message: 'Current progress will be lost and you will restart from the first stage.',
                 type: NotificationConstants.NotificationOption.warning,
                 confirm: 'OK',

--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -24,7 +24,18 @@ class BattleFrontierRunner {
         this.timeLeftPercentage(Math.floor(this.timeLeft() / GameConstants.GYM_TIME * 100));
     }
 
-    public static start(useCheckpoint: boolean) {
+    public static async start(useCheckpoint: boolean) {
+        if (!useCheckpoint && this.hasCheckpoint()) {
+            if (!await Notifier.confirm({
+                title: 'Battle Frontier',
+                message: 'Current progress will be lost and you will restart from the first stage.',
+                type: NotificationConstants.NotificationOption.warning,
+                confirm: 'OK',
+            })) {
+                return;
+            }
+        }
+
         this.started(true);
         this.stage(useCheckpoint ? this.checkpoint() : 1);
         this.highest(App.game.statistics.battleFrontierHighestStageCompleted());


### PR DESCRIPTION
Adds a confirmation dialog to BF when clicking Start while having a checkpoint. Prevents accidentally losing your checkpoint.