### PR TITLE
Enhanced Vitamin Management

### DIFF
--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -73,7 +73,7 @@
                                     </div>
                                 </div>
                             </div>
-                            
+
                             <!-- Amount buttons -->
                             <div class="col-12 pt-3">
                                 <div class="row justify-content-center">
@@ -82,8 +82,8 @@
                                             <!-- ko using: PartyController.hasMultipleStoneEvolutionsAvailable(ItemHandler.pokemonSelected(), GameConstants.StoneType[ItemHandler.stoneSelected()]), as: 'multipleEvolution' -->
                                             <button class="btn btn-success btn-block" data-bind="click: function(){ItemHandler.useStones()},
                                             tooltip: {
-                                                title: 'If a shiny is found, the game will stop using evolution items.' + (multipleEvolution ? '<br/>If the requirements for more than one evolution is fulfilled, a random evolution will be selected.' : ''), 
-                                                trigger: 'hover', 
+                                                title: 'If a shiny is found, the game will stop using evolution items.' + (multipleEvolution ? '<br/>If the requirements for more than one evolution is fulfilled, a random evolution will be selected.' : ''),
+                                                trigger: 'hover',
                                                 boundary: 'window',
                                                 html: multipleEvolution,
                                             }">
@@ -98,7 +98,7 @@
                                         </div>
                                     </div>
                                 </div>
-                               
+
                             </div>
                         </div>
                     </div>
@@ -110,6 +110,9 @@
                                 <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
                                     <div class="btn btn-primary col-2 item-bag-item" data-bind="template: { name: 'otherItemTemplate', data: GameConstants.VitaminType[$data]}, click: () => { VitaminController.currentlySelected($data); $('#pokemonVitaminModal').modal('show'); }"></div>
                                 <!-- /ko -->
+                            </div>
+                            <div class="row justify-content-center mb-2">
+                                <button type="button" class="btn btn-primary btn-sm" data-bind="click: () => { $('#pokemonVitaminExpandedModal').modal('show') }">All Vitamins</button>
                             </div>
                             <h4>Held items</h4>
                             <div class="row justify-content-center">

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -126,7 +126,7 @@
                                     >+</button>
                                 </td>
                                 <!-- /ko -->
-                                <td class="text-center align-middle tight" data-bind="text: ((($data.getBreedingAttackBonus() * (Settings.getSetting('breedingIncludeEVBonus').observableValue() ? $data.calculateEVAttackBonus() : 1)) / $data.getEggSteps()) * GameConstants.EGG_CYCLE_MULTIPLIER).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
+                                <td class="text-center align-middle tight" data-bind="text: SortOptionConfigs[SortOptions.breedingEfficiency].getValue($data)">-</td>
                                 <td class="text-center align-middle tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
                                 <td class="text-center align-middle tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
                             </tr>

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -13,11 +13,11 @@
                     <span class="btn btn-block btn-danger btn-static m-0">Vitamins are disabled.</span>
                     <!-- /ko -->
                     <div class="form-row m-0" id="protein-filter">
-                        <div class="form-group col-6 col-md-4 m-0 p-0">
+                        <div class="form-group col-6 col-lg-4 m-0 p-0">
                             <label for="protein-search">Search</label>
                             <input id="protein-search" autocomplete="off" class="form-control" placeholder="Search here" data-bind="textInput: Settings.getSetting('vitaminSearchFilter').observableValue" />
                         </div>
-                        <div class="form-group col-6 col-md-2 m-0 p-0">
+                        <div class="form-group col-6 col-lg-2 m-0 p-0">
                             <label for="protein-region-filter">Region</label>
                             <select id="protein-region-filter" name="vitaminRegionFilter" autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, +this.value)">
                                 <!-- ko foreach: Settings.getSetting('vitaminRegionFilter').options.filter(r => r.value <= player.highestRegion()) -->
@@ -25,7 +25,7 @@
                                 <!-- /ko -->
                             </select>
                         </div>
