### PR TITLE
Update FAQ to explicitly say that EV stands for Effort Value

### DIFF
--- a/src/components/FAQModal.html
+++ b/src/components/FAQModal.html
@@ -141,7 +141,7 @@
 
             <p><h5 class="text-primary"><strong>EVs and Pokérus (BETA)</strong></h5></p>
             <p><strong>What is Pokérus, and what are EVs?</strong><br/>
-            <span class="text-muted">Pokérus is a virus your Pokémon can catch. EVs increase the attack of your Pokémon.</span></p>
+            <span class="text-muted">Pokérus is a virus your Pokémon can catch. EVs, also called Effort Values, increase the attack of your Pokémon.</span></p>
             <p><strong>When do I unlock EVs?</strong><br/>
             <span class="text-muted">EVs are unlocked after defeating the Distortion World Dungeon in Sinnoh.</span></p>
             <p class="text-danger"><i>NOTE: This is a <strong>beta</strong> feature, so things will likely change in the future; feel free to post any feedback/bugs in the <a href="https://discord.gg/a6DFe4p" target="_blank">Discord</a>.</i></p>


### PR DESCRIPTION
Right now, the game doesn't say that EVs are effort values. This will fix that.