### PR TITLE
Fix Maelstrom appearing after quest

### DIFF
--- a/src/components/HoennSVG.html
+++ b/src/components/HoennSVG.html
@@ -928,7 +928,7 @@
          { name: "A Raging Maelstrom"
         , x: 59, y: 28
          , width: 13, height: 13
-        , visible:  "(App.game.quests.getQuestLine('The Weather Trio').curQuest() < 5 && App.game.quests.getQuestLine('The Weather Trio').state() >= 1)"
+        , visible:  "(App.game.quests.getQuestLine('The Weather Trio').curQuest() < 5 && App.game.quests.getQuestLine('The Weather Trio').state() == 1)"
          , image: "assets/images/map/Maelstrom.png"
          })
      %>


### PR DESCRIPTION
Fixes Maelstrom appearing after the Weather Trio quest is completed on the overworld map