### PR TITLE
Fix: Missing Gym Leader sprite on receive badge modal

### DIFF
--- a/src/components/receiveGymBadge.html
+++ b/src/components/receiveGymBadge.html
@@ -5,7 +5,7 @@ aria-labelledby="receiveBadgeModalLabel" aria-hidden="true">
        <div class="modal-header">
            <div style="width: 100%;">
                <img src="" onerror="this.src='assets/images/npcs/specialNPCs/Mysterious Trainer.png'"
-                    data-bind="attr:{ src: 'assets/images/gymLeaders/' + GymRunner.gymObservable().leaderName + '.png'}">
+                    data-bind="attr:{ src: 'assets/images/npcs/' + GymRunner.gymObservable().leaderName + '.png'}">
                <h5 class="modal-title" id="receiveBadgeModalLabel"
                    data-bind="text: GymRunner.gymObservable().leaderName.replace(/\d/g,'')">Modal title</h5>
 


### PR DESCRIPTION
Apparently, this is the only one outdated.
![image](https://user-images.githubusercontent.com/104547700/231028327-8bac9142-3f30-443b-98cc-6ba3e0cf830a.png)
