### PR TITLE
Adds Rotom Discord and Surfing Pikachu as bosses into their respective dungeons

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -3637,6 +3637,11 @@ dungeonList['Team Galactic Eterna Building'] = new Dungeon('Team Galactic Eterna
             new ObtainedPokemonRequirement('Rotom'),
             new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Team Galactic Eterna Building')),
         ])}),
+        new DungeonBossPokemon('Rotom (Discord)', 4300000, 100, {hide: true, requirement: new MultiRequirement([
+            new ObtainedPokemonRequirement('Rotom'),
+            new ObtainedPokemonRequirement('Rotom (Discord)'),
+            new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Team Galactic Eterna Building')),
+        ])}),
     ],
     54250, 205);
 
@@ -7449,6 +7454,7 @@ dungeonList['Pikachu Valley'] = new Dungeon('Pikachu Valley',
         new DungeonBossPokemon('Pikachu (Kalos Cap)', 59764020, 15),
         new DungeonBossPokemon('Pikachu (Alola Cap)', 59764020, 15, {requirement: new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)}),
         new DungeonBossPokemon('Pikachu (World Cap)', 59764020, 15, {hide: true, requirement: new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion)}),
+        new DungeonBossPokemon('Surfing Pikachu', 59764020, 15, {hide: true, requirement: new ObtainedPokemonRequirement('Surfing Pikachu')}),
     ],
     850000, 4);
 


### PR DESCRIPTION
This PR adds Rotom (Discord) and Surfing Pikachu as catchable Pokémon only after you already obtained them, as a way to EV them or any other purpose.

Rotom (Discord) added in Team Galactic Eterna Building with the same requirements as the other Rotoms plus you need to have already obtained Discord (Rotom) for it to appear. It's completely hidden until you already own it.

Surfing Pikachu added in Pikachu Valley with the other Pikachus with the requirement that you need to own it first. Same as Rotom (Discord), Surfing Pikachu is completely hidden until you already own it.

I thought it was a nice idea to have both Pokémon available in the game so they can be EV'd, and there is precedent with the inclusion of the Vivillon coming back during the Lunar Year Event just so they can be EV'd.