### PR TITLE
Creates function moveToTown

### DIFF
--- a/src/scripts/towns/TownContent.ts
+++ b/src/scripts/towns/TownContent.ts
@@ -133,3 +133,28 @@ class MoveToDungeon extends TownContent {
         return App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(this.dungeon.name)]();
     }
 }
+
+class MoveToTown extends TownContent {
+    constructor(private townName: string, private visibleRequirement: Requirement = undefined) {
+        super([]);
+    }
+
+    public cssClass() {
+        return 'btn btn-secondary';
+    }
+    public text(): string {
+        return this.townName;
+    }
+    public isVisible(): boolean {
+        return this.visibleRequirement?.isCompleted() ?? true;
+    }
+    public onclick(): void {
+        MapHelper.moveToTown(this.townName);
+    }
+    public isUnlocked(): boolean {
+        return TownList[this.townName].isUnlocked();
+    }
+    public areaStatus(): areaStatus {
+        return areaStatus[MapHelper.calculateTownCssClass(this.townName)];
+    }
+}

--- a/src/scripts/towns/TownContent.ts
+++ b/src/scripts/towns/TownContent.ts
@@ -135,7 +135,7 @@ class MoveToDungeon extends TownContent {
 }
 
 class MoveToTown extends TownContent {
-    constructor(private townName: string, private visibleRequirement: Requirement = undefined) {
+    constructor(private townName: string, private visibleRequirement: Requirement = undefined, private includeAreaStatus: boolean = true) {
         super([]);
     }
 
@@ -154,7 +154,12 @@ class MoveToTown extends TownContent {
     public isUnlocked(): boolean {
         return TownList[this.townName].isUnlocked();
     }
+
     public areaStatus(): areaStatus {
-        return areaStatus[MapHelper.calculateTownCssClass(this.townName)];
+        if (this.includeAreaStatus) {
+            return areaStatus[MapHelper.calculateTownCssClass(this.townName)];
+        } else {
+            return areaStatus.completed;
+        }
     }
 }

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2833,7 +2833,7 @@ TownList['Phenac City'] = new Town(
     'Phenac City',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Phenac City Battles'])],
+    [new MoveToTown('Phenac Stadium'), new MoveToDungeon(dungeonList['Phenac City Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2843,7 +2843,7 @@ TownList['Phenac Stadium'] = new Town(
     'Phenac Stadium',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Phenac Stadium Battles'])],
+    [new MoveToTown('Phenac City', undefined, false), new MoveToDungeon(dungeonList['Phenac Stadium Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2853,7 +2853,7 @@ TownList['Pyrite Town'] = new Town(
     'Pyrite Town',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Pyrite Town Battles'])],
+    [new MoveToTown('Pyrite Colosseum'), new MoveToTown('The Under'), new MoveToDungeon(dungeonList['Pyrite Town Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2863,7 +2863,7 @@ TownList['Pyrite Colosseum'] = new Town(
     'Pyrite Colosseum',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Pyrite Colosseum Battles'])],
+    [new MoveToTown('Pyrite Town', undefined, false), new MoveToDungeon(dungeonList['Pyrite Colosseum Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2873,7 +2873,7 @@ TownList['Agate Village'] = new Town(
     'Agate Village',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Relic Cave'])],
+    [new MoveToTown('Relic Stone'), new MoveToDungeon(dungeonList['Relic Cave'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2883,7 +2883,7 @@ TownList['Relic Stone'] = new Town(
     'Relic Stone',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Relic Cave']), new PurifyChamberTownContent()],
+    [new MoveToTown('Agate Village', undefined, false), new MoveToDungeon(dungeonList['Relic Cave']), new PurifyChamberTownContent()],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2903,7 +2903,7 @@ TownList['The Under'] = new Town(
     'The Under',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['The Under Subway'])],
+    [new MoveToTown('Pyrite Town', undefined, false), new MoveToTown('Under Colosseum'), new MoveToTown('Deep Colosseum'), new MoveToDungeon(dungeonList['The Under Subway'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2923,7 +2923,7 @@ TownList['Realgam Tower'] = new Town(
     'Realgam Tower',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Realgam Tower Battles'])],
+    [new MoveToTown('Realgam Colosseum'), new MoveToDungeon(dungeonList['Realgam Tower Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2933,7 +2933,7 @@ TownList['Realgam Colosseum'] = new Town(
     'Realgam Colosseum',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Realgam Colosseum Battles'])],
+    [new MoveToTown('Realgam Tower', undefined, false), new MoveToDungeon(dungeonList['Realgam Colosseum Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2953,7 +2953,7 @@ TownList['Deep Colosseum'] = new Town(
     'Deep Colosseum',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Deep Colosseum Battles'])],
+    [new MoveToTown('The Under', undefined, false), new MoveToDungeon(dungeonList['Deep Colosseum Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }
@@ -2973,7 +2973,7 @@ TownList['Under Colosseum'] = new Town(
     'Under Colosseum',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [new MoveToDungeon(dungeonList['Under Colosseum Battles'])],
+    [new MoveToTown('The Under', undefined, false), new MoveToDungeon(dungeonList['Under Colosseum Battles'])],
     {
         requirements: [new DevelopmentRequirement()],
     }


### PR DESCRIPTION
This creates a function that you can use to create a button to move to a town in the same way we have one to move you to a dungeon.

When used you can move to a town from another without using the map, useful when the town is not in the map for whatever reason, in the case of Orre there is a town _underneath_ another town.

Thanks Jaas for this!