### PR TITLE
Colosseum locations and dungeons

### DIFF
--- a/src/components/HoennSVG.html
+++ b/src/components/HoennSVG.html
@@ -1183,44 +1183,8 @@
         <!--Mt. Battle-->
         <%- include('templates/mapTown',
             { name: "Mt. Battle"
-            , x: 48, y: 5
-            , width: 10, height: 4
-            })
-        %>
-
-        <!--Mt. Battle extension-->
-        <%- include('templates/mapTown',
-            { name: "Mt. Battle"
-            , x: 49, y: 4
-            , width: 8, height: 1
-            , isExtension: true
-            })
-        %>
-
-        <!--Mt. Battle extension-->
-        <%- include('templates/mapTown',
-            { name: "Mt. Battle"
-            , x: 50, y: 3
-            , width: 6, height: 1
-            , isExtension: true
-            })
-        %>
-
-        <!--Mt. Battle extension-->
-        <%- include('templates/mapTown',
-            { name: "Mt. Battle"
-            , x: 49, y: 9
-            , width: 8, height: 1
-            , isExtension: true
-            })
-        %>
-
-        <!--Mt. Battle extension-->
-        <%- include('templates/mapTown',
-            { name: "Mt. Battle"
-            , x: 50, y: 10
-            , width: 6, height: 1
-            , isExtension: true
+            , x: 50, y: 5
+            , width: 6, height: 4
             })
         %>
 

--- a/src/components/HoennSVG.html
+++ b/src/components/HoennSVG.html
@@ -1155,6 +1155,125 @@
             })
         %>
 
+        <!--Agate Village-->
+        <%- include('templates/mapTown',
+            { name: "Agate Village"
+            , x: 24, y: 17
+            , width: 4, height: 6
+            })
+        %>
+
+        <!--Agate Village extension-->
+        <%- include('templates/mapTown',
+            { name: "Agate Village"
+            , x: 28, y: 19
+            , width: 3, height: 3
+            , isExtension: true
+            })
+        %>
+
+        <!--Relic Stone-->
+        <%- include('templates/mapTown',
+            { name: "Relic Stone"
+            , x: 24, y: 13
+            , width: 3, height: 4
+            })
+        %>
+
+        <!--Mt. Battle-->
+        <%- include('templates/mapTown',
+            { name: "Mt. Battle"
+            , x: 48, y: 5
+            , width: 10, height: 4
+            })
+        %>
+
+        <!--Mt. Battle extension-->
+        <%- include('templates/mapTown',
+            { name: "Mt. Battle"
+            , x: 49, y: 4
+            , width: 8, height: 6
+            , isExtension: true
+            })
+        %>
+
+        <!--Mt. Battle extension-->
+        <%- include('templates/mapTown',
+            { name: "Mt. Battle"
+            , x: 50, y: 3
+            , width: 6, height: 8
+            , isExtension: true
+            })
+        %>
+
+        <!--Cipher Lab-->
+        <%- include('templates/mapTown',
+            { name: "Cipher Lab"
+            , x: 53, y: 23
+            , width: 7, height: 5
+            })
+        %>
+
+        <!--Eclo Canyon-->
+        <%- include('templates/mapTown',
+            { name: "Eclo Canyon"
+            , x: 79, y: 24
+            , width: 7, height: 4
+            })
+        %>
+
+        <!--Eclo Canyon extension-->
+        <%- include('templates/mapTown',
+            { name: "Eclo Canyon"
+            , x: 83, y: 28
+            , width: 3, height: 2
+            , isExtension: true
+            })
+        %>
+
+        <!--Realgam Tower-->
+        <%- include('templates/mapTown',
+            { name: "Realgam Tower"
+            , x: 60, y: 31
+            , width: 4, height: 9
+            })
+        %>
+
+        <!--Realgam Tower extension-->
+        <%- include('templates/mapTown',
+            { name: "Realgam Tower"
+            , x: 59, y: 34
+            , width: 6, height: 4
+            , isExtension: true
+            })
+        %>
+
+        <!--Orre Colosseum-->
+        <%- include('templates/mapTown',
+            { name: "Orre Colosseum"
+            , x: 20, y: 36
+            , width: 7, height: 5
+            })
+        %>
+
+        <!--Orre Colosseum extension-->
+        <%- include('templates/mapTown',
+            { name: "Orre Colosseum"
+            , x: 21, y: 41
+            , width: 5, height: 2
+            , isExtension: true
+            })
+        %>
+
+        <!--Orre Colosseum extension-->
+        <%- include('templates/mapTown',
+            { name: "Orre Colosseum"
+            , x: 22, y: 34
+            , width: 5, height: 2
+            , isExtension: true
+            })
+        %>
+
         <!-- -------- -->
         <!-- DUNGEONS -->
         <!-- -------- -->

