### PR TITLE
Clear Safari battle state when modal closed

### DIFF
--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -416,6 +416,8 @@ class Safari {
 
 document.addEventListener('DOMContentLoaded', () => {
     $('#safariModal').on('hide.bs.modal', () => {
+        Safari.inBattle(false);
+        SafariBattle.busy(false);
         MapHelper.moveToTown('Fuchsia City');
     });
 });


### PR DESCRIPTION
Unlocking the Holo Caster key item (110 unique pokemon) by capturing a pokemon in the Safari zone forces the Safari modal to close to display the new key item modal. This causes the Safari battle state to remain as `true` preventing any interaction (movement, leaving) upon re-entering the Safari zone requiring the player to reload.

Discord bug thread: https://discord.com/channels/450412847017754644/1057809832628977765