### PR TITLE
Increase Uncaught Boss Pokemon Weights

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -148,12 +148,16 @@ class Dungeon {
     }
 
     /**
-     * Retreives the weights for all the possible bosses giving a slight bump to bosses which have not been caught.
+     * Retreives the weights for all the possible bosses.
      */
     get bossWeightList(): number[] {
         return this.availableBosses().map((boss) => {
-            const isCaught = App.game.party.alreadyCaughtPokemonByName(pokemonMap[boss.name].name) ? 0 : 1;
-            return (boss.options?.weight ?? 1) + (isCaught / this.availableBosses().length);
+            if (App.game.challenges.list.requireCompletePokedex.active()) {
+                const isCaught = App.game.party.alreadyCaughtPokemonByName(pokemonMap[boss.name].name) ? 0 : 1;
+                return (boss.options?.weight ?? 1) + (isCaught / this.availableBosses().length);
+            }
+
+            return boss.options?.weight ?? 1;
         });
     }
 

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -148,11 +148,12 @@ class Dungeon {
     }
 
     /**
-     * Retreives the weights for all the possible bosses
+     * Retreives the weights for all the possible bosses giving a slight bump to bosses which have not been caught.
      */
     get bossWeightList(): number[] {
         return this.availableBosses().map((boss) => {
-            return boss.options?.weight ?? 1;
+            const isCaught = App.game.party.alreadyCaughtPokemonByName(pokemonMap[boss.name].name) ? 0 : 1;
+            return (boss.options?.weight ?? 1) + (isCaught / this.availableBosses().length);
         });
     }
 


### PR DESCRIPTION
Could be an unwanted change but I did not see any comments on #2079 and it was never closed so figured I would start a discussion around it. 

I had a similar frustration when it took over 50 clears to catch Lunatone in Hoenn's Meteor Falls. I know thats just how RNG can work against you in some cases. Figured as this would only apply to dungeon bosses, and the effect of it seems to just nudge the chance of an uncaught pokemon being the dungeon boss slightly in the players favor. When all boss pokemon are caught or uncaught the bonus is nullified.

Ran some quick numbers for comparison:
Base weight + (uncaught bonus / total bosses) = weight

2 Bosses:
1 + 1/2 = 1.50 / 3.00 = 0.500
1 + 1/2 = 1.50 / 3.00 = 0.500

1 + 0/2 = 1.00 / 2.50 = 0.400
1 + 1/2 = 1.50 / 2.50 = 0.600

1 + 0/2 = 1.00 / 2.00 = 0.500
1 + 0/2 = 1.00 / 2.00 = 0.500



3 Bosses:
1 + 1/3 = 1.33 / 4.00 = 0.333
1 + 1/3 = 1.33 / 4.00 = 0.333
1 + 1/3 = 1.33 / 4.00 = 0.333

1 + 0/3 = 1.00 / 3.66 = 0.273
1 + 1/3 = 1.33 / 3.66 = 0.363
1 + 1/3 = 1.33 / 3.66 = 0.363

1 + 0/3 = 1.00 / 3.33 = 0.300
1 + 0/3 = 1.00 / 3.33 = 0.300
1 + 1/3 = 1.33 / 3.33 = 0.399

1 + 0/3 = 1.00 / 3.00 = 0.333
1 + 0/3 = 1.00 / 3.00 = 0.333
1 + 0/3 = 1.00 / 3.00 = 0.333



4 Bosses: 
1 + 1/4 = 1.25 / 5.00 = .250
1 + 1/4 = 1.25 / 5.00 = .250
1 + 1/4 = 1.25 / 5.00 = .250
1 + 1/4 = 1.25 / 5.00 = .250

1 + 0/4 = 1.00 / 4.75 = 0.210
1 + 1/4 = 1.25 / 4.75 = 0.263
1 + 1/4 = 1.25 / 4.75 = 0.263
1 + 1/4 = 1.25 / 4.75 = 0.263

1 + 0/4 = 1.00 / 4.50 = 0.222
1 + 0/4 = 1.00 / 4.50 = 0.222
1 + 1/4 = 1.25 / 4.50 = 0.277
1 + 1/4 = 1.25 / 4.50 = 0.277

1 + 0/4 = 1.00 / 4.25 = 0.235
1 + 0/4 = 1.00 / 4.25 = 0.235
1 + 0/4 = 1.00 / 4.25 = 0.235
1 + 1/4 = 1.25 / 4.25 = 0.294

1 + 0/4 = 1.00 / 4.00 = .250
1 + 0/4 = 1.00 / 4.00 = .250
1 + 0/4 = 1.00 / 4.00 = .250
1 + 0/4 = 1.00 / 4.00 = .250