-                        <div class="form-group col-6 col-md-2 m-0 p-0">
+                        <div class="form-group col-6 col-lg-2 m-0 p-0">
                             <label for="protein-type-filter">Type</label>
                             <select id="protein-type-filter" name="vitaminTypeFilter" autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, +this.value)">
                                 <!-- ko foreach: Settings.getSetting('vitaminTypeFilter').options -->
@@ -33,7 +33,7 @@
                                 <!-- /ko -->
                             </select>
                         </div>
-                        <div class="form-group col-6 col-md-4 m-0 p-0">
+                        <div class="form-group col-6 col-lg-4 m-0 p-0">
                             <label>Order</label>
                             <div class="input-group" data-bind="with: Settings.getSetting('vitaminSort')">
                                 <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])" data-bind="foreach: $data.options, attr: {name}, selectedOptions: [$data.observableValue()]">
@@ -50,20 +50,18 @@
                         </div>
                     </div>
 
-                    <div class="d-flex align-items-center m-0 mt-1">
-                        <div class="ml-1">
-                            <div class="form-check">
+                    <div class="form-row m-0 mt-1 align-items-center">
+                        <div class="col-12 col-lg-8 text-center text-lg-left">
+                            <div class="form-check form-check-inline align-middle">
                                 <input type="checkbox" id="hide-max-protein-pokemons" class="form-check-input" data-bind="checked: Settings.getSetting('vitaminHideMaxedPokemon').observableValue()" onchange="Settings.setSettingByName('vitaminHideMaxedPokemon', this.checked)" />
                                 <label for="hide-max-protein-pokemons" class="form-check-label">Hide Pokémon with max vitamins</label>
                             </div>
-                        </div>
-                        <div class="ml-3">
-                            <div class="form-check">
+                            <div class="form-check form-check-inline align-middle">
                                 <input type="checkbox" id="hide-shiny-pokemons" class="form-check-input" data-bind="checked: Settings.getSetting('vitaminHideShinyPokemon').observableValue()" onchange="Settings.setSettingByName('vitaminHideShinyPokemon', this.checked)" />
                                 <label for="hide-shiny-pokemons" class="form-check-label">Hide shiny Pokémon</label>
                             </div>
                         </div>
-                        <div class="ml-auto">
+                        <div class="col-12 col-lg-4 text-center text-lg-right p-0">
                             <div class="btn-group btn-group-toggle" data-toggle="buttons">
                                 <!-- ko foreach: VitaminController.multiplier -->
                                 <label class="btn btn-secondary" data-bind="css: { active: VitaminController.multiplierIndex() == $index() }">

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -126,7 +126,7 @@
                                     >+</button>
                                 </td>
                                 <!-- /ko -->
