### PR TITLE
[FIX] Egg.stepsRequired when Pokémon is not in party

### DIFF
--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -61,9 +61,14 @@ class Egg implements Saveable {
             this.partyPokemon(this.type !== EggType.None ? App.game.party.getPokemon(PokemonHelper.getPokemonById(this.pokemon).id) : null);
         }
 
-        // Reduce total steps based on amount of Carbos used
-        if (this.partyPokemon() && App.game?.party) {
-            this.stepsRequired = this.partyPokemon().getEggSteps();
+        if (App.game?.party) {
+            if (this.partyPokemon()) {
+                // Reduce total steps based on amount of Carbos used
+                this.stepsRequired = this.partyPokemon().getEggSteps();
+            } else {
+                // The Pokémon is not in our party - this might be a shop egg.
+                this.stepsRequired = this.totalSteps;
+            }
         }
     }
 


### PR DESCRIPTION
`Egg.stepsRequired` was left uninitialized when loading eggs from JSON and the Pokémon is not in your party.
This should fix that and allow those eggs to gain steps again.

[Discord bug thread with affected save file](https://discord.com/channels/450412847017754644/1059561403331129405)