### PR TITLE
Made player inventory column go hidden from shops if it's unwanted (Closes #3671)

### DIFF
--- a/src/components/gemMasterModal.html
+++ b/src/components/gemMasterModal.html
@@ -30,7 +30,7 @@
                                 <!-- ko foreach: gems -->
                                 <tr>
                                     <td data-bind="text: App.game.gems.gemWallet[$data.gemType]().toLocaleString('en-US')"></td>
-                                    <td><img height="24px" data-bind="attr: {src: Gems.image($data.gemType) }"></img></td>
+                                    <td><img height="24px" data-bind="attr: {src: Gems.image($data.gemType) }"/></td>
                                     <td data-bind="text: amount.toLocaleString('en-US') + ' x ' + PokemonType[$data.gemType]"></td>
                                     <!-- ko if: $index() === 0 -->
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.gems.length }">→</td>
@@ -43,7 +43,7 @@
                                             trigger: 'hover',
                                             placement:'bottom',
                                             html: true
-                                          }">
+                                          }"/>
                                     </td>
                                     <td class='vertical-middle' data-bind='attr: { rowspan: $parent.gems.length }, text: $parent.item.amount + " × " + $parent.item.itemType.displayName'></td>
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.gems.length }">

--- a/src/components/shardTraderModal.html
+++ b/src/components/shardTraderModal.html
@@ -19,13 +19,13 @@
                                 <tr>
                                     <th class="text-center">Inv</th>
                                     <th></th>
-                                    <th>Shards</th>
+                                    <th data-bind="text: ShopHandler.shopObservable().currencyName "></th>
                                     <th>QP</th>
                                     <th></th>
                                     <th></th>
                                     <th>Item</th>
                                     <th></th>
-                                    <th>Inv</th>
+                                    <th data-bind="attr: { hidden: ShopHandler.shopObservable().hidePlayerInventory }">Inv</th>
                                 </tr>
                             </thead>
                             <tbody data-bind='foreach: ShardDeal.getDeals(ShopHandler.shopObservable().location)'>
@@ -49,13 +49,13 @@
                                           }">
                                     </td>
                                     <td class='vertical-middle' data-bind='attr: { rowspan: $parent.shards.length }, text: $parent.item.amount + " × " + $parent.item.itemType.displayName'></td>
-                                    <td class='vertical-middle' data-bind="attr: { rowspan: $parent.shards.length }, text: player.itemList[$parent.item.itemType.name]().toLocaleString('en-US')"></td>
+                                    <td class='vertical-middle' data-bind="attr: { rowspan: $parent.shards.length, hidden: ShopHandler.shopObservable().hidePlayerInventory }, text: player.itemList[$parent.item.itemType.name]().toLocaleString('en-US')"></td>
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.shards.length }">
                                         <div class="btn-group btn-block" data-bind="let: { tradeAmount: ko.observable(1) }">
                                             <button class='btn btn-success btn-block' data-bind='click: function(){ShardDeal.use(ShopHandler.shopObservable()?.location, $parentContext.$index(), tradeAmount())}, css: { disabled: !ShardDeal.canUse(ShopHandler.shopObservable()?.location, $parentContext.$index()) }'>
                                                 <knockout data-bind="text: !ItemList[$parent.item.itemType.name].isSoldOut() ? 'Trade' : 'Sold out'"></knockout>
                                             </button>
-                                            <button type="button" data-bind="visible: ItemList[$parent.item.itemType.name].maxAmount > 1, text: tradeAmount() + '&nbsp;'" class="btn btn-success dropdown-toggle dropdown-toggle-split active" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"'>
+                                            <button type="button" data-bind="visible: ItemList[$parent.item.itemType.name].maxAmount > 1, text: tradeAmount() + '&nbsp;'" class="btn btn-success dropdown-toggle dropdown-toggle-split active" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                             </button>
                                             <div class="dropdown-menu" data-bind="foreach: [1, 10, 100]">
                                                 <button class="dropdown-item" type="button" data-bind="visible: ItemList[$parents[1].item.itemType.name].maxAmount > 1, click: function(){tradeAmount($data)}, text: $data"></button>

--- a/src/components/shardTraderModal.html
+++ b/src/components/shardTraderModal.html
@@ -19,7 +19,7 @@
                                 <tr>
                                     <th class="text-center">Inv</th>
                                     <th></th>
-                                    <th data-bind="text: ShopHandler.shopObservable().currencyName "></th>
+                                    <th data-bind="text: ShopHandler.shopObservable().currencyName"></th>
                                     <th>QP</th>
                                     <th></th>
                                     <th></th>

--- a/src/scripts/shop/ShardTraderShop.ts
+++ b/src/scripts/shop/ShardTraderShop.ts
@@ -3,7 +3,9 @@
 class ShardTraderShop extends Shop {
     constructor(
         public location: GameConstants.ShardTraderLocations,
-        public name: string = 'Shard Trader'
+        public name: string = 'Shard Trader',
+        public hidePlayerInventory: boolean = false,
+        public currencyName: string = 'Shards'
     ) {
         super([], name);
     }

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -4244,7 +4244,7 @@ TownList['Parfum Palace'] = new Town(
     'Parfum Palace',
     GameConstants.Region.kalos,
     GameConstants.KalosSubRegions.Kalos,
-    [new ShardTraderShop(GameConstants.ShardTraderLocations['Parfum Palace'], 'Furfrou Shard Trader'), new GemMasterShop('Furfrou Gem Trader')],
+    [new ShardTraderShop(GameConstants.ShardTraderLocations['Parfum Palace'], 'Furfrou Shard Trader', true), new GemMasterShop('Furfrou Gem Trader')],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.kalos, 6)],
     }
@@ -6102,7 +6102,7 @@ TownList['Stow-on-Side'] = new Town(
     'Stow-on-Side',
     GameConstants.Region.galar,
     GameConstants.GalarSubRegions.NorthGalar,
-    [TemporaryBattleList['Rampaging Conkeldurr'], TemporaryBattleList['Rampaging Dusknoir'], GymList['Stow-on-Side1'], GymList['Stow-on-Side2'], StowonSideShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Stow-on-Side']), new ShardTraderShop(GameConstants.ShardTraderLocations['Route 6'], 'Fossil Master')],
+    [TemporaryBattleList['Rampaging Conkeldurr'], TemporaryBattleList['Rampaging Dusknoir'], GymList['Stow-on-Side1'], GymList['Stow-on-Side2'], StowonSideShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Stow-on-Side']), new ShardTraderShop(GameConstants.ShardTraderLocations['Route 6'], 'Fossil Master', true, 'Fossils')],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.galar, 23)],
         npcs: [AncientMural1, AncientMural2, StowonSideSonia, Archaeologist],


### PR DESCRIPTION
Didn't find a way to infer whether or not the column should be hidden or not. Maybe if $parent.item.itemType is an instance of PokemonItem, but I couldn't make that work.. (Closes #3671)