--- a/src/components/HoennSVG.html
+++ b/src/components/HoennSVG.html
@@ -1167,7 +1167,7 @@
         <%- include('templates/mapTown',
             { name: "Agate Village"
             , x: 28, y: 19
-            , width: 3, height: 3
+            , width: 3, height: 4
             , isExtension: true
             })
         %>
@@ -1192,7 +1192,7 @@
         <%- include('templates/mapTown',
             { name: "Mt. Battle"
             , x: 49, y: 4
-            , width: 8, height: 6
+            , width: 8, height: 1
             , isExtension: true
             })
         %>
@@ -1201,7 +1201,25 @@
         <%- include('templates/mapTown',
             { name: "Mt. Battle"
             , x: 50, y: 3
-            , width: 6, height: 8
+            , width: 6, height: 1
+            , isExtension: true
+            })
+        %>
+
+        <!--Mt. Battle extension-->
+        <%- include('templates/mapTown',
+            { name: "Mt. Battle"
+            , x: 49, y: 9
+            , width: 8, height: 1
+            , isExtension: true
+            })
+        %>
+
+        <!--Mt. Battle extension-->
+        <%- include('templates/mapTown',
+            { name: "Mt. Battle"
+            , x: 50, y: 10
+            , width: 6, height: 1
             , isExtension: true
             })
         %>