-                                <td class="text-center align-middle tight" data-bind="text: SortOptionConfigs[SortOptions.breedingEfficiency].getValue($data)">-</td>
+                                <td class="text-center align-middle tight" data-bind="text: SortOptionConfigs[SortOptions.breedingEfficiency].getValue($data).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
                                 <td class="text-center align-middle tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
                                 <td class="text-center align-middle tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
                             </tr>

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -1,0 +1,138 @@
+<div class="modal noselect fade" id="pokemonVitaminExpandedModal" tabindex="-1" role="dialog" aria-labelledby="pokemonVitaminExpandedModal">
+    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-lg" role="document">
+        <div class="modal-content">
+            <!-- ko if: modalUtils.observableState['pokemonVitaminExpandedModal'] === 'show' -->
+            <div class="modal-header bg-dark text-light" style='justify-content: space-around;'>
+                <h5 class="modal-title text-light">Vitamins</h5>&nbsp; <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body p-0">
+                <div class="sticky-top bg-dark text-light pt-2">
+                    <!-- ko if: App.game.challenges.list.disableVitamins.active() -->
+                    <span class="btn btn-block btn-danger btn-static m-0">Vitamins are disabled.</span>
+                    <!-- /ko -->
+                    <div class="form-row m-0" id="protein-filter">
+                        <div class="form-group col-md-4 col-4 m-0 p-0">
+                            <label for="protein-search">Search</label>
+                            <input id="protein-search" autocomplete="off" class="form-control" placeholder="Search here" data-bind="textInput: Settings.getSetting('vitaminSearchFilter').observableValue" />
+                        </div>
+                        <div class="form-group col-md-2 col-2 m-0 p-0">
+                            <label for="protein-region-filter">Region</label>
+                            <select id="protein-region-filter" name="vitaminRegionFilter" autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, +this.value)">
+                                <!-- ko foreach: Settings.getSetting('vitaminRegionFilter').options.filter(r => r.value <= player.highestRegion()) -->
+                                <option data-bind="attr: { value: $data.value, selected: Settings.getSetting('vitaminRegionFilter').value === $data.value }, text: $data.text">Region</option>
+                                <!-- /ko -->
+                            </select>
+                        </div>
+                        <div class="form-group col-md-2 col-2 m-0 p-0">
+                            <label for="protein-type-filter">Type</label>
+                            <select id="protein-type-filter" name="vitaminTypeFilter" autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, +this.value)">
+                                <!-- ko foreach: Settings.getSetting('vitaminTypeFilter').options -->
+                                <option data-bind="attr: { value: $data.value, selected: Settings.getSetting('vitaminTypeFilter').value === $data.value }, text: $data.text">Type</option>
+                                <!-- /ko -->
+                            </select>
+                        </div>
+                        <div class="form-group col-md-4 col-4 m-0 p-0">
+                            <label>Order</label>
+                            <div class="input-group" data-bind="with: Settings.getSetting('vitaminSort')">
+                                <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])" data-bind="foreach: $data.options, attr: {name}, selectedOptions: [$data.observableValue()]">
+                                    <option data-bind="text: $data.text, value: $data.value"></option>
+                                </select>
+                                <div class="input-group-append bg-primary text-light">
+                                    <label for="vitaminSortDirection" class="clickable m-0 pl-2 pr-2" style="font-size: 22px;" data-bind="
+                                    text: Settings.getSetting('vitaminSortDirection').observableValue() ? '⥄' : '⥂',
+                                    tooltip: { title: Settings.getSetting('vitaminSortDirection').observableValue() ? 'Descending (highest value first)' : 'Ascending (lowest value first)', trigger: 'hover', placement:'top' }
+                                    ">⥂</label>
+                                    <input id="vitaminSortDirection" style="vertical-align: middle" class="hidden" type="checkbox" data-bind="checked: Settings.getSetting('vitaminSortDirection').observableValue()" onchange="Settings.setSettingByName('vitaminSortDirection', this.checked)" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="d-flex align-items-center m-0 mt-1">
+                        <div class="ml-1">
+                            <div class="form-check">
+                                <input type="checkbox" id="hide-max-protein-pokemons" class="form-check-input" data-bind="checked: Settings.getSetting('vitaminHideMaxedPokemon').observableValue()" onchange="Settings.setSettingByName('vitaminHideMaxedPokemon', this.checked)" />
+                                <label for="hide-max-protein-pokemons" class="form-check-label">Hide Pokémon with max vitamins</label>
+                            </div>
+                        </div>
+                        <div class="ml-3">
+                            <div class="form-check">
+                                <input type="checkbox" id="hide-shiny-pokemons" class="form-check-input" data-bind="checked: Settings.getSetting('vitaminHideShinyPokemon').observableValue()" onchange="Settings.setSettingByName('vitaminHideShinyPokemon', this.checked)" />
+                                <label for="hide-shiny-pokemons" class="form-check-label">Hide shiny Pokémon</label>
+                            </div>
+                        </div>
+                        <div class="ml-auto">
+                            <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                                <!-- ko foreach: VitaminController.multiplier -->
+                                <label class="btn btn-secondary" data-bind="css: { active: VitaminController.multiplierIndex() == $index() }">
+                                    <input type="radio" name="vitaminAmount"
+                                        data-bind="value: $index(), checked: VitaminController.multiplierIndex()"
+                                        onchange="VitaminController.multiplierIndex(+this.value)">
+                                    <knockout data-bind="text: $data"></knockout>
+                                </label>
+                                <!-- /ko -->
+                                <div class="btn-group" role="group">
+                                    <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown"></button>
+                                    <div class="dropdown-menu">
+                                        <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
+                                        <a class="dropdown-item" href="#" data-bind="text: `Remove All ${GameConstants.VitaminType[$data]}`, click: () => { PartyController.removeVitaminFromParty($data) }"></a>
+                                        <!-- /ko -->
+                                        <div class="dropdown-divider"></div>
+                                        <a class="dropdown-item" href="#" data-bind="click: () => { PartyController.removeAllVitaminsFromParty() }">Remove ALL Vitamins</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <table class="table table-striped table-hover table-bordered table-sm m-0 mt-1">
+                    <thead>
+                        <tr>
+                            <th class="align-middle">Pokémon</th>
+                            <th class="text-center align-middle">Vitamins Used</th>
+                            <!-- ko foreach: GameHelper.enumStrings(GameConstants.VitaminType) -->
+                            <th class="text-center align-middle">
+                                <span data-bind="text: $data"></span><br />
+                                <span class="font-weight-normal small" data-bind="text: `[ ${player._itemList[$data]().toLocaleString('en-US')} ]`"></span>
+                            </th>
+                            <!-- /ko -->
+                            <th class="text-center align-middle">Breeding Efficiency</th>
+                            <th class="text-center align-middle">Attack Bonus</th>
+                            <th class="text-center align-middle">Egg Steps</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: PartyController.getvitaminSortedList()">
+                        <tr data-bind="hidden: $data.hideFromProteinList()">
+                            <td class="text-left align-middle">
+                                <knockout data-bind="text: $data.displayName"></knockout>
+                                <sup data-bind="visible: $data.shiny">✨</sup>
+                            </td>
+                            <td class="text-center align-middle tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')"></td>
+                            <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
+                            <td class="text-center align-middle tight">
+                                <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+                                    data-bind="
+                                        click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
+                                        class: ($parent.vitaminsUsed[$data]() > 0 ? 'text-success' : 'text-danger')"
+                                >-</button>
+                                <knockout class="align-middle" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
+                                <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+                                    data-bind="
+                                        click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
+                                        class: ($parent.vitaminUsesRemaining() && player.itemList[GameConstants.VitaminType[$data]]() ? 'text-success' : 'text-danger')"
+                                >+</button>
+                            </td>
+                            <!-- /ko -->
+                            <td class="text-center align-middle tight" data-bind="text: ((($data.getBreedingAttackBonus() * (Settings.getSetting('breedingIncludeEVBonus').observableValue() ? $data.calculateEVAttackBonus() : 1)) / $data.getEggSteps()) * GameConstants.EGG_CYCLE_MULTIPLIER).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
+                            <td class="text-center align-middle tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
+                            <td class="text-center align-middle tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <!-- /ko -->
+        </div>
+    </div>
+</div>

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -117,7 +117,7 @@
                                         click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
                                         class: ($parent.vitaminsUsed[$data]() > 0 ? 'text-success' : 'text-danger')"
                                 >-</button>
