### PR TITLE
Include amount of each color Dream Orb obtained in notification

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -168,13 +168,17 @@ class Game {
                 const orbsUnlocked = App.game.dreamOrbController.orbs.filter((o) => !o.requirement || o.requirement.isCompleted());
                 const orbsEarned = Math.floor(timeDiffOverride / 3600);
                 if (orbsEarned > 0) {
+                    const orbAmounts = Object.fromEntries(orbsUnlocked.map(o => [o.color, 0]));
                     for (let i = 0; i < orbsEarned; i++) {
-                        GameHelper.incrementObservable(Rand.fromArray(orbsUnlocked).amount);
+                        const orb = Rand.fromArray(orbsUnlocked);
+                        GameHelper.incrementObservable(orb.amount);
+                        orbAmounts[orb.color]++;
                     }
+                    const messageAppend = Object.keys(orbAmounts).map(key => `<li>${orbAmounts[key]} ${key}</li>`).join('');
                     Notifier.notify({
                         type: NotificationConstants.NotificationOption.info,
                         title: 'Dream Orbs',
-                        message: `Gained ${orbsEarned} Dream Orbs while offline.`,
+                        message: `Gained ${orbsEarned} Dream Orbs while offline:<br /><ul style="margin-bottom: 0;">${messageAppend}</ul>`,
                         timeout: 2 * GameConstants.MINUTE,
                         setting: NotificationConstants.NotificationSetting.General.offline_earnings,
                     });

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -178,7 +178,7 @@ class Game {
                     Notifier.notify({
                         type: NotificationConstants.NotificationOption.info,
                         title: 'Dream Orbs',
-                        message: `Gained ${orbsEarned} Dream Orbs while offline:<br /><ul style="margin-bottom: 0;">${messageAppend}</ul>`,
+                        message: `Gained ${orbsEarned} Dream Orbs while offline:<br /><ul class="mb-0">${messageAppend}</ul>`,
                         timeout: 2 * GameConstants.MINUTE,
                         setting: NotificationConstants.NotificationSetting.General.offline_earnings,
                     });


### PR DESCRIPTION
Updated the Dream Orb notification to list the amount of each color obtained while offline.

![image](https://user-images.githubusercontent.com/672420/209912601-5a6ef01c-dcdc-4e9b-8ca9-9c10e66c03a5.png)
