### PR TITLE
Change default search to not use regex

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -43,7 +43,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                         <div class="form-row collapse" id="breeding-filter">
                             <div class="form-group col-md-6 col-6">
                                 <label>Search</label>
-                                <input autocomplete="off" class="form-control" oninput="BreedingFilters.search.value(new RegExp(`(${this.value})`, 'i'))" placeholder="search here"/>
+                                <input autocomplete="off" class="form-control" oninput="BreedingFilters.search.value(new RegExp(`(${/^\/.+\/$/.test(this.value) ? this.value.slice(1, -1) : GameHelper.escapeStringRegex(this.value)})`, 'i'))" placeholder="search here"/>
                             </div>
                             <div class="form-group col-md-3 col-6">
                                 <label>Category</label>

--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -33,7 +33,7 @@ aria-labelledby="pokedexModalLabel">
                                 <div class="form-group col-md-6 col-6">
                                     <label>Name</label>
                                     <input id="nameFilter" class="form-control" placeholder="Bulbasaur" value=""
-                                        data-bind="textInput: PokedexFilters.name.value">
+                                        oninput="PokedexFilters.name.value(new RegExp(`(${/^\/.+\/$/.test(this.value) ? this.value.slice(1, -1) : GameHelper.escapeStringRegex(this.value)})`, 'i'))">
                                 </div>
 
                                 <!--Region-->

--- a/src/modules/GameHelper.ts
+++ b/src/modules/GameHelper.ts
@@ -154,6 +154,10 @@ export default class GameHelper {
         return `${Object.entries(changes).reduce((filename, [format, value]) => filename.replace(format, value), nameFormat)}${isBackup ? ' Backup' : ''}.txt`;
     }
 
+    public static escapeStringRegex(s: string): string {
+        return s.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
+
     private static getTomorrow() {
         const tomorrow = new Date();
         tomorrow.setDate(tomorrow.getDate() + 1);

--- a/src/modules/settings/PokedexFilters.ts
+++ b/src/modules/settings/PokedexFilters.ts
@@ -6,9 +6,9 @@ import FilterOption from './FilterOption';
 import GameHelper from '../GameHelper';
 
 const PokedexFilters: Record<string, FilterOption> = {
-    name: new FilterOption<string>(
+    name: new FilterOption<RegExp>(
         'Search',
-        ko.observable(''),
+        ko.observable(new RegExp('', 'i')),
     ),
     region: new FilterOption<Region>(
         'Region',

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -79,8 +79,8 @@ class PokedexHelper {
             }
 
             // Check if the name contains the string
-            const name = PokedexFilters.name.value().trim();
-            if (name && !PokemonHelper.displayName(pokemon.name)().toLowerCase().includes(name.toLowerCase())) {
+            const name = PokemonHelper.displayName(pokemon.name)();
+            if (!PokedexFilters.name.value().test(name)) {
                 return false;
             }
 


### PR DESCRIPTION
closes #3819 

Defaults to not using regex in the search fields of the hatchery.
Regex can still be used by adding a `/` before and after the search field text (`/my regex here \w+/`).
Added the same behavior to the Pokédex.