### PR TITLE
Add `gainPokemonByName` method

### DIFF
--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -40,6 +40,11 @@ class Party implements Feature {
 
     }
 
+    gainPokemonByName(name: PokemonNameType, shiny = false, suppressNotification = false, gender = -1) {
+        const pokemon = pokemonMap[name];
+        this.gainPokemonById(pokemon.id, shiny, suppressNotification, gender);
+    }
+
     gainPokemonById(id: number, shiny = false, suppressNotification = false, gender = -1) {
         // If no gender defined, calculate it
         if (gender === -1) {


### PR DESCRIPTION
This PR adds a `gainPokemonByName()` method to `Party`, this way we can instead use the Pokémon name rather than ID so we don't end up with more MissingNo.