### PR TITLE
Improve the Pokedex with 3 new features

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -29,15 +29,15 @@ aria-labelledby="pokedexModalLabel">
                     <div class="collapse" id="pokedex-filter-container" style="margin-bottom: 0.5rem;">
                         <div class="container-fluid py-3">
                             <div class="form-row text-left">
-                                <!--Name-->
-                                <div class="form-group col-md-6 col-6">
-                                    <label>Name</label>
-                                    <input id="nameFilter" class="form-control" placeholder="Bulbasaur" value=""
-                                        oninput="PokedexFilters.name.value(new RegExp(`(${/^\/.+\/$/.test(this.value) ? this.value.slice(1, -1) : GameHelper.escapeStringRegex(this.value)})`, 'i'))">
+                                <!--Name or ID-->
+                                <div class="form-group col-md-3 col-3">
+                                    <label>Name or ID</label>
+                                    <input id="nameFilter" class="form-control" placeholder="Bulbasaur or 1" value=""
+                                        oninput="PokedexHelper.formatSearch(this.value)">
                                 </div>
 
                                 <!--Region-->
-                                <div class="form-group col-md-6 col-6">
+                                <div class="form-group col-md-3 col-3">
                                     <label>Region</label>
                                     <select id="pokedex-filter-region" class="custom-select" style="margin-right: 8px"
                                             data-bind="options: PokedexFilters.region.options,
@@ -48,7 +48,7 @@ aria-labelledby="pokedexModalLabel">
                                 </div>
 
                                 <!--Types-->
-                                <div class="form-group col-md-6 col-6">
+                                <div class="form-group col-md-3 col-3">
                                     <label>Type</label>
                                     <select id="pokedex-filter-type1" class="custom-select" style="margin-right: 8px"
                                             data-bind="options: PokedexFilters.type1.options,
@@ -57,7 +57,7 @@ aria-labelledby="pokedexModalLabel">
                                                        value: PokedexFilters.type1.value">
                                     </select>
                                 </div>
-                                <div class="form-group col-md-6 col-6">
+                                <div class="form-group col-md-3 col-3">
                                     <label>Type</label>
                                     <select id="pokedex-filter-type2" class="custom-select"
                                             data-bind="options: PokedexFilters.type2.options,
@@ -67,7 +67,7 @@ aria-labelledby="pokedexModalLabel">
                                     </select>
                                 </div>
 
-                                <div class="form-group col-md-6 col-6">
+                                <div class="form-group col-md-3 col-3">
                                     <label for="pokedex-filter-shiny-caught">Caught Status</label>
                                     <select id="pokedex-filter-shiny-caught" autocomplete="off" class="custom-select"
                                         data-bind="options: PokedexFilters.caughtShiny.options,
@@ -77,7 +77,7 @@ aria-labelledby="pokedexModalLabel">
                                     </select>
                                 </div>
 
-                                <div class="form-group col-md-6 col-6">
+                                <div class="form-group col-md-3 col-3">
                                     <label for="pokedex-filter-pokerus-status">Pokerus Status</label>
                                     <select id="pokedex-filter-pokerus-status" autocomplete="off" class="custom-select"
                                         data-bind="options: PokedexFilters.statusPokerus.options,
@@ -87,8 +87,21 @@ aria-labelledby="pokedexModalLabel">
                                     </select>
                                 </div>
 
+                                <div class="form-group col-md-3 col-3">
+                                    <label for="pokedex-filter-obtain-method">Obtain Method</label>
+                                    <select id="pokedex-filter-obtain-method" autocomplete="off" class="custom-select"
+                                        data-bind="options: PokedexFilters.obtainMethod.options,
+                                                   optionsValue: 'value',
+                                                   optionsText: 'text',
+                                                   value: PokedexFilters.obtainMethod.value">
+                                    </select>
+                                </div>
+
+                                <!--Empty-->
+                                <div class="form-group col-md-3 col-3"></div>
+
                                 <!--Rare Hold Item-->
-                                <div class="col-md-4 col-12">
+                                <div class="col-md-3 col-12">
                                     <div class="form-group my-2">
                                         <span>Rare Hold Item</span>
                                         <label class="form-check-label toggler-wrapper style-1 float-right">
