### PR TITLE
Manaphy is a wanderer again

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1102,7 +1102,9 @@ class Farming implements Feature {
             BerryColor.Red,
             11.1,
             BerryFirmness.Very_Hard,
-            ['This Berry is surrounded by mystery. It is rumored to be imbued with the power of the sea.']
+            ['This Berry is surrounded by mystery. It is rumored to be imbued with the power of the sea.'],
+            undefined,
+            ['Manaphy']
         );
 
         this.berryData[BerryType.Ganlon] = new Berry(


### PR DESCRIPTION
Makes Manaphy a Liechi wanderer again, as it was before but it stopped after the berry rework and nobody knows why and there is no mention of a reason why anywhere.