### PR TITLE
Implement pluralizeString() function

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -390,16 +390,13 @@ export function pluralizeString(str: string, amt: number): string {
     if (amt <= 1) {
         return str;
     }
-    const regexS = /[s]$/;
-    const regexY = /[y]$/;
-    const regexCH = /[ch]$/;
 
     switch (true) {
-        case regexS.test(str):
+        case /s$/.test(str):
             return str;
-        case regexY.test(str):
-            return str.replace(regexY, 'ies');
-        case regexCH.test(str):
+        case /y$/.test(str):
+            return str.replace(/y$/, 'ies');
+        case /ch$/.test(str):
             return `${str}es`;
         default:
             return `${str}s`;

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -386,6 +386,11 @@ export function camelCaseToString(str: string): string {
     return str.replace(/[\s_-]?([A-Z])/g, ' $1').replace(/\b\w/g, (w) => (w.replace(/\w/, (c) => c.toUpperCase()))).trim();
 }
 
+export function pluralizeString(str: string, amt: number): string {
+    const regex = /[s]$/;
+    return (amt > 1 && !regex.test(str)) ? `${str}s` : str;
+}
+
 export function formatDate(date: Date): string {
     return date.toISOString().replace(/T/, ' ').replace(/.\d+Z/, '');
 }

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -387,8 +387,23 @@ export function camelCaseToString(str: string): string {
 }
 
 export function pluralizeString(str: string, amt: number): string {
-    const regex = /[s]$/;
-    return (amt > 1 && !regex.test(str)) ? `${str}s` : str;
+    if (amt <= 1) {
+        return str;
+    }
+    const regexS = /[s]$/;
+    const regexY = /[y]$/;
+    const regexCH = /[ch]$/;
+
+    switch (true) {
+        case regexS.test(str):
+            return str;
+        case regexY.test(str):
+            return str.replace(regexY, 'ies');
+        case regexCH.test(str):
+            return `${str}es`;
+        default:
+            return `${str}s`;
+    }
 }
 
 export function formatDate(date: Date): string {

--- a/src/modules/items/Item.ts
+++ b/src/modules/items/Item.ts
@@ -2,7 +2,7 @@
 
 import { Observable } from 'knockout';
 import {
-    Currency, ITEM_PRICE_MULTIPLIER, Pokeball, humanifyString, camelCaseToString,
+    Currency, ITEM_PRICE_MULTIPLIER, Pokeball, humanifyString, camelCaseToString, pluralizeString,
 } from '../GameConstants';
 import NotificationConstants from '../notifications/NotificationConstants';
 import Notifier from '../notifications/Notifier';
@@ -84,9 +84,11 @@ export default class Item {
         }
 
         let n = amt;
+        const displayName = pluralizeString(humanifyString(this.displayName), n);
+
         if (n > this.maxAmount) {
             Notifier.notify({
-                message: `You can only buy ${this.maxAmount.toLocaleString('en-US')} &times; ${humanifyString(this.displayName)}!`,
+                message: `You can only buy ${this.maxAmount.toLocaleString('en-US')} &times; ${displayName}!`,
                 type: NotificationConstants.NotificationOption.danger,
             });
             n = this.maxAmount;
@@ -94,19 +96,17 @@ export default class Item {
 
         if (!this.isAvailable()) {
             Notifier.notify({
-                message: `${humanifyString(this.displayName)} is sold out!`,
+                message: `${displayName} is sold out!`,
                 type: NotificationConstants.NotificationOption.danger,
             });
             return;
         }
 
-        const multiple = n > 1 ? 's' : '';
-
         if (App.game.wallet.loseAmount(new Amount(this.totalPrice(n), this.currency))) {
             this.gain(n);
             this.increasePriceMultiplier(n);
             Notifier.notify({
-                message: `You bought ${n.toLocaleString('en-US')} × <img src="${this.image}" height="24px"/> ${humanifyString(this.displayName)}${multiple}.`,
+                message: `You bought ${n.toLocaleString('en-US')} × <img src="${this.image}" height="24px"/> ${displayName}.`,
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.Items.item_bought,
             });
@@ -121,7 +121,7 @@ export default class Item {
                     break;
             }
             Notifier.notify({
-                message: `You don't have enough ${curr} to buy ${n.toLocaleString('en-US')} ${humanifyString(this.displayName) + multiple}!`,
+                message: `You don't have enough ${curr} to buy ${n.toLocaleString('en-US')} ${displayName}!`,
                 type: NotificationConstants.NotificationOption.danger,
             });
         }

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -208,6 +208,7 @@ namespace GameConstants {
     }
     declare function humanifyString(str: string): string;
     declare function camelCaseToString(str: string): string;
+    declare function pluralizeString(str: string, amt: number): string;
     declare function formatDate(date: Date): string;
     declare function formatTime(input: number | Date): string;
     declare function formatTimeFullLetters(input: number): string;

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -1897,6 +1897,15 @@ class Update implements Saveable {
         },
 
         '0.10.6': ({ playerData, saveData }) => {
+            // Give the player any missing questline or temporary battle rewards
+            Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'Unfinished Business', 8, 172.01);
+            Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'Princess Diancie', 6, 681.01);
+            Update.giveMissingQuestLineProgressRewardPokemon(saveData, 'A Mystery Gift', 1, 801.01);
+            Update.giveMissingTempBattleRewardPokemon(saveData, 123, 25.14); // Ash Ketchum Pinkan
+            Update.giveMissingTempBattleRewardPokemon(saveData, 151, 25.08); // Ash Ketchum Alola
+            if (saveData.statistics.dungeonsCleared[157] > 0) { // Tower of Waters
+                Update.giveMissingPokemon(saveData, 892.01);
+            }
         },
     };
 
@@ -2297,6 +2306,26 @@ class Update implements Saveable {
         } else {
             // Push the quest, doesn't exist in save data yet
             saveData.quests.questLines.push({ state: 1, name: questLineName, quest: 0 });
+        }
+    }
+
+    static giveMissingQuestLineProgressRewardPokemon(saveData, questLineName: string, questStep: number, pokemonId: number) {
+        const quest = saveData.quests.questLines.find((q) => q.name == questLineName);
+        if (quest?.state == 2 || (quest?.state == 1 && quest?.quest >= questStep)) {
+            Update.giveMissingPokemon(saveData, pokemonId);
+        }
+    }
+
+    static giveMissingTempBattleRewardPokemon(saveData, tempBattleIndex: number, pokemonId: number) {
+        if (saveData.statistics.temporaryBattleDefeated[tempBattleIndex] > 0) {
+            Update.giveMissingPokemon(saveData, pokemonId);
+        }
+    }
+
+    static giveMissingPokemon(saveData, pokemonId: number) {
+        if (!saveData.party.caughtPokemon.find((p) => p.id == pokemonId)) {
+            saveData.party.caughtPokemon.push({ id: pokemonId });
+            saveData.statistics.pokemonCaptured[pokemonId] = saveData.statistics.pokemonCaptured[pokemonId] + 1 || 1;
         }
     }
 

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -188,16 +188,14 @@ class DungeonRunner {
     }
 
     public static lootNotification(input, amount, weight, image) {
-        const multiple = (amount < 2) ? '' : 's';
-        let message = `Found ${amount} × <img src="${image}" height="24px"/> ${GameConstants.camelCaseToString(GameConstants.humanifyString(input))}${multiple} in a dungeon chest.`;
+        let message = `Found ${amount} × <img src="${image}" height="24px"/> ${GameConstants.pluralizeString(GameConstants.camelCaseToString(GameConstants.humanifyString(input)), amount)} in a dungeon chest.`;
         let type = NotificationConstants.NotificationOption.success;
         let setting = NotificationConstants.NotificationSetting.Dungeons.common_dungeon_item_found;
 
         if (typeof BerryType[input] == 'number') {
-            const berryPlural = (amount === 1) ? 'Berry' : 'Berries';
-            message = `Found ${Math.floor(amount)} × <img src="${image}" height="24px"/> ${GameConstants.humanifyString(input)} ${berryPlural} in a dungeon chest.`;
+            message = `Found ${Math.floor(amount)} × <img src="${image}" height="24px"/> ${GameConstants.humanifyString(input)} ${GameConstants.pluralizeString('Berry', amount)} in a dungeon chest.`;
         } if (ItemList[input] instanceof PokeballItem) {
-            message = `Found ${amount} × <img src="${image}" height ="24px"/> ${ItemList[input].displayName}${multiple} in a dungeon chest.`;
+            message = `Found ${amount} × <img src="${image}" height ="24px"/> ${GameConstants.pluralizeString(ItemList[input].displayName, amount)} in a dungeon chest.`;
         } else if (PokemonHelper.getPokemonByName(input).name != 'MissingNo.') {
             message = `Encountered ${GameHelper.anOrA(input)} <img src="${image}" height="40px"/> ${GameConstants.humanifyString(input)} in a dungeon chest.`;
         }

--- a/src/scripts/farming/BerryDeal.ts
+++ b/src/scripts/farming/BerryDeal.ts
@@ -310,9 +310,8 @@ class BerryDeal {
             GameHelper.incrementObservable(App.game.statistics.berryDailyDealTrades);
 
             const amount = deal.item.amount * maxTrades;
-            const multiple = amount > 1 ? 's' : '';
             Notifier.notify({
-                message: `You traded for ${amount.toLocaleString('en-US')} × <img src="${deal.item.itemType.image}" height="24px"/> ${GameConstants.humanifyString(deal.item.itemType.displayName)}${multiple}.`,
+                message: `You traded for ${amount.toLocaleString('en-US')} × <img src="${deal.item.itemType.image}" height="24px"/> ${GameConstants.pluralizeString(GameConstants.humanifyString(deal.item.itemType.displayName), amount)}.`,
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.Items.item_bought,
             });

--- a/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
+++ b/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
@@ -37,8 +37,7 @@ class HarvestBerriesQuest extends Quest implements QuestInterface {
     }
 
     get description(): string {
-        const berryPlural = (this.amount === 1) ? 'Berry' : 'Berries';
-        return `Harvest ${this.amount.toLocaleString('en-US')} ${BerryType[this.berryType]} ${berryPlural} at the farm.`;
+        return `Harvest ${this.amount.toLocaleString('en-US')} ${BerryType[this.berryType]} ${GameConstants.pluralizeString('Berry', this.amount)} at the farm.`;
     }
 
     toJSON() {

--- a/src/scripts/underground/ShardDeal.ts
+++ b/src/scripts/underground/ShardDeal.ts
@@ -49,11 +49,10 @@ class ShardDeal {
             deal.shards.forEach((value) => Underground.gainMineItem(value.shardType.id, -value.amount * maxTrades));
 
             const amount = deal.item.amount * maxTrades;
-            const multiple = amount > 1 ? 's' : '';
             deal.item.itemType.gain(deal.item.amount * maxTrades);
             App.game.wallet.loseAmount(new Amount(deal.questPointCost * maxTrades, GameConstants.Currency.questPoint));
             Notifier.notify({
-                message: `You traded for ${amount.toLocaleString('en-US')} × <img src="${deal.item.itemType.image}" height="24px"/> ${GameConstants.humanifyString(deal.item.itemType.displayName)}${multiple}.`,
+                message: `You traded for ${amount.toLocaleString('en-US')} × <img src="${deal.item.itemType.image}" height="24px"/> ${GameConstants.pluralizeString(GameConstants.humanifyString(deal.item.itemType.displayName), amount)}.`,
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.Items.item_bought,
             });


### PR DESCRIPTION
Adds global function to check for plural cases on strings. Currently utilized in shops, deals, and dungeon loot notifs. 

Definitely doesn't cover every case it might run in to, but for now it covers common cases for `Berry -> Berries`, `Mulch -> Mulches`, `Carbos -> Carbos`. More cases can always be implemented later.