@@ -102,7 +115,7 @@ aria-labelledby="pokedexModalLabel">
                                 </div>
 
                                 <!--Hide shiny images-->
-                                <div class="col-md-4 col-12 checkbox-border-x">
+                                <div class="col-md-3 col-12 checkbox-border-left">
                                     <div class="form-group my-2">
                                         <span>Hide shiny image</span>
                                         <label class="form-check-label toggler-wrapper style-1 float-right">
@@ -116,12 +129,26 @@ aria-labelledby="pokedexModalLabel">
                                 </div>
 
                                 <!--Hide alternate forms-->
-                                <div class="col-md-4 col-12">
+                                <div class="col-md-3 col-12 checkbox-border-left">
                                     <div class="form-group my-2">
-                                        <span>Hide alternate forms</span>
+                                        <span style="font-size: 13px;">Hide alternate forms</span>
                                         <label class="form-check-label toggler-wrapper style-1 float-right">
                                             <input class="form-check-input" type="checkbox" id="pokedex-filter-hide-alternate"
                                                 data-bind="checked: PokedexFilters.hideAlternate.value">
+                                            <div class="toggler-slider">
+                                                <div class="toggler-knob"></div>
+                                            </div>
+                                        </label>
+                                    </div>
+                                </div>
+
+                                <!--Filter Mega Stone-->
+                                <div class="col-md-3 col-12 checkbox-border-left">
+                                    <div class="form-group my-2">
+                                        <span>Filter MegaStone</span>
+                                        <label class="form-check-label toggler-wrapper style-1 float-right">
+                                            <input class="form-check-input" type="checkbox" id="pokedex-filter-mega-stone"
+                                                data-bind="checked: PokedexFilters.megaStone.value">
                                             <div class="toggler-slider">
                                                 <div class="toggler-knob"></div>
                                             </div>

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -1879,3 +1879,25 @@ export const DayCycleStartHours: Record<DayCyclePart, number> = {
     [DayCyclePart.Dusk]: 17,
     [DayCyclePart.Night]: 18,
 };
+
+// Pokemon Location
+export enum PokemonLocationType {
+    Route,
+    Roaming,
+    Dungeon,
+    DungeonBoss,
+    DungeonChest,
+    Evolution,
+    Egg,
+    Baby,
+    Shop,
+    Fossil,
+    Safari,
+    BattleFrontier,
+    Wandering,
+    Discord,
+    QuestLineReward,
+    TempBattleReward,
+    GymReward,
+    DungeonReward,
+}

--- a/src/modules/settings/PokedexFilters.ts
+++ b/src/modules/settings/PokedexFilters.ts
@@ -1,5 +1,5 @@
 import PokemonType from '../enums/PokemonType';
-import { Pokerus, Region } from '../GameConstants';
+import { Pokerus, Region, PokemonLocationType } from '../GameConstants';
 import SettingOption from './SettingOption';
 import Settings from './Settings';
 import FilterOption from './FilterOption';
@@ -9,6 +9,10 @@ const PokedexFilters: Record<string, FilterOption> = {
     name: new FilterOption<RegExp>(
         'Search',
         ko.observable(new RegExp('', 'i')),
+    ),
+    id: new FilterOption<number>(
+        'SearchID',
+        ko.observable(-1),
     ),
     region: new FilterOption<Region>(
         'Region',
@@ -66,6 +70,17 @@ const PokedexFilters: Record<string, FilterOption> = {
             ...Settings.enumToNumberSettingOptionArray(Pokerus, (t) => t !== 'Infected'),
         ],
     ),
+    obtainMethod: new FilterOption<PokemonLocationType>(
+        'Obtain Method',
+        ko.observable(null),
+        'pokedexObtainMethodFilter',
+        [
+            new SettingOption('All', null),
+            ...Settings.selectOptionsToSettingOptions(
+                GameHelper.enumSelectOption(PokemonLocationType),
+            ),
+        ],
+    ),
     heldItem: new FilterOption<boolean>(
         'Rare Held Item',
         ko.observable(false),
@@ -75,6 +90,11 @@ const PokedexFilters: Record<string, FilterOption> = {
         'Hide alternate forms',
         ko.observable(false),
         'pokedexHideAltFilter',
+    ),
+    megaStone: new FilterOption<boolean>(
+        'Filter MegaStone',
+        ko.observable(false),
+        'pokedexFilterMegaStone',
     ),
 };
 

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -703,4 +703,26 @@ namespace GameConstants {
         [DayCyclePart.Dusk]: 17,
         [DayCyclePart.Night]: 18,
     };
+
+    // Pokemon Location
+    declare enum PokemonLocationType {
+        Route,
+        Roaming,
+        Dungeon,
+        DungeonBoss,
+        DungeonChest,
+        Evolution,
+        Egg,
+        Baby,
+        Shop,
+        Fossil,
+        Safari,
+        BattleFrontier,
+        Wandering,
+        Discord,
+        QuestLineReward,
+        TempBattleReward,
+        GymReward,
+        DungeonReward,
+    }
 }

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -1,26 +1,5 @@
 ///<reference path="../GameConstants.d.ts"/>
 
