### PR TITLE
Added tooltip for dungeon total pokerus icon

### DIFF
--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -29,8 +29,13 @@
 
                   <!--Pokérus image-->
                   <knockout data-bind="if: RouteHelper.minPokerusCheck(player.town().dungeon.allAvailablePokemon())">
-                      <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(player.town().dungeon.allAvailablePokemon())] + '.png'}"
-                    src=""/>
+                      <img src="" data-bind="
+                        attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(player.town().dungeon.allAvailablePokemon())] + '.png'},
+                        tooltip: {
+                            title: RouteHelper.dungeonPokerusEVs(player.town().dungeon),
+                            placement: 'bottom',
+                            trigger: 'hover'
+                        }" />
                   </knockout>
               </knockout>
             </h2>


### PR DESCRIPTION
When about to enter a dungeon, the pokerus icon at the top of the screen now shows a tooltip with the number of pokemon needed to EV. It uses the same message that is shown on the tooltip for pokerus at the bottom of the "inside dungeon" screen