### PR TITLE
Goodbye miraheze (change wiki link in menu) 

### DIFF
--- a/src/components/gameMenu.html
+++ b/src/components/gameMenu.html
@@ -67,7 +67,7 @@
             <a class="dropdown-item" href="https://discord.gg/a6DFe4p" target="_blank">Discord</a>
         </li>
         <li>
-            <a class="dropdown-item" href="http://pokeclicker.miraheze.org/" target="_blank">Wiki</a>
+            <a class="dropdown-item" href="https://wiki.pokeclicker.com/#!" target="_blank">Wiki</a>
         </li>
         <li>
             <a class="dropdown-item" href="https://github.com/pokeclicker/pokeclicker/issues" target="_blank">Report a bug</a>


### PR DESCRIPTION
Dear friends, family and players. We are all together here to say the last goodbye to miraheze wiki. It was a good wiki, some times, that followed us for years in the hard moments and in the moments of change. But the were an accident, a rabbit attack in the edge of the world, that hurt it, that damage it so hard, so badly, that it's end was unavoidable. But even in this moments of lost we have to embrace the happiness and say hello to our new wiki, maybe smaller and way too young, but up to date and 100% compromised with us, and this little symbolic change of one link for other is that bye and hello we will need to make when we get ready. 