### PR TITLE
Removed Fog Check for Castform (Hoenn)

### DIFF
--- a/src/modules/routes/RouteData.ts
+++ b/src/modules/routes/RouteData.ts
@@ -922,7 +922,7 @@ Routes.add(new RegionRoute(
           ])),
           new SpecialRoutePokemon(['Castform (Snowy)'], new MultiRequirement([
               new ObtainedPokemonRequirement('Castform'),
-              new WeatherRequirement([WeatherType.Snow, WeatherType.Blizzard, WeatherType.Hail, WeatherType.Fog]),
+              new WeatherRequirement([WeatherType.Snow, WeatherType.Blizzard, WeatherType.Hail]),
           ])),
       ],
     }),


### PR DESCRIPTION
Removed the Fog weather check for Castform (Snowy) since there is never Fog weather in Hoenn.