### PR TITLE
Hotkey for opening the shop

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -107,6 +107,7 @@
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.farm')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.hatchery')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.underground')}"></tr>
+                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.shop')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.oakItems')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.pokeballSelection')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.dailyQuests')}"></tr>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -302,6 +302,7 @@ Settings.add(new HotkeySetting('hotkey.farm', 'Farm', 'F'));
 Settings.add(new HotkeySetting('hotkey.hatchery', 'Hatchery', 'H'));
 Settings.add(new HotkeySetting('hotkey.oakItems', 'Oak Items', 'O'));
 Settings.add(new HotkeySetting('hotkey.underground', 'Underground', 'U'));
+Settings.add(new HotkeySetting('hotkey.shop', 'Poké Mart', 'E'));
 Settings.add(new HotkeySetting('hotkey.dailyQuests', 'Daily Quests', 'Q'));
 Settings.add(new HotkeySetting('hotkey.pokeballSelection', 'Poké Ball Selection', 'P', { suffix: ' + Number' }));
 

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -127,6 +127,7 @@ class GameController {
         const $shipModal = $('#ShipModal');
         // Shop
         const $shopModal = $('#shopModal');
+        $shopModal.on('hidden.bs.modal shown.bs.modal', _ => $shopModal.data('disable-toggle', false));
 
         $(document).on('keydown', e => {
             // Ignore any of our controls if focused on an input element
@@ -411,6 +412,16 @@ class GameController {
                         $('.modal').modal('hide');
                         $undergroundModal.data('disable-toggle', true);
                         $undergroundModal.modal('toggle');
+                        return e.preventDefault();
+                    }
+                    break;
+                case Settings.getSetting('hotkey.shop').value:
+                    // Open the Poke Mart
+                    if (App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Champion Lance')]() >= 1 && !$shopModal.data('disable-toggle')) {
+                        $('.modal').modal('hide');
+                        ShopHandler.showShop(pokeMartShop);
+                        $shopModal.data('disable-toggle', true);
+                        $shopModal.modal('toggle');
                         return e.preventDefault();
                     }
                     break;


### PR DESCRIPTION
Closes #4071 
Hotkey "E" added for opening the shop, configurable in Hotkeys section of settings.

I chose "E" because the title of the modal is "Explorer's Poke Mart" and other suggested hotkeys were not going to work.

For example 
M [Mart] does not work because it is already used within the shop (Max Items)
P [Poke Mart] does not work because it is already used for pokeball selection
B [Buy] does not work because it is already used within the shop (Buy)

Please do not merge unless you make sure I did the translations thing right... first time adding translatable content. I'm not sure if I should have changed the translations subrepo in this PR or not... and whether changing it to something translations/develop based is good or bad

Here is the translations PR
https://github.com/pokeclicker/pokeclicker-translations/pull/85
