### PR TITLE
Made Balls 0.25s Faster

### DIFF
--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -25,11 +25,11 @@ class Pokeballs implements Feature {
 
     constructor() {
         this.pokeballs = [
-            new Pokeball(GameConstants.Pokeball.Pokeball, () => 0, 1250, 'A standard Poké Ball', undefined, 25),
-            new Pokeball(GameConstants.Pokeball.Greatball, () => 5, 1000, '+5% chance to catch'),
-            new Pokeball(GameConstants.Pokeball.Ultraball, () => 10, 750, '+10% chance to catch'),
-            new Pokeball(GameConstants.Pokeball.Masterball, () => 100, 500, '100% chance to catch'),
-            new Pokeball(GameConstants.Pokeball.Fastball, () => 0, 500, 'Reduced catch time', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            new Pokeball(GameConstants.Pokeball.Pokeball, () => 0, 1000, 'A standard Poké Ball', undefined, 25),
+            new Pokeball(GameConstants.Pokeball.Greatball, () => 5, 750, '+5% chance to catch'),
+            new Pokeball(GameConstants.Pokeball.Ultraball, () => 10, 500, '+10% chance to catch'),
+            new Pokeball(GameConstants.Pokeball.Masterball, () => 100, 250, '100% chance to catch'),
+            new Pokeball(GameConstants.Pokeball.Fastball, () => 0, 250, 'Reduced catch time', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
             new Pokeball(GameConstants.Pokeball.Quickball, () => {
                 if (App.game.gameState == GameConstants.GameState.fighting && player.route()) {
                     const kills = App.game.statistics.routeKills[GameConstants.Region[player.region]]?.[player.route()]?.() || 0;
@@ -40,7 +40,7 @@ class Pokeballs implements Feature {
                     return Math.min(15,Math.pow(DungeonRunner.timeLeftPercentage(),2) / 500);
                 }
                 return 0;
-            }, 1000, 'Increased catch rate on routes with less Pokémon defeated', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            }, 750, 'Increased catch rate on routes with less Pokémon defeated', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
             new Pokeball(GameConstants.Pokeball.Timerball, () => {
                 if (App.game.gameState == GameConstants.GameState.fighting && player.route()) {
                     const kills = App.game.statistics.routeKills[GameConstants.Region[player.region]]?.[player.route()]?.() || 0;
@@ -54,7 +54,7 @@ class Pokeballs implements Feature {
                     return (timeLeftPercentWhenMax < timeLeftPercent) ? (200 / timeLeftPercent - 2) : maxBonus;
                 }
                 return 0;
-            }, 1000, 'Increased catch rate on routes with more Pokémon defeated', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            }, 750, 'Increased catch rate on routes with more Pokémon defeated', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
             new Pokeball(GameConstants.Pokeball.Duskball, () => {
                 const now = new Date();
                 // If player in a dungeon or it's night time
@@ -62,9 +62,9 @@ class Pokeballs implements Feature {
                     return 15;
                 }
                 return 0;
-            }, 1000, 'Increased catch rate at night time or in dungeons', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            }, 750, 'Increased catch rate at night time or in dungeons', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
 
-            new Pokeball(GameConstants.Pokeball.Luxuryball, () => 0, 1250, 'A Luxury Poké Ball, awards a random currency for catches', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            new Pokeball(GameConstants.Pokeball.Luxuryball, () => 0, 1000, 'A Luxury Poké Ball, awards a random currency for catches', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
 
             new Pokeball(GameConstants.Pokeball.Diveball, () => {
 
@@ -73,7 +73,7 @@ class Pokeballs implements Feature {
                     return 15;
                 }
                 return 0;
-            }, 1250, 'Increased catch rate on water routes', new RouteKillRequirement(10, GameConstants.Region.hoenn, 101)),
+            }, 750, 'Increased catch rate on water routes', new RouteKillRequirement(10, GameConstants.Region.hoenn, 101)),
 
             new Pokeball(GameConstants.Pokeball.Lureball, () => {
                 if (App.game.gameState == GameConstants.GameState.fighting && player.route()) {
@@ -86,7 +86,7 @@ class Pokeballs implements Feature {
                     }
                 }
                 return 0;
-            }, 1250, 'Increased catch rate on fished Pokémon', new RouteKillRequirement(10, GameConstants.Region.hoenn, 101)),
+            }, 750, 'Increased catch rate on fished Pokémon', new RouteKillRequirement(10, GameConstants.Region.hoenn, 101)),
 
             new Pokeball(GameConstants.Pokeball.Nestball, () => {
                 const highestRegionRoutes = Routes.getRoutesByRegion(player.highestRegion());
@@ -95,17 +95,17 @@ class Pokeballs implements Feature {
 
                 // Increased rate for earlier routes, scales with regional progression
                 return Math.min(15,Math.max(1,player.highestRegion()) * Math.max(1,(maxRoute / currentRoute)));
-            }, 1250, 'Increased catch rate on earlier routes', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            }, 750, 'Increased catch rate on earlier routes', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
 
             new Pokeball(GameConstants.Pokeball.Repeatball, () => {
                 const amountCaught = App.game.statistics.pokemonCaptured[Battle.enemyPokemon().id]();
 
                 return Math.min(15,Math.pow(amountCaught,2) / 5000);
-            }, 1250, 'Increased catch rate and EV gain rate with more catches', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
+            }, 750, 'Increased catch rate and EV gain rate with more catches', new RouteKillRequirement(10, GameConstants.Region.johto, 34)),
 
             new Pokeball(GameConstants.Pokeball.Beastball, () => {
                 return 10;
-            }, 1000, 'Can only be used on Ultra Beasts', new TemporaryBattleRequirement('Anabel')),
+            }, 750, 'Can only be used on Ultra Beasts', new TemporaryBattleRequirement('Anabel')),
         ];
         this._alreadyCaughtSelection = ko.observable(this.defaults.alreadyCaughtSelection);
         this._alreadyCaughtShinySelection = ko.observable(this.defaults.alreadyCaughtShinySelection);


### PR DESCRIPTION
Made all Balls 0.25s faster. Made half of special balls, those at Poké Ball speed (1.25s before), match new Great Ball speed (0.75s, before it was 1s). This speeds up grinding in early Kanto. Also helps with late goals like EV-ing Pokémon and getting DT for the dungeon achievements.

In other words:
Poké Ball changed from 1.25s -> 1s.
Great Ball changed from 1s -> 0.75s.
Ultra Ball changed from 0.75s -> 0.5s.
Master Ball changed from 0.5s -> 0.25s.
As for special balls. Most are now 0.75s (before, 1.25s and 1s) except Fast Ball that has 0.25s (before, 0.5s) to match new Master Ball speed, and Luxury Ball that has 1s (before, 1.25s) to match new Poké Ball speed.