### PR TITLE
Arrows for BerryDex Modal

### DIFF
--- a/src/components/berryDexModal.html
+++ b/src/components/berryDexModal.html
@@ -8,6 +8,10 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
+            <div class="btn-group btn-block m-0" role="group">
+            <button class="btn btn-sm btn-info" data-bind="click: () => App.game.statistics.selectedBerryID((App.game.statistics.selectedBerryID() + GameHelper.enumLength(BerryType) - 1) % GameHelper.enumLength(BerryType))">&lt;</button>
+            <button class="btn btn-sm btn-info" data-bind="click: () => App.game.statistics.selectedBerryID((App.game.statistics.selectedBerryID() + 1) % (GameHelper.enumLength(BerryType) - 1))">&gt;</button>
+            </div>
             <div class="modal-body p-0">
                 <img data-bind="attr:{ src: FarmController.getBerryImage($data) }" src=""/>
                 <table class="table table-striped table-hover table-bordered table-sm m-0">


### PR DESCRIPTION
Assistance is welcome!
To do:
- make unobtained berries skippable
- skip the "None" berry while going backwards
(able to with
``click: () => (App.game.statistics.selectedBerryID() + GameHelper.enumLength(BerryType) - 1) % GameHelper.enumLength(BerryType) - 1)``
as that skips to two berries over, so that might give you some ideas)

And once this is done maybe we can add arrows to pokemon too!