-                                <knockout class="align-middle" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
+                                <knockout class="align-middle d-inline-block" style="width: .875rem;" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
                                 <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
                                     data-bind="
                                         click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -13,11 +13,11 @@
                     <span class="btn btn-block btn-danger btn-static m-0">Vitamins are disabled.</span>
                     <!-- /ko -->
                     <div class="form-row m-0" id="protein-filter">
-                        <div class="form-group col-md-4 col-4 m-0 p-0">
+                        <div class="form-group col-6 col-md-4 m-0 p-0">
                             <label for="protein-search">Search</label>
                             <input id="protein-search" autocomplete="off" class="form-control" placeholder="Search here" data-bind="textInput: Settings.getSetting('vitaminSearchFilter').observableValue" />
                         </div>
-                        <div class="form-group col-md-2 col-2 m-0 p-0">
+                        <div class="form-group col-6 col-md-2 m-0 p-0">
                             <label for="protein-region-filter">Region</label>
                             <select id="protein-region-filter" name="vitaminRegionFilter" autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, +this.value)">
                                 <!-- ko foreach: Settings.getSetting('vitaminRegionFilter').options.filter(r => r.value <= player.highestRegion()) -->
@@ -25,7 +25,7 @@
                                 <!-- /ko -->
                             </select>
                         </div>
