### PR TITLE
Fix Vitamin Modal UI issues

### DIFF
--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -85,7 +85,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="table-responsive" style="overflow-y: overlay">
+                <div class="table-responsive" style="overflow-y: hidden;">
                     <table class="table table-striped table-hover table-bordered table-sm m-0 mt-1">
                         <thead>
                             <tr>

--- a/src/components/pokemonVitaminModal.html
+++ b/src/components/pokemonVitaminModal.html
@@ -74,7 +74,7 @@
                     </div>
                 </div>
                 <i data-bind="text: VitaminController.add() ? 'Left click to give, Right click to take' : 'Left/Right click to take'">Left click to give, Right click to take</i>
-                <div class="table-responsive" style="overflow-y: overlay">
+                <div class="table-responsive" style="overflow-y: hidden;">
                     <table class="table table-striped table-hover table-bordered table-sm m-0">
                         <thead>
                             <tr class="text-light">


### PR DESCRIPTION
Fixes the flashing scrollbar that appears when the pokemon list is not fully loaded due to the spinning pokeball loading image. Also fixes the entire list being loaded immediately in Firefox due to the responsive table layout.