### PR TITLE
Fix: Real Evolution challenge exploit by evolving a pokémon in the hatchery

### DIFF
--- a/src/modules/items/ItemHandler.ts
+++ b/src/modules/items/ItemHandler.ts
@@ -52,9 +52,9 @@ export default class ItemHandler {
 
         const partyPokemon = App.game.party.getPokemonByName(this.pokemonSelected());
         if (partyPokemon.breeding && App.game.challenges.list.realEvolutions.active()) {
-            // If the real evolution challenge is active, we prevent using stones on pokemons in the hatchery to prevent exploits
+            // If the real evolution challenge is active, we prevent using stones on Pokémon in the hatchery to prevent exploits
             return Notifier.notify({
-                message: 'You can\'t use a stone on a Pokémon if it\'s in the hatchery...',
+                message: 'You can\'t use an evolution item on a Pokémon if it\'s in the hatchery...',
                 type: NotificationConstants.NotificationOption.danger,
             });
         }

--- a/src/modules/items/ItemHandler.ts
+++ b/src/modules/items/ItemHandler.ts
@@ -49,6 +49,16 @@ export default class ItemHandler {
                 type: NotificationConstants.NotificationOption.danger,
             });
         }
+
+        const partyPokemon = App.game.party.getPokemonByName(this.pokemonSelected());
+        if (partyPokemon.breeding && App.game.challenges.list.realEvolutions.active()) {
+            // If the real evolution challenge is active, we prevent using stones on pokemons in the hatchery to prevent exploits
+            return Notifier.notify({
+                message: 'You can\'t use a stone on a Pokémon if it\'s in the hatchery...',
+                type: NotificationConstants.NotificationOption.danger,
+            });
+        }
+
         const amountTotal = Math.min(this.amountSelected(), player.itemList[this.stoneSelected()]());
 
         if (!amountTotal) {


### PR DESCRIPTION
Fixes issue #3444. If the real evolution challenge is active, you can't use a stone on Pokémons in the hatchery.