### PR TITLE
Use next tier of dungeon flash if holding light ball

### DIFF
--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -318,13 +318,18 @@ class DungeonRunner {
         const clears = App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(dungeonName)]();
 
         const config = [
+            { flash: undefined, clearsNeeded: 0 },
             { flash: DungeonFlash.tiers[0], clearsNeeded: 100 },
             { flash: DungeonFlash.tiers[1], clearsNeeded: 250 },
             { flash: DungeonFlash.tiers[2], clearsNeeded: 400 },
         ].reverse();
 
-        // findIndex, so we can get next tier when light ball is implemented
+        const holdingLightBall = +(App.game.party.caughtPokemon.find(
+            p => p.heldItem() === ItemList.Light_Ball
+        ) !== undefined);
+
         const index = config.findIndex((tier) => tier.clearsNeeded <= clears);
-        return config[index]?.flash;
+
+        return config[Math.max(0, index - holdingLightBall)]?.flash;
     }
 }


### PR DESCRIPTION
- If any pokemon is holding a light ball, the next best tier of flash will be used
- No effect above 400 clears as there is no next tier of flash
- Multiple Pikachu holing light ball does not have any extra effect, only one is counted.
- Flash tier chosen when entering dungeon, does not recalc if you equip a light ball while already inside

Closes #3380 

---

### Todo
- [ ] Use different item - Luminous Moss
- [ ] New item will be a ConsumableHeldItem - limited uses before needing to be replaced
- [ ] Make it only work after the first dungeon clear
- [ ] Make the new item also give an attack debuff to the pokemon