-                        <div class="form-group col-md-2 col-2 m-0 p-0">
+                        <div class="form-group col-6 col-md-2 m-0 p-0">
                             <label for="protein-type-filter">Type</label>
                             <select id="protein-type-filter" name="vitaminTypeFilter" autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, +this.value)">
                                 <!-- ko foreach: Settings.getSetting('vitaminTypeFilter').options -->
@@ -33,7 +33,7 @@
                                 <!-- /ko -->
                             </select>
                         </div>
-                        <div class="form-group col-md-4 col-4 m-0 p-0">
+                        <div class="form-group col-6 col-md-4 m-0 p-0">
                             <label>Order</label>
                             <div class="input-group" data-bind="with: Settings.getSetting('vitaminSort')">
                                 <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])" data-bind="foreach: $data.options, attr: {name}, selectedOptions: [$data.observableValue()]">

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -111,17 +111,25 @@
                                 <td class="text-center align-middle tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')"></td>
                                 <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
                                 <td class="text-center align-middle tight">
-                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
-                                        data-bind="
-                                            click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
-                                            class: ($parent.vitaminsUsed[$data]() > 0 ? 'text-success' : 'text-danger')"
-                                    >-</button>
-                                    <knockout class="align-middle d-inline-block" style="width: .875rem;" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
-                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
-                                        data-bind="
-                                            click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
-                                            class: ($parent.vitaminUsesRemaining() && player.itemList[GameConstants.VitaminType[$data]]() ? 'text-success' : 'text-danger')"
-                                    >+</button>
+                                    <div class="d-flex justify-content-between p-0">
+                                        <div>
+                                            <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top text-success" style="line-height: 0.6; font-size: 1rem;"
+                                                data-bind="
+                                                    click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
+                                                    css: { invisible: $parent.vitaminsUsed[$data]() == 0 }"
+                                            >-</button>
+                                        </div>
+                                        <div class="w-50">
+                                            <knockout class="align-middle" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
+                                        </div>
+                                        <div>
+                                            <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top text-success" style="line-height: 0.6; font-size: 1rem;"
+                                                data-bind="
+                                                    click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
+                                                    css: { invisible: !$parent.vitaminUsesRemaining() || !player.itemList[GameConstants.VitaminType[$data]]() }"
+                                            >+</button>
+                                        </div>
+                                    </div>
                                 </td>
                                 <!-- /ko -->
                                 <td class="text-center align-middle tight" data-bind="text: SortOptionConfigs[SortOptions.breedingEfficiency].getValue($data).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -111,25 +111,15 @@
                                 <td class="text-center align-middle tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')"></td>
                                 <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
                                 <td class="text-center align-middle tight">
-                                    <div class="d-flex justify-content-between p-0">
-                                        <div>
-                                            <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top text-success" style="line-height: 0.6; font-size: 1rem;"
-                                                data-bind="
-                                                    click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
-                                                    css: { invisible: $parent.vitaminsUsed[$data]() == 0 }"
-                                            >-</button>
-                                        </div>
-                                        <div class="w-50">
-                                            <knockout class="align-middle" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
-                                        </div>
-                                        <div>
-                                            <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top text-success" style="line-height: 0.6; font-size: 1rem;"
-                                                data-bind="
-                                                    click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
-                                                    css: { invisible: !$parent.vitaminUsesRemaining() || !player.itemList[GameConstants.VitaminType[$data]]() }"
-                                            >+</button>
-                                        </div>
-                                    </div>
+                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+                                        data-bind="
+                                            click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
+                                            class: ($parent.vitaminsUsed[$data]() > 0 ? 'text-success' : 'text-muted')">-</button>
+                                    <knockout class="align-middle d-inline-block" style="width: .875rem;" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
+                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+                                        data-bind="
+                                            click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
+                                            class: ($parent.vitaminUsesRemaining() && player.itemList[GameConstants.VitaminType[$data]]() ? 'text-success' : 'text-muted')">+</button>
                                 </td>
                                 <!-- /ko -->
                                 <td class="text-center align-middle tight" data-bind="text: SortOptionConfigs[SortOptions.breedingEfficiency].getValue($data).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -87,50 +87,52 @@
                         </div>
                     </div>
                 </div>
