### PR TITLE
[Draft] Add Berry Icon to Berry Notifications

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -2033,6 +2033,7 @@ class Farming implements Feature {
         if (!disableNotification) {
             Notifier.notify({
                 message: `You found ${GameHelper.anOrA(BerryType[berry])} ${BerryType[berry]} Berry!`,
+                image: FarmController.getBerryImage(berry),
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.Items.route_item_found,
             });
@@ -2070,6 +2071,7 @@ class Farming implements Feature {
         if (!this.unlockedBerries[berry]()) {
             Notifier.notify({
                 message: `You've discovered the ${BerryType[berry]} Berry!`,
+                image: FarmController.getBerryImage(berry),
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.Farming.berry_discovered,
                 sound: NotificationConstants.NotificationSound.Farming.berry_discovered,


### PR DESCRIPTION
Addresses part of https://github.com/pokeclicker/pokeclicker/issues/3904

Adds Berry icon to `x Berry Found` and `x Berry Unlocked` toast notification

<img width="357" alt="image" src="https://user-images.githubusercontent.com/14989011/216729227-d1181fe4-5189-4842-b123-3f8ac46fa02e.png">

