### PR TITLE
Add redeemable code REFUND-VITAMINS

### DIFF
--- a/src/modules/codes/RedeemableCode.ts
+++ b/src/modules/codes/RedeemableCode.ts
@@ -3,10 +3,10 @@ import NotificationConstants from '../notifications/NotificationConstants';
 import Requirement from '../requirements/Requirement';
 
 export default class RedeemableCode {
-    constructor(public name: string, public hash: number, public isRedeemed: boolean, private rewardFunction: () => void, private requirement: Requirement = undefined) {
+    constructor(public name: string, public hash: number, public isRedeemed: boolean, private rewardFunction: () => Promise<boolean | undefined>, private requirement: Requirement = undefined) {
     }
 
-    redeem() {
+    async redeem() {
         if (this.isRedeemed) {
             Notifier.notify({
                 message: 'You have already redeemed this code.',
@@ -24,7 +24,7 @@ export default class RedeemableCode {
         }
 
         // If nothing returned, assume it was redeemed fine
-        if (this.rewardFunction() === undefined) {
+        if (await this.rewardFunction() ?? true) {
             this.isRedeemed = true;
         }
     }

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -365,7 +365,7 @@ class PartyPokemon implements Saveable {
     }
 
     public hideFromHeldItemList = ko.pureComputed(() => {
-        if (!HeldItem.heldItemSelected().canUse(this)) {
+        if (!HeldItem.heldItemSelected()?.canUse(this)) {
             return true;
         }
         if (!new RegExp(Settings.getSetting('heldItemSearchFilter').observableValue() , 'i').test(this.displayName)) {

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3675,6 +3675,12 @@ const DreamResearcher2 = new NPC('Dream Researcher', [
     requirement: new TemporaryBattleRequirement('Dream Researcher'),
 });
 
+const VitaminRefundCode = new NPC('Pokémon Breeder', [
+    'I used to have my Pokémon maxed out on Protein, but then I found out about the new Vitamins!',
+    'I swapped out some of my Proteins for the new Vitamins, but then I was left with a bunch of extra Protein I couldn\'t use.',
+    'Luckily I was able to use the code REFUND-VITAMINS to get my money back! Too bad it only has one use though...',
+]);
+
 //Unova Towns
 TownList['Aspertia City'] = new Town(
     'Aspertia City',
@@ -3892,6 +3898,7 @@ TownList['Nacrene City'] = new Town(
     [NacreneCityShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Nacrene City'])],
     {
         requirements: [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Pinwheel Forest'))],
+        npcs: [VitaminRefundCode],
     }
 );
 TownList['Striaton City'] = new Town(

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3679,6 +3679,7 @@ const VitaminRefundCode = new NPC('Pokémon Breeder', [
     'I used to have my Pokémon maxed out on Protein, but then I found out about the new Vitamins!',
     'I swapped out some of my Proteins for the new Vitamins, but then I was left with a bunch of extra Protein I couldn\'t use.',
     'Luckily I was able to use the code REFUND-VITAMINS to get my money back! Too bad it only has one use though...',
+    'It will also only refund Vitamins you bought after hitting the price cap.',
 ]);
 
 //Unova Towns


### PR DESCRIPTION
Fixes #3845 

Refunds all vitamins in the player inventory, for whatever their currency and base price is.

NPC advertising the code in Nacrene City, south east of Unova - location chosen because Unova is the first region where new players may want to take out a bunch of vitamins and have them sitting around, and the city is near the day care for that region.