### PR TITLE
Fix numeric settings loading

### DIFF
--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,7 +1,8 @@
 // Get our polyfills loaded first
 import './polyfill';
 
-import './temporaryWindowInjection';
-
 // Ensure that the Knockout Extenders are injected
 import './koExtenders';
+
+// Load everything else
+import './temporaryWindowInjection';


### PR DESCRIPTION
Import our knockout bindings before the modules.
This should fix the settings not loading correctly.
The numeric settings were being loaded as strings, which was causing them to display incorrectly.

closes #3677 