-                <table class="table table-striped table-hover table-bordered table-sm m-0 mt-1">
-                    <thead>
-                        <tr>
-                            <th class="align-middle">Pokémon</th>
-                            <th class="text-center align-middle">Vitamins Used</th>
-                            <!-- ko foreach: GameHelper.enumStrings(GameConstants.VitaminType) -->
-                            <th class="text-center align-middle">
-                                <span data-bind="text: $data"></span><br />
-                                <span class="font-weight-normal small" data-bind="text: `[ ${player._itemList[$data]().toLocaleString('en-US')} ]`"></span>
-                            </th>
-                            <!-- /ko -->
-                            <th class="text-center align-middle">Breeding Efficiency</th>
-                            <th class="text-center align-middle">Attack Bonus</th>
-                            <th class="text-center align-middle">Egg Steps</th>
-                        </tr>
-                    </thead>
-                    <tbody data-bind="foreach: PartyController.getvitaminSortedList()">
-                        <tr data-bind="hidden: $data.hideFromProteinList()">
-                            <td class="text-left align-middle">
-                                <knockout data-bind="text: $data.displayName"></knockout>
-                                <sup data-bind="visible: $data.shiny">✨</sup>
-                            </td>
-                            <td class="text-center align-middle tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')"></td>
-                            <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
-                            <td class="text-center align-middle tight">
-                                <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
-                                    data-bind="
-                                        click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
-                                        class: ($parent.vitaminsUsed[$data]() > 0 ? 'text-success' : 'text-danger')"
-                                >-</button>
-                                <knockout class="align-middle d-inline-block" style="width: .875rem;" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
-                                <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
-                                    data-bind="
-                                        click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
-                                        class: ($parent.vitaminUsesRemaining() && player.itemList[GameConstants.VitaminType[$data]]() ? 'text-success' : 'text-danger')"
-                                >+</button>
-                            </td>
-                            <!-- /ko -->
-                            <td class="text-center align-middle tight" data-bind="text: ((($data.getBreedingAttackBonus() * (Settings.getSetting('breedingIncludeEVBonus').observableValue() ? $data.calculateEVAttackBonus() : 1)) / $data.getEggSteps()) * GameConstants.EGG_CYCLE_MULTIPLIER).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
-                            <td class="text-center align-middle tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
-                            <td class="text-center align-middle tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover table-bordered table-sm m-0 mt-1">
+                        <thead>
+                            <tr>
+                                <th class="align-middle">Pokémon</th>
+                                <th class="text-center align-middle">Vitamins Used</th>
+                                <!-- ko foreach: GameHelper.enumStrings(GameConstants.VitaminType) -->
+                                <th class="text-center align-middle">
+                                    <span data-bind="text: $data"></span><br />
+                                    <span class="font-weight-normal small" data-bind="text: `[ ${player._itemList[$data]().toLocaleString('en-US')} ]`"></span>
+                                </th>
+                                <!-- /ko -->
+                                <th class="text-center align-middle">Breeding Efficiency</th>
+                                <th class="text-center align-middle">Attack Bonus</th>
+                                <th class="text-center align-middle">Egg Steps</th>
+                            </tr>
+                        </thead>
+                        <tbody data-bind="foreach: PartyController.getvitaminSortedList()">
+                            <tr data-bind="hidden: $data.hideFromProteinList()">
+                                <td class="text-left align-middle">
+                                    <knockout data-bind="text: $data.displayName"></knockout>
+                                    <sup data-bind="visible: $data.shiny">✨</sup>
+                                </td>
+                                <td class="text-center align-middle tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')"></td>
+                                <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
+                                <td class="text-center align-middle tight">
+                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+                                        data-bind="
+                                            click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
+                                            class: ($parent.vitaminsUsed[$data]() > 0 ? 'text-success' : 'text-danger')"
+                                    >-</button>
+                                    <knockout class="align-middle d-inline-block" style="width: .875rem;" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
+                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+                                        data-bind="
+                                            click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
+                                            class: ($parent.vitaminUsesRemaining() && player.itemList[GameConstants.VitaminType[$data]]() ? 'text-success' : 'text-danger')"
+                                    >+</button>
+                                </td>
+                                <!-- /ko -->
+                                <td class="text-center align-middle tight" data-bind="text: ((($data.getBreedingAttackBonus() * (Settings.getSetting('breedingIncludeEVBonus').observableValue() ? $data.calculateEVAttackBonus() : 1)) / $data.getEggSteps()) * GameConstants.EGG_CYCLE_MULTIPLIER).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
+                                <td class="text-center align-middle tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
+                                <td class="text-center align-middle tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
             <!-- /ko -->
         </div>

