### PR TITLE
Fix pokemon list attack

### DIFF
--- a/src/components/nextRegionModal.html
+++ b/src/components/nextRegionModal.html
@@ -15,7 +15,7 @@
                    <strong>There are a few things you should know before you depart:</strong><br/>
                    You will gain <strong data-bind="text: App.game.breeding.queueSlotsGainedFromRegion(player.highestRegion())"></strong> queue slots in the Hatchery.<br/>
                    <!-- ko if: App.game.challenges.list.regionalAttackDebuff.active() -->
-                   When Pokémon are in a Region they're not native to, they will only retain <strong data-bind="text: App.game.party.getRegionAttackMultiplier(player.highestRegion() + 1).toLocaleString(undefined,{style: 'percent'})"></strong> of their total attack.<br/>
+                   When Pokémon are in a Region they're not native to, they will only retain <strong data-bind="text: Party.getRegionAttackMultiplier(player.highestRegion() + 1).toLocaleString(undefined,{style: 'percent'})"></strong> of their total attack.<br/>
                    <!-- /ko -->
                    You will also have to progress to the Dock in <span data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() + 1])"></span> before you are able to travel between regions again.
                </p>

--- a/src/components/pokemonListContainer.html
+++ b/src/components/pokemonListContainer.html
@@ -74,7 +74,7 @@
                                     tooltip:  { title: $data.megaStone?.getTooltipText() ?? '', trigger: 'hover', placement:'bottom' }
                                     "/>
                             </div>
-                            <div class="pokemonAttack" data-bind="text: attack.toLocaleString('en-US')"></div>
+                            <div class="pokemonAttack" data-bind="text: Party.calculateOnePokemonAttack($data).toLocaleString('en-US')"></div>
                             <div class="pokemonLevel" data-bind="text: level"></div>
                         </div>
                     </td>

