### PR TITLE
Added Breeding Efficiency in Vitamin Modal and fixed it

### DIFF
--- a/src/components/pokemonVitaminModal.html
+++ b/src/components/pokemonVitaminModal.html
@@ -82,6 +82,7 @@
                             <th class="text-center bg-dark align-middle" data-bind="text: `${GameConstants.VitaminType[VitaminController.currentlySelected()]} Used`">X Used</th>
                             <th class="text-center bg-dark align-middle">Attack Bonus</th>
                             <th class="text-center bg-dark align-middle">Egg Steps</th>
+                            <th class="text-center bg-dark align-middle">Breeding Efficiency</th>
                         </tr>
                     </thead>
                     <tbody data-bind="foreach: PartyController.getvitaminSortedList()">
@@ -97,6 +98,7 @@
                             <td class="text-center tight" data-bind="text: $data.vitaminsUsed[VitaminController.currentlySelected()]().toLocaleString('en-US')">-</td>
                             <td class="text-center tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
                             <td class="text-center tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
+                            <td class="text-center tight" data-bind="text: ((($data.getBreedingAttackBonus() * (Settings.getSetting('breedingIncludeEVBonus').observableValue() ? $data.calculateEVAttackBonus() : 1)) / $data.getEggSteps()) * GameConstants.EGG_CYCLE_MULTIPLIER).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -277,7 +277,7 @@ class PartyPokemon implements Saveable {
     getBreedingAttackBonus = ko.pureComputed((): number => {
         const attackBonusPercent = (GameConstants.BREEDING_ATTACK_BONUS + this.vitaminsUsed[GameConstants.VitaminType.Calcium]()) / 100;
         const proteinBoost = this.vitaminsUsed[GameConstants.VitaminType.Protein]();
-        return Math.floor((this.baseAttack * attackBonusPercent) + proteinBoost);
+        return (this.baseAttack * attackBonusPercent) + proteinBoost;
     });
 
     public hideFromProteinList = ko.pureComputed(() => {


### PR DESCRIPTION
The Vitamin Modal now has a dedicated column for BE. Closes [#3667](https://github.com/pokeclicker/pokeclicker/issues/3667).

BE was broken : prior to 0.10.5, the Attack Bonus was not rounded down when computing that.
From 0.10.4 to 0.10.5, with no vitamin, over 600 Pokémons got their BE reduced, by up to a fifth, the change on the sorted list affected over 800 Pokémons.

The Attack Bonus in Vitamin Modal now shows raw Attack Bonus instead of rounded down one : I think that it helps see the exact difference when adding calciums.