--- a/src/components/pokemonVitaminModal.html
+++ b/src/components/pokemonVitaminModal.html
@@ -74,34 +74,36 @@
                     </div>
                 </div>
                 <i data-bind="text: VitaminController.add() ? 'Left click to give, Right click to take' : 'Left/Right click to take'">Left click to give, Right click to take</i>
-                <table class="table table-striped table-hover table-bordered table-sm m-0">
-                    <thead>
-                        <tr class="text-light">
-                            <th class="text-left bg-dark align-middle">Pokémon</th>
-                            <th class="text-center bg-dark align-middle">Vitamins Used</th>
-                            <th class="text-center bg-dark align-middle" data-bind="text: `${GameConstants.VitaminType[VitaminController.currentlySelected()]} Used`">X Used</th>
-                            <th class="text-center bg-dark align-middle">Attack Bonus</th>
-                            <th class="text-center bg-dark align-middle">Egg Steps</th>
-                            <th class="text-center bg-dark align-middle">Breeding Efficiency</th>
-                        </tr>
-                    </thead>
-                    <tbody data-bind="foreach: PartyController.getvitaminSortedList()">
-                        <tr class="clickable" data-bind="
-                            click: () => VitaminController.add() ? $data.useVitamin(VitaminController.currentlySelected(), VitaminController.getMultiplier()) : $data.removeVitamin(VitaminController.currentlySelected(), VitaminController.getMultiplier());,
-                            event: { contextmenu: () => { $data.removeVitamin(VitaminController.currentlySelected(), VitaminController.getMultiplier()); return false; } },
-                            hidden: $data.hideFromProteinList()">
-                            <td class="text-left">
-                                <knockout data-bind="text: $data.displayName"></knockout>
-                                <sup data-bind="visible: $data.shiny">✨</sup>
-                            </td>
-                            <td class="text-center tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')">-</td>
-                            <td class="text-center tight" data-bind="text: $data.vitaminsUsed[VitaminController.currentlySelected()]().toLocaleString('en-US')">-</td>
-                            <td class="text-center tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
-                            <td class="text-center tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
-                            <td class="text-center tight" data-bind="text: ((($data.getBreedingAttackBonus() * (Settings.getSetting('breedingIncludeEVBonus').observableValue() ? $data.calculateEVAttackBonus() : 1)) / $data.getEggSteps()) * GameConstants.EGG_CYCLE_MULTIPLIER).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover table-bordered table-sm m-0">
+                        <thead>
+                            <tr class="text-light">
+                                <th class="text-left bg-dark align-middle">Pokémon</th>
+                                <th class="text-center bg-dark align-middle">Vitamins Used</th>
+                                <th class="text-center bg-dark align-middle" data-bind="text: `${GameConstants.VitaminType[VitaminController.currentlySelected()]} Used`">X Used</th>
+                                <th class="text-center bg-dark align-middle">Attack Bonus</th>
+                                <th class="text-center bg-dark align-middle">Egg Steps</th>
+                                <th class="text-center bg-dark align-middle">Breeding Efficiency</th>
+                            </tr>
+                        </thead>
+                        <tbody data-bind="foreach: PartyController.getvitaminSortedList()">
+                            <tr class="clickable" data-bind="
+                                click: () => VitaminController.add() ? $data.useVitamin(VitaminController.currentlySelected(), VitaminController.getMultiplier()) : $data.removeVitamin(VitaminController.currentlySelected(), VitaminController.getMultiplier());,
+                                event: { contextmenu: () => { $data.removeVitamin(VitaminController.currentlySelected(), VitaminController.getMultiplier()); return false; } },
+                                hidden: $data.hideFromProteinList()">
+                                <td class="text-left">
+                                    <knockout data-bind="text: $data.displayName"></knockout>
+                                    <sup data-bind="visible: $data.shiny">✨</sup>
+                                </td>
+                                <td class="text-center tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')">-</td>
+                                <td class="text-center tight" data-bind="text: $data.vitaminsUsed[VitaminController.currentlySelected()]().toLocaleString('en-US')">-</td>
+                                <td class="text-center tight" data-bind="text: $data.getBreedingAttackBonus().toLocaleString('en-US')">-</td>
+                                <td class="text-center tight" data-bind="text: $data.getEggSteps().toLocaleString('en-US')">-</td>
+                                <td class="text-center tight" data-bind="text: ((($data.getBreedingAttackBonus() * (Settings.getSetting('breedingIncludeEVBonus').observableValue() ? $data.calculateEVAttackBonus() : 1)) / $data.getEggSteps()) * GameConstants.EGG_CYCLE_MULTIPLIER).toLocaleString('en-US', { maximumSignificantDigits: 2 })">-</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
             <!-- /ko -->
             <span class="bg-dark text-light text-right align-right p-1" data-bind="text:`Showing ${PartyController.getvitaminSortedList().filter(p => !p.hideFromProteinList()).length.toLocaleString('en-US')} Pokémon`"></span>

