### PR TITLE
(spelling error) "dugeon" -> "dungeon"

### DIFF
--- a/src/modules/requirements/InDungeonRequirement.ts
+++ b/src/modules/requirements/InDungeonRequirement.ts
@@ -13,6 +13,6 @@ export default class InDungeonRequirement extends Requirement {
     public hint(): string {
         return `You must be in the ${
             this.dungeon
-        } dugeon`;
+        } dungeon`;
     }
 }


### PR DESCRIPTION
InDungeonRequirements.ts spelling error