### PR TITLE
Makes Sudowoodo show up earlier, plus a couple requirements changes

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -306,9 +306,7 @@ TemporaryBattleList.Sudowoodo = new TemporaryBattle(
     'Sudowoodo',
     [new GymPokemon('Sudowoodo', 540000, 20)],
     undefined,
-    [
-        new GymBadgeRequirement(BadgeEnums.Plain),
-    ],
+    [new GymBadgeRequirement(BadgeEnums.Plain)],
     [new TemporaryBattleRequirement('Sudowoodo'), new ObtainedPokemonRequirement('Sudowoodo')],
     {
         isTrainerBattle: false,

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -308,14 +308,13 @@ TemporaryBattleList.Sudowoodo = new TemporaryBattle(
     undefined,
     [
         new GymBadgeRequirement(BadgeEnums.Plain),
-        new RouteKillRequirement(10, GameConstants.Region.johto, 36),
     ],
     [new TemporaryBattleRequirement('Sudowoodo'), new ObtainedPokemonRequirement('Sudowoodo')],
     {
         isTrainerBattle: false,
         returnTown: 'Goldenrod City',
         hideTrainer: true,
-        visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.johto, 36),
+        visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.johto, 31),
     }
 );
 TemporaryBattleList['Silver 3'] = new TemporaryBattle(

--- a/src/scripts/wildBattle/RouteData.ts
+++ b/src/scripts/wildBattle/RouteData.ts
@@ -567,10 +567,12 @@ Routes.add(new RegionRoute(
         land: ['Pidgey', 'Nidoran(M)', 'Nidoran(F)', 'Vulpix', 'Growlithe', 'Hoothoot', 'Stantler'],
         headbutt: ['Exeggcute', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [new OneFromManyRequirement([
+    [
+        new OneFromManyRequirement([
             new RouteKillRequirement(10, GameConstants.Region.johto, 35),
-            new TemporaryBattleRequirement('Sudowoodo')
-        ]
+            new TemporaryBattleRequirement('Sudowoodo'),
+        ]),
+    ]
 ));
 Routes.add(new RegionRoute(
     'Johto Route 37', GameConstants.Region.johto, 37,

--- a/src/scripts/wildBattle/RouteData.ts
+++ b/src/scripts/wildBattle/RouteData.ts
@@ -567,7 +567,10 @@ Routes.add(new RegionRoute(
         land: ['Pidgey', 'Nidoran(M)', 'Nidoran(F)', 'Vulpix', 'Growlithe', 'Hoothoot', 'Stantler'],
         headbutt: ['Exeggcute', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [new GymBadgeRequirement(BadgeEnums.Plain)]
+    [new OneFromManyRequirement([
+            new RouteKillRequirement(10, GameConstants.Region.johto, 35),
+            new TemporaryBattleRequirement('Sudowoodo')
+        ]
 ));
 Routes.add(new RegionRoute(
     'Johto Route 37', GameConstants.Region.johto, 37,

--- a/src/scripts/wildBattle/RouteData.ts
+++ b/src/scripts/wildBattle/RouteData.ts
@@ -578,7 +578,10 @@ Routes.add(new RegionRoute(
         land: ['Pidgey', 'Pidgeotto', 'Vulpix', 'Growlithe', 'Hoothoot', 'Ledyba', 'Spinarak', 'Stantler'],
         headbutt: ['Exeggcute', 'Pineco'],
     }),
-    [new TemporaryBattleRequirement('Sudowoodo')]
+    [
+        new TemporaryBattleRequirement('Sudowoodo'),
+        new RouteKillRequirement(10, GameConstants.Region.johto, 36),
+    ]
 ));
 Routes.add(new RegionRoute(
     'Johto Route 38', GameConstants.Region.johto, 38,


### PR DESCRIPTION
In the games you can see Sudowoodo as soon as you have access to Violet Town, but it's a blockade until you beat Whitney. Right now in Pokeclicker you can only see Sudowoodo after you beat route 36. This route is also being blocked by Whitney, which doesn't make sense, because you can access it through route 35 and it has grass, but the Sudowoodo still blocks it until you beat Whitney.

So I've made the following changes:

1. Sudowoodo shows up after you beat Route 31, but you cannot fight it until you beat Whitney.
2. You only need to beat Whitney to unlock Sudowoodo's battle, instead of beating Whitney plus Route 36. This renders Route 35 optional (as some of the routes in Kanto are). In the games, after beating Whitney, you could backtrack from Goldenrod to Violet to do Sudowoodo from there, thus you don't need to step on route 35 ever if you don't want.
3. Route 36 now has two possible unlock requirements, either doing route 35, or Sudowoodo battle.
4. To access route 37 now you need to beat both Sudowoodo and route 36. If you come form Goldenrod side you would do route 36 then Sudowoodo, if you come from Violet side you would Sudowoodo then route 36, which makes sense with how the encounter are laid out in route 36.

This whole PR is not an important/necessary change, but I think showing Sudowoodo from a bit earlier in the game is a nice bit, showing you and reminding you of the blockade.