@@ -1234,16 +1252,25 @@
         <!--Realgam Tower-->
         <%- include('templates/mapTown',
             { name: "Realgam Tower"
-            , x: 60, y: 31
-            , width: 4, height: 9
+            , x: 59, y: 34
+            , width: 6, height: 4
             })
         %>
 
         <!--Realgam Tower extension-->
         <%- include('templates/mapTown',
             { name: "Realgam Tower"
-            , x: 59, y: 34
-            , width: 6, height: 4
+            , x: 61, y: 31
+            , width: 2, height: 3
+            , isExtension: true
+            })
+        %>
+
+        <!--Realgam Tower extension-->
+        <%- include('templates/mapTown',
+            { name: "Realgam Tower"
+            , x: 60, y: 38
+            , width: 4, height: 2
             , isExtension: true
             })
         %>

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -1205,7 +1205,22 @@ export const HoennDungeons = [
     'Sky Pillar',
     'Victory Road Hoenn',
     'Near Space',
-    'Pyrite Bldg', // 57
+    'Phenac City Battles',
+    'Pyrite Town Battles',
+    'Pyrite Colosseum Battles',
+    'Pyrite Bldg',
+    'Pyrite Cave',
+    'Relic Cave',
+    'Mt. Battle Battles',
+    'The Under Subway',
+    'Cipher Lab Battles',
+    'Realgam Tower Battles',
+    'Realgam Colosseum Battles',
+    'Snagem Hideout',
+    'Deep Colosseum Battles',
+    'Phenac Stadium Battles',
+    'Under Colosseum Battles',
+    'Orre Colosseum Battles', // 72
     // These aren't implemented anywhere yet
     /*
     "Island Cave",
@@ -1234,7 +1249,7 @@ export const HoennDungeons = [
 ];
 
 export const SinnohDungeons = [
-    'Oreburgh Gate', // 58
+    'Oreburgh Gate', // 73
     'Valley Windworks',
     'Eterna Forest',
     'Old Chateau',
@@ -1257,11 +1272,11 @@ export const SinnohDungeons = [
     'Flower Paradise',
     'Snowpoint Temple',
     'Stark Mountain',
-    'Hall of Origin', // 81
+    'Hall of Origin', // 96
 ];
 
 export const UnovaDungeons = [
-    'Floccesy Ranch', // 82
+    'Floccesy Ranch', // 97
     'Liberty Garden',
     'Castelia Sewers',
     'Relic Passage',
@@ -1283,11 +1298,11 @@ export const UnovaDungeons = [
     'Pledge Grove',
     'Pinwheel Forest',
     'Dreamyard',
-    'P2 Laboratory', // 104
+    'P2 Laboratory', // 119
 ];
 
 export const KalosDungeons = [
-    'Santalune Forest', // 105
+    'Santalune Forest', // 120
     'Connecting Cave',
     'Glittering Cave',
     'Reflection Cave',
@@ -1300,12 +1315,12 @@ export const KalosDungeons = [
     'Team Flare Secret HQ',
     'Terminus Cave',
     'Pokémon Village',
-    'Victory Road Kalos', // 117
+    'Victory Road Kalos', // 132
     // 'Unknown Dungeon',
 ];
 
 export const AlolaDungeons = [
-    'Trainers\' School', // 118
+    'Trainers\' School', // 133
     'Hau\'oli Cemetery',
     'Verdant Cavern',
     'Melemele Meadow',
@@ -1334,11 +1349,11 @@ export const AlolaDungeons = [
     'Ruins of Abundance',
     'Ruins of Hope',
     'Poni Meadow',
-    'Resolution Cave', // 147
+    'Resolution Cave', // 162
 ];
 
 export const GalarDungeons = [
-    'Slumbering Weald Shrine', // 148
+    'Slumbering Weald Shrine', // 163
     'Galar Mine',
     'Galar Mine No. 2',
     'Glimwood Tangle',
@@ -1358,7 +1373,7 @@ export const GalarDungeons = [
     'Lakeside Cave',
     'Dyna Tree Hill',
     'Tunnel to the Top',
-    'Crown Shrine', // 168
+    'Crown Shrine', // 183
 ];
 
 export const RegionDungeons = [

--- a/src/modules/modules.test.ts
+++ b/src/modules/modules.test.ts
@@ -99,7 +99,7 @@ describe('Test GameConstants', () => {
         expect(getGymRegion('Not a real gym')).toEqual(-1);
     });
     it('return the dungeons total index', () => {
-        expect(getDungeonIndex('Abundant Shrine')).toEqual(96);
+        expect(getDungeonIndex('Abundant Shrine')).toEqual(111);
         expect(getDungeonIndex('Not a real dungeon')).toEqual(-1);
     });
     it('return the region a dungeon is in', () => {

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2043,8 +2043,53 @@ class Update implements Saveable {
                 saveData.statistics.temporaryBattleDefeated[7] = 0;
             }
 
-            // Add Pyrite Blgd dungeon
+            // Add Phenac City Battles dungeon
             saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 57);
+
+            // Add Pyrite Town Battles dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 58);
+
+            // Add Pyrite Colosseum Battles dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 59);
+
+            // Add Pyrite Blgd dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 60);
+
+            // Add Pyrite Cave dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 61);
+
+            // Add Relic Cave dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 62);
+
+            // Add Mt. Battle Battles dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 63);
+
+            // Add The Under Subway dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 64);
+
+            // Add Cipher Lab Battles dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 65);
+
+            // Add Realgam Tower Battles dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 66);
+
+            // Add Realgam Colosseum Battles dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 67);
+
+            // Add Snagem Hideout dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 68);
+
+            // Add Deep Colosseum dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 69);
+
+            // Add Phenac Stadium dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 70);
+
+            // Add Under Colosseum dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 71);
+
+            // Add Orre Colosseum dungeon
+            saveData.statistics.dungeonsCleared = Update.moveIndex(saveData.statistics.dungeonsCleared, 72);
 
             //Team Flare Grunt 1
             saveData.statistics.temporaryBattleDefeated = Update.moveIndex(saveData.statistics.temporaryBattleDefeated, 114);

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -3472,6 +3472,27 @@ dungeonList['Near Space'] = new Dungeon('Near Space',
 
 // Orre
 
+dungeonList['Phenac City Battles'] = new Dungeon('Phenac City Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Pyrite Town Battles'] = new Dungeon('Pyrite Town Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Pyrite Colosseum Battles'] = new Dungeon('Pyrite Colosseum Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
 dungeonList['Pyrite Bldg'] = new Dungeon('Pyrite Bldg',
     [
         new DungeonTrainer('Cooltrainer',
@@ -3571,6 +3592,90 @@ dungeonList['Pyrite Bldg'] = new Dungeon('Pyrite Bldg',
                 new GymPokemon('Linoone', 910000, 33),
             ], { weight: 1 }, 'Dokken', '(female)'),
     ],
+    40000, 131);
+
+dungeonList['Pyrite Cave'] = new Dungeon('Pyrite Cave',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Relic Cave'] = new Dungeon('Relic Cave',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Mt. Battle Battles'] = new Dungeon('Mt. Battle Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['The Under Subway'] = new Dungeon('The Under Subway',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Cipher Lab Battles'] = new Dungeon('Cipher Lab Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Realgam Tower Battles'] = new Dungeon('Phenac City Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Realgam Colosseum Battles'] = new Dungeon('Phenac City Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Snagem Hideout'] = new Dungeon('Snagem Hideout',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Deep Colosseum Battles'] = new Dungeon('Deep Colosseum Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Phenac Stadium Battles'] = new Dungeon('Phenac Stadium Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Under Colosseum Battles'] = new Dungeon('Under Colosseum Battles',
+    [],
+    {},
+    560000,
+    [],
+    40000, 131);
+
+dungeonList['Orre Colosseum Battles'] = new Dungeon('Orre Colosseum Battles',
+    [],
+    {},
+    560000,
+    [],
     40000, 131);
 
 // Sinnoh

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2926,37 +2926,37 @@ TownList['Realgam Tower'] = new Town(
     {
         requirements: [new DevelopmentRequirement()],
     }
-    );
+);
 
 TownList['Realgam Colosseum'] = new Town(
-        'Realgam Colosseum',
-        GameConstants.Region.hoenn,
-        GameConstants.HoennSubRegions.Orre,
-        [new MoveToDungeon(dungeonList['Realgam Colosseum Battles'])],
-        {
-            requirements: [new DevelopmentRequirement()],
-        }
-    );
+    'Realgam Colosseum',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Realgam Colosseum Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
 
 TownList['Eclo Canyon'] = new Town(
-        'Eclo Canyon',
-        GameConstants.Region.hoenn,
-        GameConstants.HoennSubRegions.Orre,
-        [new MoveToDungeon(dungeonList['Snagem Hideout'])],
-        {
-            requirements: [new DevelopmentRequirement()],
-        }
-    );
+    'Eclo Canyon',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Snagem Hideout'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
 
 TownList['Deep Colosseum'] = new Town(
-        'Deep Colosseum',
-        GameConstants.Region.hoenn,
-        GameConstants.HoennSubRegions.Orre,
-        [new MoveToDungeon(dungeonList['Deep Colosseum Battles'])],
-        {
-            requirements: [new DevelopmentRequirement()],
-        }
-    );
+    'Deep Colosseum',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Deep Colosseum Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
 
 TownList['Orre Colosseum'] = new Town(
     'Orre Colosseum',

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2828,6 +2828,156 @@ TownList['Outskirt Stand'] = new Town(
     }
 );
 
+TownList['Phenac City'] = new Town(
+    'Phenac City',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Phenac City Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Phenac Stadium'] = new Town(
+    'Phenac Stadium',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Phenac Stadium Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Pyrite Town'] = new Town(
+    'Pyrite Town',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Pyrite Town Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Pyrite Colosseum'] = new Town(
+    'Pyrite Colosseum',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Pyrite Colosseum Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Agate Village'] = new Town(
+    'Agate Village',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Relic Cave'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Relic Stone'] = new Town(
+    'Relic Stone',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Relic Cave'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Mt. Battle'] = new Town(
+    'Mt. Battle',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Mt. Battle Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['The Under'] = new Town(
+    'The Under',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['The Under Subway'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Cipher Lab'] = new Town(
+    'Cipher Lab',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Cipher Lab Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Realgam Tower'] = new Town(
+    'Realgam Tower',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Realgam Tower Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+    );
+
+TownList['Realgam Colosseum'] = new Town(
+        'Realgam Colosseum',
+        GameConstants.Region.hoenn,
+        GameConstants.HoennSubRegions.Orre,
+        [new MoveToDungeon(dungeonList['Realgam Colosseum Battles'])],
+        {
+            requirements: [new DevelopmentRequirement()],
+        }
+    );
+
+TownList['Eclo Canyon'] = new Town(
+        'Eclo Canyon',
+        GameConstants.Region.hoenn,
+        GameConstants.HoennSubRegions.Orre,
+        [new MoveToDungeon(dungeonList['Snagem Hideout'])],
+        {
+            requirements: [new DevelopmentRequirement()],
+        }
+    );
+
+TownList['Deep Colosseum'] = new Town(
+        'Deep Colosseum',
+        GameConstants.Region.hoenn,
+        GameConstants.HoennSubRegions.Orre,
+        [new MoveToDungeon(dungeonList['Deep Colosseum Battles'])],
+        {
+            requirements: [new DevelopmentRequirement()],
+        }
+    );
+
+TownList['Orre Colosseum'] = new Town(
+    'Orre Colosseum',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Orre Colosseum Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
+TownList['Under Colosseum'] = new Town(
+    'Under Colosseum',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [new MoveToDungeon(dungeonList['Under Colosseum Battles'])],
+    {
+        requirements: [new DevelopmentRequirement()],
+    }
+);
+
 //Hoenn Dungeons
 TownList['Petalburg Woods'] = new DungeonTown(
     'Petalburg Woods',
@@ -2999,6 +3149,30 @@ TownList['Near Space'] = new DungeonTown(
         new QuestLineCompletedRequirement('The Delta Episode'),
     ]
 );
+TownList['Phenac City Battles'] = new DungeonTown(
+    'Phenac City Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Pyrite Town Battles'] = new DungeonTown(
+    'Pyrite Town Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Pyrite Colosseum Battles'] = new DungeonTown(
+    'Pyrite Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
 TownList['Pyrite Bldg'] = new DungeonTown(
     'Pyrite Bldg',
     GameConstants.Region.hoenn,
@@ -3007,6 +3181,135 @@ TownList['Pyrite Bldg'] = new DungeonTown(
         new DevelopmentRequirement(),
     ]
 );
+TownList['Pyrite Cave'] = new DungeonTown(
+    'Pyrite Cave',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Relic Cave'] = new DungeonTown(
+    'Relic Cave',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Mt. Battle Battles'] = new DungeonTown(
+    'Mt. Battle Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['The Under Subway'] = new DungeonTown(
+    'The Under Subway',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Cipher Lab Battles'] = new DungeonTown(
+    'Cipher Lab Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Realgam Tower Battles'] = new DungeonTown(
+    'Realgam Tower Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Realgam Colosseum Battles'] = new DungeonTown(
+    'Realgam Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Snagem Hideout'] = new DungeonTown(
+    'Snagem Hideout',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Deep Colosseum Battles'] = new DungeonTown(
+    'Deep Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Phenac Stadium Battles'] = new DungeonTown(
+    'Phenac Stadium Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Under Colosseum Battles'] = new DungeonTown(
+    'Under Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Realgam Tower Battles'] = new DungeonTown(
+    'Realgam Tower Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Realgam Colosseum Battles'] = new DungeonTown(
+    'Realgam Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Deep Colosseum Battles'] = new DungeonTown(
+    'Deep Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Under Colosseum Battles'] = new DungeonTown(
+    'Under Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+TownList['Orre Colosseum Battles'] = new DungeonTown(
+    'Under Colosseum Battles',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [
+        new DevelopmentRequirement(),
+    ]
+);
+
 
 //Sinnoh Shops
 const SandgemTownShop = new Shop([


### PR DESCRIPTION
This PR creates all the locations from Colosseum in the SVG, as well as all the towns and dungeons.

Most of the dungeons are not in the map because they are part of the town, for most of them you need to go to the town first, and then the dungeon.

Things to do in other PRs: 
1. Images for all the towns and dungeons.
2. A way you can go from a town to another. Some cities are not in the map because they are only accessible to go there through another city. (This one is important)
3. Adding the dock, farm, UG, etc..
4. Populate the towns and the dungeons.