### PR TITLE
Update function to give player missing reward Pokemon

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -1901,9 +1901,9 @@ class Update implements Saveable {
             Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'Unfinished Business', 8, 172.01);
             Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'Princess Diancie', 6, 681.01);
             Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'A Mystery Gift', 1, 801.01);
-            Update.giveMissingTempBattleRewardPokemon(saveData, 'Ash Ketchum Pinkan', 25.14);
-            Update.giveMissingTempBattleRewardPokemon(saveData, 'Ash Ketchum Alola', 25.08);
-            if (saveData.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Tower of Waters')] > 0) {
+            Update.giveMissingTempBattleRewardPokemon(saveData, 123, 25.14); // Ash Ketchum Pinkan
+            Update.giveMissingTempBattleRewardPokemon(saveData, 151, 25.08); // Ash Ketchum Alola
+            if (saveData.statistics.dungeonsCleared[157] > 0) { // Tower of Waters
                 Update.giveMissingPokemon(saveData, 892.01);
             }
         },
@@ -2316,8 +2316,7 @@ class Update implements Saveable {
         }
     }
 
-    static giveMissingTempBattleRewardPokemon(saveData, tempBattleName: string, pokemonId: number) {
-        const tempBattleIndex = GameConstants.getTemporaryBattlesIndex(tempBattleName);
+    static giveMissingTempBattleRewardPokemon(saveData, tempBattleIndex: number, pokemonId: number) {
         if (saveData.statistics.temporaryBattleDefeated[tempBattleIndex] > 0) {
             Update.giveMissingPokemon(saveData, pokemonId);
         }

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -1897,6 +1897,15 @@ class Update implements Saveable {
         },
 
         '0.10.6': ({ playerData, saveData }) => {
+            // Give the player any missing questline or temporary battle rewards
+            Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'Unfinished Business', 8, 172.01);
+            Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'Princess Diancie', 6, 681.01);
+            Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'A Mystery Gift', 1, 801.01);
+            Update.giveMissingTempBattleRewardPokemon(saveData, 'Ash Ketchum Pinkan', 25.14);
+            Update.giveMissingTempBattleRewardPokemon(saveData, 'Ash Ketchum Alola', 25.08);
+            if (saveData.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Tower of Waters')] > 0) {
+                Update.giveMissingPokemon(saveData, 892.01);
+            }
         },
     };
 
@@ -2297,6 +2306,27 @@ class Update implements Saveable {
         } else {
             // Push the quest, doesn't exist in save data yet
             saveData.quests.questLines.push({ state: 1, name: questLineName, quest: 0 });
+        }
+    }
+
+    static giveMissingQuestLineProgressRewardPokemon(saveData, questLineName: string, questStep: number, pokemonId: number) {
+        const quest = saveData.quests.questLines.find((q) => q.name == questLineName);
+        if (quest?.state == 2 || (quest?.state == 1 && quest?.quest >= questStep)) {
+            Update.giveMissingPokemon(saveData, pokemonId);
+        }
+    }
+
+    static giveMissingTempBattleRewardPokemon(saveData, tempBattleName: string, pokemonId: number) {
+        const tempBattleIndex = GameConstants.getTemporaryBattlesIndex(tempBattleName);
+        if (saveData.statistics.temporaryBattleDefeated[tempBattleIndex] > 0) {
+            Update.giveMissingPokemon(saveData, pokemonId);
+        }
+    }
+
+    static giveMissingPokemon(saveData, pokemonId: number) {
+        if (!saveData.party.caughtPokemon.find((p) => p.id == pokemonId)) {
+            saveData.party.caughtPokemon.push({ id: pokemonId });
+            saveData.statistics.pokemonCaptured[pokemonId] = saveData.statistics.pokemonCaptured[pokemonId] + 1 || 1;
         }
     }
 


### PR DESCRIPTION
Some players may be missing one-time reward pokemon as a result of the ID changes in the previous update:

- Spiky-eared Pichu
- Aegislash (Blade)
- Magearna (Original Color)
- Pinkan Pikachu
- Pikachu (Partner Cap)
- Urshifu (Rapid Strike)

This will give the player the missing pokemon if they have the relevant criteria (questline, temp battle, dungeon) completed. Not sure if any other statistics need to be incremented. Also didn't include anything to remove Missingno as I'm not sure if we just want to remove it for everyone or only those affected by this issue.

Included some re-usable helper methods in Update that can be used in the future if needed.