### PR TITLE
Can now merge $playername$ into npc texts

### DIFF
--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -163,6 +163,7 @@ import RoamingPokemonList from './pokemons/RoamingPokemonList';
 import DataPokemon from './pokemons/DataPokemon';
 import RoamingPokemon from './pokemons/RoamingPokemon';
 import UndergroundMegaStoneItem from './underground/UndergroundMegaStoneItem';
+import TextMerger from './utilities/TextMerger';
 
 Object.assign(<any>window, {
     SaveSelector,
@@ -335,4 +336,5 @@ Object.assign(<any>window, {
     DataPokemon,
     RoamingPokemon,
     UndergroundMegaStoneItem,
+    TextMerger,
 });

--- a/src/modules/utilities/TextMerger.ts
+++ b/src/modules/utilities/TextMerger.ts
@@ -5,7 +5,7 @@ export default class TextMerger {
 
     public static mergeText(text: string) : string {
         if (this.mergeValues == null) {
-            this.BuildMergeValues();
+            this.buildMergeValues();
         }
         const mergeSubstrings = text.match(/\$[a-zA-Z]*\$/g);
         if (mergeSubstrings == null) {
@@ -23,7 +23,7 @@ export default class TextMerger {
         return textResult;
     }
 
-    private static BuildMergeValues() {
+    private static buildMergeValues() {
         this.mergeValues = {
             playername: App.game.profile.name,
         };

--- a/src/modules/utilities/TextMerger.ts
+++ b/src/modules/utilities/TextMerger.ts
@@ -1,0 +1,31 @@
+import type { Observable } from 'knockout';
+
+export default class TextMerger {
+    private static mergeValues : { [name: string]: Observable<string> };
+
+    public static mergeText(text: string) : string {
+        if (this.mergeValues == null) {
+            this.BuildMergeValues();
+        }
+        const mergeSubstrings = text.match(/\$[a-zA-Z]*\$/g);
+        if (mergeSubstrings == null) {
+            return text;
+        }
+
+        let textResult = text;
+        mergeSubstrings.forEach((s) => {
+            const key = s.substring(1, s.length - 1).toLocaleLowerCase();
+            if (this.mergeValues[key]()) {
+                textResult = text.replace(s, this.mergeValues[key]());
+            }
+        });
+
+        return textResult;
+    }
+
+    private static BuildMergeValues() {
+        this.mergeValues = {
+            playername: App.game.profile.name,
+        };
+    }
+}

--- a/src/modules/utilities/TextMerger.ts
+++ b/src/modules/utilities/TextMerger.ts
@@ -1,6 +1,7 @@
 import type { Observable } from 'knockout';
 
 export default class TextMerger {
+    private static tempElementForEscape = document.createElement('textarea');
     private static mergeValues : { [name: string]: Observable<string> };
 
     public static mergeText(text: string) : string {
@@ -16,7 +17,7 @@ export default class TextMerger {
         mergeSubstrings.forEach((s) => {
             const key = s.substring(1, s.length - 1).toLocaleLowerCase();
             if (this.mergeValues[key]()) {
-                textResult = text.replace(s, this.mergeValues[key]());
+                textResult = text.replace(s, this.escapeHtml(this.mergeValues[key]()));
             }
         });
 
@@ -27,5 +28,10 @@ export default class TextMerger {
         this.mergeValues = {
             playername: App.game.profile.name,
         };
+    }
+
+    private static escapeHtml(text: string) {
+        TextMerger.tempElementForEscape.textContent = text;
+        return TextMerger.tempElementForEscape.innerHTML;
     }
 }

--- a/src/scripts/towns/NPC.ts
+++ b/src/scripts/towns/NPC.ts
@@ -13,7 +13,7 @@ class NPC {
     ) {}
 
     get dialogHTML(): string {
-        return this.dialog.map(line => `<p>${line}</p>`).join('\n');
+        return this.dialog.map(line => `<p>${TextMerger.mergeText(line)}</p>`).join('\n');
     }
 
     public isVisible() {


### PR DESCRIPTION
This adds the code to be able to use $playername$ in NPC texts.
Simply use it in the text, and it will be replaced by the player name. Like `Hello $playername$!`.
The code can be used elsewhere, by adding `TextMerger.mergeText()` anywhere else in the code.
If you want to add more texts that can be merge, add them to TextMerger.ts:buildMergeValues()