### PR TITLE
Luxuryball effect now shows in pokeball selector

### DIFF
--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -62,7 +62,7 @@ class Pokeballs implements Feature {
                 return 0;
             }, 1000, 'Increased catch rate at night time or in dungeons', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
             // TODO: this needs some sort of bonus, possibly extra dungeon tokens
-            new Pokeball(GameConstants.Pokeball.Luxuryball, () => 0, 1250, 'A Luxury Poké Ball', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            new Pokeball(GameConstants.Pokeball.Luxuryball, () => 0, 1250, 'Gives random currency while catching', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
 
             new Pokeball(GameConstants.Pokeball.Diveball, () => {
 

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -61,8 +61,8 @@ class Pokeballs implements Feature {
                 }
                 return 0;
             }, 1000, 'Increased catch rate at night time or in dungeons', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
-            // TODO: this needs some sort of bonus, possibly extra dungeon tokens
-            new Pokeball(GameConstants.Pokeball.Luxuryball, () => 0, 1250, 'Gives random currency while catching', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            // Drops random currency (money, DT, qp, BP, fp) 
+            new Pokeball(GameConstants.Pokeball.Luxuryball, () => 0, 1250, 'Drops random currencies while catching', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
 
             new Pokeball(GameConstants.Pokeball.Diveball, () => {
 

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -61,7 +61,7 @@ class Pokeballs implements Feature {
                 }
                 return 0;
             }, 1000, 'Increased catch rate at night time or in dungeons', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
-            // Drops random currency (money, DT, qp, BP, fp) 
+            // Drops random currency (money, DT, qp, BP, fp)
             new Pokeball(GameConstants.Pokeball.Luxuryball, () => 0, 1250, 'Drops random currencies while catching', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
 
             new Pokeball(GameConstants.Pokeball.Diveball, () => {


### PR DESCRIPTION
Hi again!
Is me! The maker of short pr changing a single word or sentence. This time the visible change are.... 🥁🥁 5 WORDS! Almost a record of length...
And why change that 5 words? Because now luxury ball makes something... 🙀 so selector should say more than "a luxury ball" something to indicate what it makes... You know, to don't think "oh luxury... But I'm f2p..." 

Also as bonus I edited the comment in code saying TODO for adding an effect as it have already an effect. 


And this PR is finished! (and again I took more time write than make the change) if you want more small little changes keep tuned with your favorite person (or a person that you like... Just a little...) !

