### PR TITLE
Time Flute now increases catching speed too

### DIFF
--- a/src/scripts/items/FluteItem.ts
+++ b/src/scripts/items/FluteItem.ts
@@ -67,7 +67,7 @@ class FluteItem extends Item {
 }
 
 ItemList.Yellow_Flute       = new FluteItem(GameConstants.FluteItemType.Yellow_Flute, 'Pokémon Attack', ['Grass', 'Flying', 'Electric'], 'pokemonAttack', 1.02);
-ItemList.Time_Flute        = new FluteItem(GameConstants.FluteItemType.Time_Flute, 'Gym and Dungeon Timers', ['Ground', 'Poison', 'Steel'], undefined, 1.02);
+ItemList.Time_Flute        = new FluteItem(GameConstants.FluteItemType.Time_Flute, 'Gym and Dungeon Timers, and to Catching Speed', ['Ground', 'Poison', 'Steel'], undefined, 1.02);
 ItemList.Black_Flute        = new FluteItem(GameConstants.FluteItemType.Black_Flute, 'Click Attack', ['Dark', 'Psychic', 'Fighting'], 'clickAttack', 1.02);
 ItemList.Red_Flute         = new FluteItem(GameConstants.FluteItemType.Red_Flute, 'Egg Steps', ['Fire', 'Rock', 'Dragon'], 'eggStep', 1.02);
 ItemList.White_Flute         = new FluteItem(GameConstants.FluteItemType.White_Flute, 'Shiny Chance', ['Normal', 'Fairy', 'Ice'], 'shiny', 1.02);

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -195,7 +195,7 @@ class Pokeballs implements Feature {
     }
 
     calculateCatchTime(ball: GameConstants.Pokeball): number {
-        return this.pokeballs[ball].catchTime;
+        return Math.ceil(this.pokeballs[ball].catchTime / FluteEffectRunner.getFluteMultiplier(GameConstants.FluteItemType.Time_Flute));
     }
 
     gainPokeballs(ball: GameConstants.Pokeball, amount: number, purchase = true): void {


### PR DESCRIPTION
I felt like the Time Flute was kind of weak compared to the other flutes, so I improved it.

It is sometimes used to pass a wall, if you are not willing to breed, and that is all... few minutes each day, lol.
The other flutes have long term interesting and competitive effects. Even the black flute can be used for much longer periods of time...

On the other hand, there is nothing affecting the catching speed, somehow with good reasons.

So, now, it also reduces the catch time by up to ~18% with maximal achievement bonus. That is not much so it does not break anything, but still is something and hopefully will make players think about it more often after they are done with badges.