### PR TITLE
Mega Mewtwo and Gengar fix

### DIFF
--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -3777,7 +3777,7 @@ export const pokemonList = createPokemonArray(
     {
         'id': 94.01,
         'name': 'Mega Gengar',
-        'type': [PokemonType.Poison, PokemonType.Ghost],
+        'type': [PokemonType.Ghost, PokemonType.Poison],
         'eggCycles': 20,
         'levelType': LevelType.mediumslow,
         'exp': 207,
@@ -6086,7 +6086,7 @@ export const pokemonList = createPokemonArray(
         },
     },
     {
-        'id': 150.01,
+        'id': 150.02,
         'name': 'Mega Mewtwo Y',
         'type': [PokemonType.Psychic],
         'eggCycles': 120,


### PR DESCRIPTION
Fixes Mega Gengar having its types flipped, and both Mega Mewtwos having the same ID