### PR TITLE
Match hatchery dropdown for Pokemon ID #

### DIFF
--- a/src/modules/settings/SortOptions.ts
+++ b/src/modules/settings/SortOptions.ts
@@ -27,7 +27,7 @@ export type SortOptionConfig = {
 
 export const SortOptionConfigs: Record<SortOptions, SortOptionConfig> = {
     [SortOptions.id]: {
-        text: 'Pokémon #',
+        text: 'Pokémon ID #',
         getValue: (p) => p.id,
     },
 

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -244,7 +244,7 @@ Settings.add(new Setting<string>('breedingDisplayFilter', 'breedingDisplayFilter
         new SettingOption('Times Hatched', 'timesHatched'),
         new SettingOption('Breeding Efficiency', 'breedingEfficiency'),
         new SettingOption('Steps per Attack Bonus', 'stepsPerAttack'),
-        new SettingOption('Pokedex ID', 'dexId'),
+        new SettingOption('Pokémon ID #', 'dexId'),
         new SettingOption('Vitamins used', 'vitamins'),
         new SettingOption('EVs', 'evs'),
     ],


### PR DESCRIPTION
The dropdown selections in the hatchery now match and both say `Pokemon ID #` instead of one saying `Pokedex ID` and the other `Pokemon #`

Closes #2121