### PR TITLE
Fixes Red Gyarados to be allowed to fight too early

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -430,13 +430,17 @@ TemporaryBattleList['Red Gyarados'] = new TemporaryBattle(
     'Red Gyarados',
     [new GymPokemon('Gyarados', 1100000, 30, undefined, true)],
     undefined,
-    [new QuestLineStartedRequirement('Team Rocket Again')],
+    [
+        new QuestLineStartedRequirement('Team Rocket Again'),
+        new RouteKillRequirement(10, GameConstants.Region.johto, 43),
+    ],
     undefined,
     {
         displayName: 'Red Gyarados',
         returnTown: 'Mahogany Town',
         isTrainerBattle: false,
         hideTrainer: true,
+        visibleRequirement: new GymBadgeRequirement(BadgeEnums.Fog),
     }
 );
 TemporaryBattleList['Suicune 3'] = new TemporaryBattle(

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -1849,7 +1849,7 @@ TownList['Team Rocket\'s Hideout'] = new DungeonTown(
     'Team Rocket\'s Hideout',
     GameConstants.Region.johto,
     GameConstants.JohtoSubRegions.Johto,
-    [new RouteKillRequirement(10, GameConstants.Region.johto, 43)]
+    [new TemporaryBattleRequirement('Red Gyarados')]
 );
 TownList['Radio Tower'] = new DungeonTown(
     'Radio Tower',


### PR DESCRIPTION
I brought up this issue in Discord in a bug thread.

What happens right now:

1. Team Rocket Again quest starts as soon as you beat Morty, its first step is to beat Red Gyarados
2. Red Gyarados shows up in the map after you beat Morty
3. You can fight Red Gyarados without even clearing route 42, 43, or without even have ever been in Mahogany Town.
4. You can do the Rocket's Hideout in Mahogany before beating Red Gyarados. If you do the dungeon before Red Gyarados, once you beat Red Gyarados, you will have to do the dungeon again to progress in the quest.

I changed the whole sequence as it is in the games, which also makes more sense in general, like this:

1. Red Gyarados still shows up in the map after you beat Morty, but this time when you click on it the battle doesn't start, you get a prompt saying you need to beat route 43 first.
2. Once you beat route 43 you get access to fight Red Gyarados.
3. Team Rocket's Hideout is now locked behind Red Gyarados, you get a prompt when you click on it saying that you need to fight Red Gyarados first.