### PR TITLE
Fixes typo in Daycare Access

### DIFF
--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -97,7 +97,7 @@ class BreedingController {
             $('#breedingModal').modal('show');
         } else {
             Notifier.notify({
-                message: 'You do not have access to the Day Care yet.\n<i>Clear Route 5 first.</i>',
+                message: 'You do not have access to the Day Care yet.\n<i>Clear the Pewter City Gym first.</i>',
                 type: NotificationConstants.NotificationOption.warning,
             });
         }


### PR DESCRIPTION
Now that the daycare access has changed, this change in text reflects that. ropute 5 to clearing the pewter city gym.