### PR TITLE
fix: bug in underground item placement

### DIFF
--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -86,14 +86,14 @@ class Mine {
     }
 
     private static getRandomCoord(max: number, size: number): number {
-        return Rand.floor(max - size);
+        return Rand.floor(max - size + 1);
     }
 
     private static canAddReward(x: number, y: number, reward: UndergroundItem): boolean {
         if (Mine.alreadyHasRewardId(reward.id)) {
             return false;
         }
-        if (y + reward.space.length >= App.game.underground.getSizeY() || x + reward.space[0].length >= Underground.sizeX) {
+        if (y + reward.space.length > App.game.underground.getSizeY() || x + reward.space[0].length > Underground.sizeX) {
             return false;
         }
         for (let i = 0; i < reward.space.length; i++) {


### PR DESCRIPTION
Currently in Mine.canAddReward, if y is 10 and reward.space.length is 2 (i.e. we're on the second to last row and the item is two spaces high), then the item is placeable, but current comparison is '>= 12' so the method returns false. Using strict comparison fixes this issue.

Additionally, Mine.getRandomCoord also never returns the last row/column, adding one to the call fixes that. This way, if an item is two spaces high, Mine.getRandomCoord(12 - 2 + 1) will return a number between 0 and 10.