-enum PokemonLocationType {
-    Route,
-    Roaming,
-    Dungeon,
-    DungeonBoss,
-    DungeonChest,
-    Evolution,
-    Egg,
-    Baby,
-    Shop,
-    Fossil,
-    Safari,
-    BattleFrontier,
-    Wandering,
-    Discord,
-    QuestLineReward,
-    TempBattleReward,
-    GymReward,
-    DungeonReward
-}
-
 class PokemonHelper extends TmpPokemonHelper {
     /*
     PRETTY MUCH ONLY USED BY THE BOT BELOW
@@ -125,7 +104,7 @@ class PokemonHelper extends TmpPokemonHelper {
         Object.entries(App.game.breeding.hatchList).forEach(([eggType, eggArr]) => {
             eggArr.forEach((pokemonArr, region) => {
                 // If we only want to check up to a maximum region
-                if (maxRegion != GameConstants.Region.none && region > maxRegion)  {
+                if (maxRegion != GameConstants.Region.none && region > maxRegion) {
                     return false;
                 }
                 if (pokemonArr.includes(pokemonName)) {
@@ -328,121 +307,72 @@ class PokemonHelper extends TmpPokemonHelper {
         return questLines;
     }
 
-    public static getPokemonLocations = (pokemonName: PokemonNameType, maxRegion: GameConstants.Region = GameConstants.Region.none) => {
+    public static getPokemonLocations = (pokemonName: PokemonNameType, maxRegion: GameConstants.Region = GameConstants.Region.none, locationTypes: Array<number> = []) => {
         const encounterTypes = {};
+        const encounterFunction = {};
         // Routes
-        const regionRoutes = PokemonHelper.getPokemonRegionRoutes(pokemonName, maxRegion);
-        if (Object.keys(regionRoutes).length) {
-            encounterTypes[PokemonLocationType.Route] = regionRoutes;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Route] = () => PokemonHelper.getPokemonRegionRoutes(pokemonName, maxRegion);
         // Dungeons
-        const dungeons = PokemonHelper.getPokemonDungeons(pokemonName, maxRegion);
-        if (dungeons.length) {
-            encounterTypes[PokemonLocationType.Dungeon] = dungeons;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Dungeon] = () => PokemonHelper.getPokemonDungeons(pokemonName, maxRegion);
         // Dungeon Boss
-        const bossDungeons = PokemonHelper.getPokemonBossDungeons(pokemonName, maxRegion);
-        if (bossDungeons.length) {
-            encounterTypes[PokemonLocationType.DungeonBoss] = bossDungeons;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.DungeonBoss] = () => PokemonHelper.getPokemonBossDungeons(pokemonName, maxRegion);
         // Dungeon Chest
-        const chestDungeons = PokemonHelper.getPokemonChestDungeons(pokemonName, maxRegion);
-        if (chestDungeons.length) {
-            encounterTypes[PokemonLocationType.DungeonChest] = chestDungeons;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.DungeonChest] = () => PokemonHelper.getPokemonChestDungeons(pokemonName, maxRegion);
         // Eggs
-        const eggs = PokemonHelper.getPokemonEggs(pokemonName, maxRegion);
-        if (eggs.length) {
-            encounterTypes[PokemonLocationType.Egg] = eggs;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Egg] = () => PokemonHelper.getPokemonEggs(pokemonName, maxRegion);
         // Shops
-        const shops = PokemonHelper.getPokemonShops(pokemonName, maxRegion);
-        if (shops.length) {
-            encounterTypes[PokemonLocationType.Shop] = shops;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Shop] = () => PokemonHelper.getPokemonShops(pokemonName, maxRegion);
         // Roaming
-        const roaming = PokemonHelper.getPokemonRoamingRegions(pokemonName, maxRegion);
-        if (roaming.length) {
-            encounterTypes[PokemonLocationType.Roaming] = roaming;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Roaming] = () => PokemonHelper.getPokemonRoamingRegions(pokemonName, maxRegion);
         // Baby
-        const parents = PokemonHelper.getPokemonParents(pokemonName, maxRegion);
-        if (parents.length) {
-            encounterTypes[PokemonLocationType.Baby] = parents;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Baby] = () => PokemonHelper.getPokemonParents(pokemonName, maxRegion);
         // Fossil
-        const fossils = PokemonHelper.getPokemonFossils(pokemonName);
-        if (fossils.length) {
-            encounterTypes[PokemonLocationType.Fossil] = fossils;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Fossil] = () => PokemonHelper.getPokemonFossils(pokemonName);
         // Safari
-        const safariChance = PokemonHelper.getPokemonSafariChance(pokemonName);
-        if (Object.keys(safariChance).length) {
-            encounterTypes[PokemonLocationType.Safari] = safariChance;
-        }
+        encounterFunction[GameConstants.PokemonLocationType.Safari] = () => PokemonHelper.getPokemonSafariChance(pokemonName);
         // Evolution
-        const evolutions = PokemonHelper.getPokemonPrevolution(pokemonName, maxRegion);
-        if (evolutions.length) {
-            encounterTypes[PokemonLocationType.Evolution] = evolutions;
-        }
-
+        encounterFunction[GameConstants.PokemonLocationType.Evolution] = () => PokemonHelper.getPokemonPrevolution(pokemonName, maxRegion);
         // Battle Frontier
-        const battleFrontier = PokemonHelper.getPokemonBattleFrontier(pokemonName);
-        if (battleFrontier.length) {
-            encounterTypes[PokemonLocationType.BattleFrontier] = battleFrontier;
-        }
-
+        encounterFunction[GameConstants.PokemonLocationType.BattleFrontier] = () => PokemonHelper.getPokemonBattleFrontier(pokemonName);
         // Wandering
-        const wandering = PokemonHelper.getPokemonWandering(pokemonName);
-        if (wandering.length) {
-            encounterTypes[PokemonLocationType.Wandering] = wandering;
-        }
-
+        encounterFunction[GameConstants.PokemonLocationType.Wandering] = () => PokemonHelper.getPokemonWandering(pokemonName);
         // Discord
-        const discord = PokemonHelper.getPokemonDiscord(pokemonName);
-        if (discord.length) {
-            encounterTypes[PokemonLocationType.Discord] = discord;
-        }
-
+        encounterFunction[GameConstants.PokemonLocationType.Discord] = () => PokemonHelper.getPokemonDiscord(pokemonName);
         // Temp battle reward
-        const tempBattle = PokemonHelper.getPokemonTempBattleReward(pokemonName);
-        if (tempBattle.length) {
-            encounterTypes[PokemonLocationType.TempBattleReward] = tempBattle;
-        }
-
+        encounterFunction[GameConstants.PokemonLocationType.TempBattleReward] = () => PokemonHelper.getPokemonTempBattleReward(pokemonName);
         // Gym reward
-        const gymReward = PokemonHelper.getPokemonGymReward(pokemonName);
-        if (gymReward.length) {
-            encounterTypes[PokemonLocationType.GymReward] = gymReward;
-        }
-
+        encounterFunction[GameConstants.PokemonLocationType.GymReward] = () => PokemonHelper.getPokemonGymReward(pokemonName);
         // Dungeon reward
-        const dungeonReward = PokemonHelper.getPokemonDungeonReward(pokemonName);
-        if (dungeonReward.length) {
-            encounterTypes[PokemonLocationType.DungeonReward] = dungeonReward;
-        }
-
+        encounterFunction[GameConstants.PokemonLocationType.DungeonReward] = () => PokemonHelper.getPokemonDungeonReward(pokemonName);
         // Quest Line reward
-        const questLineReward = PokemonHelper.getPokemonQuestLineReward(pokemonName);
-        if (questLineReward.length) {
-            encounterTypes[PokemonLocationType.QuestLineReward] = questLineReward;
-        }
-
-        // Return the list of items
+        encounterFunction[GameConstants.PokemonLocationType.QuestLineReward] = () => PokemonHelper.getPokemonQuestLineReward(pokemonName);
+        // Filter and return the list of items
+        Object.keys(encounterFunction).forEach((type) => {
+            if (locationTypes.length == 0 || locationTypes.includes(+type)) {
+                const result = encounterFunction[type]();
+                if (Object.keys(result).length > 0) {
+                    encounterTypes[type] = result;
+                }
+            }
+        });
         return encounterTypes;
     }
 
     public static hasEvableLocations = (pokemonName: PokemonNameType) => {
-        const locations = PokemonHelper.getPokemonLocations(pokemonName);
-        return locations[PokemonLocationType.Dungeon] ||
-            locations[PokemonLocationType.DungeonBoss] ||
-            locations[PokemonLocationType.DungeonChest] ||
-            locations[PokemonLocationType.Evolution] ||
-            locations[PokemonLocationType.Roaming] ||
-            locations[PokemonLocationType.Route] ||
-            locations[PokemonLocationType.Safari] ||
-            locations[PokemonLocationType.Shop] ||
-            locations[PokemonLocationType.Wandering];
-
+        return Object.keys(PokemonHelper.getPokemonLocations(
+            pokemonName,
+            GameConstants.Region.none,
+            [
+                GameConstants.PokemonLocationType.Dungeon,
+                GameConstants.PokemonLocationType.DungeonBoss,
+                GameConstants.PokemonLocationType.DungeonChest,
+                GameConstants.PokemonLocationType.Evolution,
+                GameConstants.PokemonLocationType.Roaming,
+                GameConstants.PokemonLocationType.Route,
+                GameConstants.PokemonLocationType.Safari,
+                GameConstants.PokemonLocationType.Shop,
+                GameConstants.PokemonLocationType.Wandering,
+            ]
+        )).length > 0;
     };
 }

--- a/src/styles/pokedex.less
+++ b/src/styles/pokedex.less
@@ -57,8 +57,7 @@
   border-bottom: 1px solid grey;
 }
 @media (min-width: 768px) {
-  .checkbox-border-x {
+  .checkbox-border-left {
     border-left: 1px solid grey;
-    border-right: 1px solid grey;
   }
 }


### PR DESCRIPTION
### Changelog

- Add 3 new filter features to the Pokedex, now we can search pokemons by `ID`, `Obtain Method` and `Mega Stone`.

- Change the pokedex layout to show more pokemon blocks when the Filters active.

- Move the `enum` `PokemonLocationType` from private of `PokemonHelper.ts` to global of `GameConstants.ts`.

- Rewrite the `PokemonHelper.getPokemonLocations`, now you can specify the obtain method argument if you only want to calculate a few of the methods before calculating all the methods, which can speed up the calc code. It's useful in the new pokedex filter.
also rewite the `PokemonHelper.hasEvableLocations`.

### Previews
![layout](https://user-images.githubusercontent.com/34838824/226248923-d0bb1a19-abf4-44e5-a51a-ad87324f4817.png)
![obtainmethod](https://user-images.githubusercontent.com/34838824/226249163-881dc50e-cb21-40ff-b245-d23e823f5570.png)
![ID](https://user-images.githubusercontent.com/34838824/226249181-213a50de-c1df-41f9-9b82-8d8cc6b5c7dc.png)
![megastone](https://user-images.githubusercontent.com/34838824/226249187-c2a05363-8c1b-404d-bcc4-1696f2f7366b.png)

### Others(Murmur?)
I think the current Pokedex is not good enough, and it lacks something helpful for new players, the three new features will be useful in my mind so I code them.  

It's my first time to code TypeSctipt with unskillful coding, poor English.  
Feel free to point the mistakes if any.  

I change a lot of codes this time. I don't know if my codes is reasonable and if it affects others.  

If the PR is merged I will also work this on the Hatchery filters.  

