### PR TITLE
Added notification settings for hiring/firing Hatchery Helpers and Farm Hands

### DIFF
--- a/src/modules/notifications/NotificationConstants.ts
+++ b/src/modules/notifications/NotificationConstants.ts
@@ -57,6 +57,7 @@ const NotificationConstants = {
             hatched: new NotificationSetting('notification.hatched', 'Egg hatched', true),
             hatched_shiny: new NotificationSetting('notification.hatched_shiny', 'Egg hatched a shiny', true),
             empty_queue: new NotificationSetting('empty_queue', 'Hatchery queue is empty', true),
+            hatchery_helper: new NotificationSetting('notification.hatchery_helper', 'Hatchery Helper Hired/Fired', true),
         },
         Dungeons: {
             dungeon_complete: new NotificationSetting('notification.dungeon_complete', 'Dungeon completed', true),
@@ -85,6 +86,7 @@ const NotificationConstants = {
             berry_dropped: new NotificationSetting('notification.berry_dropped', 'Berry has been dropped', true),
             mulch_ran_out: new NotificationSetting('notification.mulch_ran_out', 'Mulch has run out', true),
             wandering_pokemon: new NotificationSetting('notification.wandering_pokemon', 'Wandering Pokémon encountered', true),
+            farm_hand: new NotificationSetting('notification.farm_hand', 'Farm Hand Hired/Fired', true),
         },
     },
 };

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -105,6 +105,7 @@ class HatcheryHelper {
             message: 'Thanks for hiring me,\nI won\'t let you down!',
             type: NotificationConstants.NotificationOption.success,
             timeout: 30 * GameConstants.SECOND,
+            setting: NotificationConstants.NotificationSetting.Hatchery.hatchery_helper,
         });
     }
 
@@ -114,6 +115,7 @@ class HatcheryHelper {
             message: 'Thanks for the work.\nLet me know when you\'re hiring again!',
             type: NotificationConstants.NotificationOption.info,
             timeout: 30 * GameConstants.SECOND,
+            setting: NotificationConstants.NotificationSetting.Hatchery.hatchery_helper,
         });
         this.hired(false);
         return;

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -137,6 +137,7 @@ class FarmHand {
             message: 'Thanks for hiring me,\nI won\'t let you down!',
             type: NotificationConstants.NotificationOption.success,
             timeout: 30 * GameConstants.SECOND,
+            setting: NotificationConstants.NotificationSetting.Farming.farm_hand,
         });
     }
 
@@ -146,6 +147,7 @@ class FarmHand {
             message: 'Thanks for the work.\nLet me know when you\'re hiring again!',
             type: NotificationConstants.NotificationOption.info,
             timeout: 30 * GameConstants.SECOND,
+            setting: NotificationConstants.NotificationSetting.Farming.farm_hand,
         });
         this.hired(false);
         return;


### PR DESCRIPTION
Farm Hands currently have four notifications (each one is 30s duration):
- "Thanks for hiring me"
- "Thanks for the work, let me know when you're hiring again"
- "You don't have enough farm points to hire me..."
- "It looks like you're short on farm points... let me know when you're hiring again"
- "Here's your bill for the hour"

The first two are for hiring and firing respectively, which are manual actions (i.e. they always follow a click and don't happen when AFK or idle). This PR adds a setting to notifications tab for Hatchery Helper Hire/Fire notification. When disabled, the two aforementioned notifications do not show up. When enabled, they do.

Hatchery Helpers have:
- "Thanks for hiring me"
- "Thanks for the work. Let me know when you're hiring again"
- "You don't have enough <currency> to hire me..."
- "Looks like you're short on <currency>... let me know when you're hiring again!"

The first two are for hiring and firing respectively, which are manual actions (i.e. they always follow a click and don't happen when AFK or idle). This PR adds a setting to notifications tab for Hatchery Helper Hire/Fire notification. When disabled, the two aforementioned notifications do not show up. When enabled, they do.