--- a/src/modules/DataStore/BadgeCase.ts
+++ b/src/modules/DataStore/BadgeCase.ts
@@ -34,7 +34,7 @@ export default class BadgeCase implements Feature {
 
         // Track when users gains a badge and their total attack
         LogEvent('gained badge', 'badges', `gained badge (${camelCaseToString(BadgeEnums[badge])})`,
-            App.game.party.calculatePokemonAttack(undefined, undefined, true, undefined, true, false, WeatherType.Clear));
+            App.game.party.calculatePokemonAttack(undefined, undefined, true, undefined, undefined, true, false, WeatherType.Clear));
     }
 
     hasBadge(badge: BadgeEnums): boolean {

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -210,13 +210,13 @@ class BreedingController {
     public static getDisplayValue(pokemon: PartyPokemon): string {
         const pokemonData = pokemonMap[pokemon.name];
         switch (this.displayValue()) {
-            case 'attack': return `Attack: ${Math.floor(pokemon.attack * BreedingController.calculateRegionalMultiplier(pokemon)).toLocaleString('en-US')}`;
-            case 'attackBonus': return `Attack Bonus: ${Math.floor(pokemon.getBreedingAttackBonus() * BreedingController.calculateRegionalMultiplier(pokemon)).toLocaleString('en-US')}`;
+            case 'attack': return `Attack: ${Math.floor(pokemon.attack * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff())).toLocaleString('en-US')}`;
+            case 'attackBonus': return `Attack Bonus: ${Math.floor(pokemon.getBreedingAttackBonus() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff())).toLocaleString('en-US')}`;
             case 'baseAttack': return `Base Attack: ${pokemon.baseAttack.toLocaleString('en-US')}`;
             case 'eggSteps': return `Egg Steps: ${pokemon.getEggSteps().toLocaleString('en-US')}`;
             case 'timesHatched': return `Hatches: ${App.game.statistics.pokemonHatched[pokemonData.id]().toLocaleString('en-US')}`;
-            case 'breedingEfficiency': return `Efficiency: ${(pokemon.breedingEfficiency() * BreedingController.calculateRegionalMultiplier(pokemon)).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
-            case 'stepsPerAttack': return `Steps/Att: ${(pokemon.getEggSteps() / (pokemon.getBreedingAttackBonus() * BreedingController.calculateRegionalMultiplier(pokemon))).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
+            case 'breedingEfficiency': return `Efficiency: ${(pokemon.breedingEfficiency() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff())).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
+            case 'stepsPerAttack': return `Steps/Att: ${(pokemon.getEggSteps() / (pokemon.getBreedingAttackBonus() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff()))).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
             case 'dexId': return `#${pokemon.id <= 0 ? '???' : Math.floor(pokemon.id).toString().padStart(3,'0')}`;
             case 'vitamins': return `Vitamins: ${pokemon.totalVitaminsUsed()}`;
             case 'evs': return `EVs: ${pokemon.evs()}`;
@@ -225,17 +225,6 @@ class BreedingController {
 
     // Applied regional debuff
     public static regionalAttackDebuff = ko.observable(-1);
-
-    public static calculateRegionalMultiplier(pokemon: PartyPokemon): number {
-        // Check if reginal debnuff is active
-        if (App.game.challenges.list.regionalAttackDebuff.active()) {
-            // Check if regional debuff being applied for sorting
-            if (BreedingController.regionalAttackDebuff() > -1 && PokemonHelper.calcNativeRegion(pokemon.name) !== BreedingController.regionalAttackDebuff()) {
-                return App.game.party.getRegionAttackMultiplier();
-            }
-        }
-        return 1.0;
-    }
 
     // Queue size limit setting
     public static queueSizeLimit = ko.observable(-1);

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -210,13 +210,13 @@ class BreedingController {
     public static getDisplayValue(pokemon: PartyPokemon): string {
         const pokemonData = pokemonMap[pokemon.name];
         switch (this.displayValue()) {
-            case 'attack': return `Attack: ${Math.floor(pokemon.attack * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff())).toLocaleString('en-US')}`;
-            case 'attackBonus': return `Attack Bonus: ${Math.floor(pokemon.getBreedingAttackBonus() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff())).toLocaleString('en-US')}`;
+            case 'attack': return `Attack: ${Math.floor(pokemon.attack * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff(), -1)).toLocaleString('en-US')}`;
+            case 'attackBonus': return `Attack Bonus: ${Math.floor(pokemon.getBreedingAttackBonus() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff(), -1)).toLocaleString('en-US')}`;
             case 'baseAttack': return `Base Attack: ${pokemon.baseAttack.toLocaleString('en-US')}`;
             case 'eggSteps': return `Egg Steps: ${pokemon.getEggSteps().toLocaleString('en-US')}`;
             case 'timesHatched': return `Hatches: ${App.game.statistics.pokemonHatched[pokemonData.id]().toLocaleString('en-US')}`;
-            case 'breedingEfficiency': return `Efficiency: ${(pokemon.breedingEfficiency() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff())).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
-            case 'stepsPerAttack': return `Steps/Att: ${(pokemon.getEggSteps() / (pokemon.getBreedingAttackBonus() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff()))).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
+            case 'breedingEfficiency': return `Efficiency: ${(pokemon.breedingEfficiency() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff(), -1)).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
+            case 'stepsPerAttack': return `Steps/Att: ${(pokemon.getEggSteps() / (pokemon.getBreedingAttackBonus() * Party.calculateRegionalMultiplier(pokemon, BreedingController.regionalAttackDebuff(), -1))).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
             case 'dexId': return `#${pokemon.id <= 0 ? '???' : Math.floor(pokemon.id).toString().padStart(3,'0')}`;
             case 'vitamins': return `Vitamins: ${pokemon.totalVitaminsUsed()}`;
             case 'evs': return `EVs: ${pokemon.evs()}`;

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -208,10 +208,11 @@ class HatcheryHelpers {
             if (egg.isNone()) {
                 // Get the currently selected region
                 const currentRegion = +Settings.getSetting('breedingRegionalAttackDebuffSetting').value;
+                const subregion = -1;
 
                 // Check if there's a pokemon we can chuck into an egg
                 const pokemon = [...App.game.party.caughtPokemon]
-                    .sort(PartyController.compareBy(helper.sortOption(), helper.sortDirection(), currentRegion))
+                    .sort(PartyController.compareBy(helper.sortOption(), helper.sortDirection(), currentRegion, subregion))
                     .find(p => BreedingController.visible(p)());
                 if (pokemon) {
                     this.hatchery.gainPokemonEgg(pokemon, true);

--- a/src/scripts/discord/DiscordRichPresence.ts
+++ b/src/scripts/discord/DiscordRichPresence.ts
@@ -59,7 +59,7 @@ class DiscordRichPresence {
         },
         {
             key: 'attack',
-            value: () => App.game.party.calculatePokemonAttack(PokemonType.None, PokemonType.None, true, undefined, true, false, WeatherType.Clear, true, true),
+            value: () => App.game.party.calculatePokemonAttack(PokemonType.None, PokemonType.None, true, undefined, undefined, true, false, WeatherType.Clear, true, true),
             default: 0,
         },
         {

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -186,7 +186,7 @@ class Party implements Feature {
         return attack;
     }
 
-    public static calculateRegionalMultiplier(pokemon: PartyPokemon, region: number, subRegion: number = 0): number {
+    public static calculateRegionalMultiplier(pokemon: PartyPokemon, region: number, subRegion: number): number {
         if (region == GameConstants.Region.alola && subRegion == GameConstants.AlolaSubRegions.MagikarpJump && Math.floor(pokemon.id) != 129) {
             // Only magikarps can attack in magikarp jump
             return 0;

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -127,15 +127,10 @@ class Party implements Feature {
      * @returns {number} damage to be done.
      */
 
-    public calculatePokemonAttack(type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, ignoreRegionMultiplier = false, region: GameConstants.Region = player.region, includeBreeding = false, useBaseAttack = false, overrideWeather?: WeatherType, ignoreLevel = false, includeFlute = true): number {
+    public calculatePokemonAttack(type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, ignoreRegionMultiplier = false, region: GameConstants.Region = player.region, subRegion: number = player.subregion, includeBreeding = false, useBaseAttack = false, overrideWeather?: WeatherType, ignoreLevel = false, includeFlute = true): number {
         let attack = 0;
         for (const pokemon of this.caughtPokemon) {
-            if (region == GameConstants.Region.alola && player.region == GameConstants.Region.alola && player.subregion == GameConstants.AlolaSubRegions.MagikarpJump &&
-                Math.floor(pokemon.id) != 129) {
-                // Only magikarps can attack in magikarp jump
-                continue;
-            }
-            attack += this.calculateOnePokemonAttack(pokemon, type1, type2, region, ignoreRegionMultiplier, includeBreeding, useBaseAttack, overrideWeather, ignoreLevel, includeFlute);
+            attack += Party.calculateOnePokemonAttack(pokemon, type1, type2, region, subRegion, ignoreRegionMultiplier, includeBreeding, useBaseAttack, overrideWeather, ignoreLevel, includeFlute);
         }
 
         const bonus = this.multiplier.getBonus('pokemonAttack');
@@ -143,33 +138,30 @@ class Party implements Feature {
         return Math.round(attack * bonus);
     }
 
-    public calculateOnePokemonAttack(pokemon: PartyPokemon, type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, region: GameConstants.Region = player.region, ignoreRegionMultiplier = false, includeBreeding = false, useBaseAttack = false, overrideWeather: WeatherType, ignoreLevel = false, includeFlute = true): number {
+    public static calculateOnePokemonAttack(pokemon: PartyPokemon, type1: PokemonType = PokemonType.None, type2: PokemonType = PokemonType.None, region: GameConstants.Region = player.region, subRegion: number = player.subregion, ignoreRegionMultiplier = false, includeBreeding = false, useBaseAttack = false, overrideWeather: WeatherType, ignoreLevel = false, includeFlute = true): number {
         let multiplier = 1, attack = 0;
-        const pAttack = useBaseAttack ? pokemon.baseAttack : (ignoreLevel ? pokemon.calculateAttack(ignoreLevel) : pokemon.attack);
-        const nativeRegion = PokemonHelper.calcNativeRegion(pokemon.name);
 
-        // Check if the pokemon is in their native region
-        if (!ignoreRegionMultiplier && nativeRegion != region && nativeRegion != GameConstants.Region.none) {
-            // Check if the challenge mode is active
-            if (App.game.challenges.list.regionalAttackDebuff.active()) {
-                // Pokemon only retain a % of their total damage in other regions based on highest region.
-                multiplier = this.getRegionAttackMultiplier();
-            }
+        if (!ignoreRegionMultiplier) {
+            multiplier = Party.calculateRegionalMultiplier(pokemon, region, subRegion);
+        }
+        if (multiplier == 0) {
+            return 0;
         }
 
+        const pAttack = useBaseAttack ? pokemon.baseAttack : (ignoreLevel ? pokemon.calculateAttack(ignoreLevel) : pokemon.attack);
+
+        const dataPokemon = PokemonHelper.getPokemonByName(pokemon.name);
         // Check if the Pokemon is currently breeding (no attack)
         if (includeBreeding || !pokemon.breeding) {
             if (type1 == PokemonType.None) {
                 attack = pAttack * multiplier;
             } else {
-                const dataPokemon = PokemonHelper.getPokemonByName(pokemon.name);
                 attack = pAttack * TypeHelper.getAttackModifier(dataPokemon.type1, dataPokemon.type2, type1, type2) * multiplier;
             }
         }
 
         // Weather boost
         const weather = Weather.weatherConditions[overrideWeather ?? Weather.currentWeather()];
-        const dataPokemon = PokemonHelper.getPokemonByName(pokemon.name);
         weather.multipliers?.forEach(value => {
             if (value.type == dataPokemon.type1) {
                 attack *= value.multiplier;
@@ -181,7 +173,6 @@ class Party implements Feature {
 
         // Should we take flute boost into account
         if (includeFlute) {
-            const dataPokemon = PokemonHelper.getPokemonByName(pokemon.name);
             FluteEffectRunner.activeGemTypes().forEach(value => {
                 if (value == dataPokemon.type1) {
                     attack *= GameConstants.FLUTE_TYPE_ATTACK_MULTIPLIER;
@@ -195,7 +186,24 @@ class Party implements Feature {
         return attack;
     }
 
-    public getRegionAttackMultiplier(highestRegion = player.highestRegion()): number {
+    public static calculateRegionalMultiplier(pokemon: PartyPokemon, region: number, subRegion: number = 0): number {
+        if (region == GameConstants.Region.alola && subRegion == GameConstants.AlolaSubRegions.MagikarpJump && Math.floor(pokemon.id) != 129) {
+            // Only magikarps can attack in magikarp jump
+            return 0;
+        }
+        // Check if regional debuff challenge mode is active
+        if (App.game.challenges.list.regionalAttackDebuff.active()) {
+            // Check if the pokemon is in their native region
+            const nativeRegion = PokemonHelper.calcNativeRegion(pokemon.name);
+            if (region > -1 && nativeRegion != region && nativeRegion != GameConstants.Region.none) {
+                // Pokemon only retain a % of their total damage in other regions based on highest region.
+                return Party.getRegionAttackMultiplier();
+            }
+        }
+        return 1.0;
+    }
+
+    public static getRegionAttackMultiplier(highestRegion = player.highestRegion()): number {
         // between 0.2 -> 1 based on highest region
         return Math.min(1, Math.max(0.2, 0.1 + (highestRegion / 10)));
     }

--- a/src/scripts/quests/QuestHelper.ts
+++ b/src/scripts/quests/QuestHelper.ts
@@ -72,7 +72,7 @@ class QuestHelper {
         const routes = Routes.getRoutesByRegion(region).map(r => r.number);
         const first = Math.min(...routes);
         const last = Math.max(...routes);
-        const attack = Math.max(1, App.game.party.calculatePokemonAttack(PokemonType.None, PokemonType.None, false, region, true, false, WeatherType.Clear));
+        const attack = Math.max(1, App.game.party.calculatePokemonAttack(PokemonType.None, PokemonType.None, false, region, -1, true, false, WeatherType.Clear));
 
         for (let route = last; route >= first; route--) {
             if (PokemonFactory.routeHealth(route, region) < attack) {

--- a/src/scripts/types/DamageCalculator.ts
+++ b/src/scripts/types/DamageCalculator.ts
@@ -22,6 +22,7 @@ class DamageCalculator {
             DamageCalculator.type2(),
             ignoreRegionMultiplier,
             DamageCalculator.region(),
+            -1,
             DamageCalculator.includeBreeding(),
             DamageCalculator.baseAttackOnly(),
             DamageCalculator.weather(),
@@ -39,7 +40,7 @@ class DamageCalculator {
                 continue;
             }
 
-            const attack = App.game.party.calculateOnePokemonAttack(pokemon, this.type1(), this.type2(), this.region(), ignoreRegionMultiplier, this.includeBreeding(), this.baseAttackOnly(), this.weather(), this.ignoreLevel());
+            const attack = Party.calculateOnePokemonAttack(pokemon, this.type1(), this.type2(), this.region(), -1, ignoreRegionMultiplier, this.includeBreeding(), this.baseAttackOnly(), this.weather(), this.ignoreLevel());
 
             typedamage[dataPokemon.type1] += attack / 2;
             const otherType = dataPokemon.type2 !== PokemonType.None ? dataPokemon.type2 : dataPokemon.type1;
@@ -67,11 +68,12 @@ class DamageCalculator {
             name: dataPokemon.name,
             type1: dataPokemon.type1,
             type2: dataPokemon.type2,
-            damage: App.game.party.calculateOnePokemonAttack(
+            damage: Party.calculateOnePokemonAttack(
                 pokemon,
                 DamageCalculator.type1(),
                 DamageCalculator.type2(),
                 DamageCalculator.region(),
+                -1,
                 ignoreRegionMultiplier,
                 DamageCalculator.includeBreeding(),
                 DamageCalculator.baseAttackOnly(),

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -256,7 +256,7 @@ class MapHelper {
             // Gather users attack when they moved regions
             LogEvent('attack measurement', 'new region',
                 GameConstants.Region[player.highestRegion()],
-                App.game.party.calculatePokemonAttack(undefined, undefined, true, undefined, true, false, WeatherType.Clear));
+                App.game.party.calculatePokemonAttack(undefined, undefined, true, undefined, undefined, true, false, WeatherType.Clear));
             // Update hatchery region filter to include new region if all previous regions selected
             if (BreedingFilters.region.value() == (2 << player.highestRegion() - 1) - 1) {
                 BreedingFilters.region.value((2 << player.highestRegion()) - 1);


### PR DESCRIPTION
Fixes #511
The attack value displayed in the Pokemon List now changes depending on the Region.
Sorting in this list will also depend on the region.
Works with the Magikarp Jump subregion (all Pokemon except Magikarps will be displayed as 0).