### PR TITLE
Gym pokemon no longer selects image based on shadow status

### DIFF
--- a/src/scripts/gym/GymPokemon.ts
+++ b/src/scripts/gym/GymPokemon.ts
@@ -3,10 +3,10 @@ class GymPokemon {
     maxHealth: number;
     level: number;
     shiny: boolean;
-    shadow: GameConstants.ShadowStatus; // Currently don't do anything. Will be added later
+    shadow: GameConstants.ShadowStatus;
     requirements: Requirement[];
 
-    constructor(name: PokemonNameType, maxHealth: number, level: number, requirements: Requirement | Requirement[] = [], shiny?: boolean, shadow?: GameConstants.ShadowStatus) {
+    constructor(name: PokemonNameType, maxHealth: number, level: number, requirements: Requirement | Requirement[] = [], shiny?: boolean, shadow = GameConstants.ShadowStatus.None) {
         this.name = name;
         this.maxHealth = maxHealth;
         this.level = level;


### PR DESCRIPTION
A small bug in the shadow image code i made:
If you had a pokemon in shadow form, and you battled the same mon against any form of trainer, that mon had the shadow image too. This is fixed now