### PR TITLE
Make contagious pokeball default to caught selection on unlock

### DIFF
--- a/src/components/FAQModal.html
+++ b/src/components/FAQModal.html
@@ -175,6 +175,7 @@
             <span class="text-muted">Pokérus is spread by Pokémon that are infected, to other Pokémon in the hatchery (not in the queue) that share a type with the infected Pokémon. Neither Pokémon can be ready to hatch, nor can a Hatchery Helper be used on either Pokémon, in order to spread the virus.</span></p>
             <p><strong>How do I gain EVs?</strong><br/>
             <span class="text-muted">EVs can be gained in a variety of ways, but are primarily gained by capturing (not breeding) Pokémon.</span></p>
+            <p class="text-muted">You can use the Contagious Poké Ball selector (unlocked after getting Pokérus) to focus catching Pokémon with less than 50 EVs. Note that setting this selector to "Do not catch" will prevent you from catching any Contagious Pokémon, even if your Caught selector has a Poké Ball set.</p>
             <span class="text-muted">Base Yield: <code>0.1EV</code><br/>
             Evolution Item Yield: <code>1EV</code><br/>
             Wanderer Yield: <code>0.5EV</code><br/>

--- a/src/modules/keyItems/KeyItems.ts
+++ b/src/modules/keyItems/KeyItems.ts
@@ -54,9 +54,16 @@ export default class KeyItems implements Feature {
             new KeyItem(KeyItemType.Gem_case, 'A case specifically designed for holding gems.', undefined, undefined, undefined, 'Gem Case'),
             new KeyItem(KeyItemType.DNA_splicers, 'A splicer that fuses certain Pokémon.', undefined, undefined, undefined, 'DNA Splicers'),
             new KeyItem(KeyItemType.Reins_of_unity, 'Reins that people presented to the king. They enhance Calyrex’s power over bountiful harvests and unite Calyrex with its beloved steeds.', undefined, undefined, undefined, 'Reins of Unity'),
-            new KeyItem(KeyItemType.Pokerus_virus, 'A virus sample collected from the Hatchery.',
+            new KeyItem(KeyItemType.Pokerus_virus,
+                'A virus sample collected from your starter Pokémon. Infect more Pokémon in the hatchery, and use the new Pokérus Poké Ball option to focus catching Contagious pokemon for a damage boost.',
                 () => App.game.statistics.dungeonsCleared[getDungeonIndex('Distortion World')]() > 0,
-                undefined, () => { App.game.party.getPokemon(RegionalStarters[Region.kanto][player.regionStarters[Region.kanto]()]).pokerus = Pokerus.Contagious; }, 'Pokérus Virus'),
+                undefined,
+                () => {
+                    App.game.party.getPokemon(
+                        RegionalStarters[Region.kanto][player.regionStarters[Region.kanto]()],
+                    ).pokerus = Pokerus.Contagious;
+                    App.game.pokeballs.alreadyCaughtContagiousSelection = App.game.pokeballs.alreadyCaughtSelection;
+                }, 'Pokérus Virus'),
         ];
     }
 

--- a/src/modules/keyItems/KeyItems.ts
+++ b/src/modules/keyItems/KeyItems.ts
@@ -63,6 +63,15 @@ export default class KeyItems implements Feature {
                         RegionalStarters[Region.kanto][player.regionStarters[Region.kanto]()],
                     ).pokerus = Pokerus.Contagious;
                     App.game.pokeballs.alreadyCaughtContagiousSelection = App.game.pokeballs.alreadyCaughtSelection;
+                    Information.show({
+                        steps: [
+                            {
+                                element: document.getElementById('pokeballSelector'),
+                                intro: 'You can now choose a different ball for Pokémon which are Contagious with Pokérus. This will be helpful for gaining EVs on those Pokémon.</br></br>Note: If you set the Contagious selector to "Do not catch", you will not catch Contagious pokemon - even if your Caught selector is set to catch Pokémon.',
+                            },
+                        ],
+                        exitOnEsc: false,
+                    });
                 }, 'Pokérus Virus'),
         ];
     }

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -1927,6 +1927,8 @@ class Update implements Saveable {
         },
 
         '0.10.9': ({ playerData, saveData }) => {
+            saveData.pokeballs.alreadyCaughtContagiousSelection = saveData.pokeballs.alreadyCaughtSelection;
+
             //Hex Maniac Aster
             saveData.statistics.temporaryBattleDefeated = Update.moveIndex(saveData.statistics.temporaryBattleDefeated, 112);
 


### PR DESCRIPTION
When unlocked (or on update), sets the contagious pokeball option to the player's caught pokeball selection.
This keeps the player's catching setup working the same as before unlocking this, and they can experiment with it further from there to figure out how it works in more detail.

Adds some text to the Pokerus_virus unlock modal and an Information popup, to bring the new option to their attention. Existing players could learn about it through the changelog.

Adds some FAQ text explaining the selector with similar text to the Information popup.