### PR TITLE
Changes the message prompt when you click the daycare before being unlocked to Route 3

### DIFF
--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -97,7 +97,7 @@ class BreedingController {
             $('#breedingModal').modal('show');
         } else {
             Notifier.notify({
-                message: 'You do not have access to the Day Care yet.\n<i>Clear the Pewter City Gym first.</i>',
+                message: 'You do not have access to the Day Care yet.\n<i>Clear Route 3 first.</i>',
                 type: NotificationConstants.NotificationOption.warning,
             });
         }


### PR DESCRIPTION
Day Care actually unlocks after Route 3 now, not after Brock's Gym (or Route 5). This small PR fixes the message