--- a/src/index.html
+++ b/src/index.html
@@ -589,8 +589,11 @@
 <!-- Statistics Modal-->
 @import "pokemonStatisticsModal.html"
 
-<!-- Pokemon Selector Modal-->
+<!-- Vitamin Modal-->
 @import "pokemonVitaminModal.html"
+
+<!-- Expanded Vitamin Modal -->
+@import "pokemonVitaminExpandedModal.html"
 
 <!-- Badge Case Modal-->
 @import "badgeCase.html"

--- a/src/modules/items/VitaminController.ts
+++ b/src/modules/items/VitaminController.ts
@@ -3,7 +3,7 @@ import { VitaminType } from '../GameConstants';
 export default class VitaminController {
     public static currentlySelected = ko.observable(VitaminType.Protein).extend({ numeric: 0 });
     public static add = ko.observable(true).extend({ boolean: null });
-    public static multiplier = ['×1', '×5', 'x10', 'Max'];
+    public static multiplier = ['×1', '×5', '×10', 'Max'];
     public static multiplierIndex = ko.observable(0);
 
     public static incrementMultiplier() {


### PR DESCRIPTION
Adds a way to easily manage vitamins for all pokemon from a single place. There is a new button labeled "All Vitamins" below the vitamin list in the inventory that will open this new modal. Clicking each individual vitamin in the inventory will still open the current modal.

Clicking/tapping the Plus (+) and Minus (-) buttons in the grid will add or remove vitamins for the pokemon in that row. Green signifies that vitamins can be added or removed and red signifies that vitamins cannot be added or removed (no vitamins remaining or at max vitamins)

![image](https://user-images.githubusercontent.com/672420/210679491-4de19a99-ffae-4af7-9e02-86c274cf5a1f.png)
![image](https://user-images.githubusercontent.com/672420/210679508-b47a5d8c-2eea-4f2d-955f-4207d2ec852c.png)

The `Remove All xx` options all display a confirmation dialog.