### PR TITLE
pokdexPokerusFilter -> pokedexPokerusFilter

### DIFF
--- a/src/modules/settings/PokedexFilters.ts
+++ b/src/modules/settings/PokedexFilters.ts
@@ -64,7 +64,7 @@ const PokedexFilters: Record<string, FilterOption> = {
     statusPokerus: new FilterOption<number>(
         'Pokerus',
         ko.observable(-1).extend({ numeric: 0 }),
-        'pokdexPokerusFilter',
+        'pokedexPokerusFilter',
         [
             new SettingOption('All', '-1'),
             ...Settings.enumToNumberSettingOptionArray(Pokerus, (t) => t !== 'Infected'),


### PR DESCRIPTION
After a long break from PokeClicker, deserved or not up to the viewer, LegitSi found himself with an odd predicament upon returning. His games kept whitescreening during autoclicking AFK sessions! They still saved the progress, but it severely reduced his output. This was unacceptable to LegitSi. He couldn't make a shiny farm with this kind of blemish, and he was almost there to the Shinydex, meaning things got extra slow. This wasn't happening before, so what's someone to do?

He asked around, and was promptly told that CTRL+SHIFT+I still works in the client version, allowing for potential debug information to be sent. Some good news, praise the sun! But when our LegitSi opened said inspect element, there was a peculiar sight at the top. 

**-1 is not a valid value for setting pokdexPokerusFilter**

This was quite odd to LegitSi, yes it was, for two main reasons. It indicated that there was a bug in the game's code, for one, but also that there was a typo. Our LegitSi was not the kind of person to immediately run away at the sight of code, no no no! He was the person that reverse-engineered Enigma formulas to mathmetically disprove the existence of quads, and get Enigma himself in the process. That typo particularly interested LegitSi as well. It was a quest of his to one day have his contributor achievements be acknowledged and recognized, but he knew he had to work for it. His only success as of this moment was correcting a typo across the code, so this seemed like an easy task!

And indeed it was, for our little LegitSi spent more time cursing GitHub for its backwards systems than fixing the actual typo itself. But questions arose, yes they did, for this particular variable was a hapax legomenon, fancy people speak for happening only once in the code. What was this to be used for, he said to himself. Did he do it wrong, he also said to himself. In particular, since it was once again late at night when he was fixing this bug, he had zero desire to investigate why exactly it made that bug for this hapax legomenon of a variable. He much more desired figuring out why the whitescreens were there!

And thus, LegitSi decided to make an elaborate description basically saying that more work needed to be done in this field. But how to get there, you may ask? Simple! While opening up a new client and getting to CTRL+SHIFT+I as soon as possible is advised, it's probably not necessary. Simply scroll up to the first entry, where it is likely to appear. There you will see it, in all its shining glory, as a travesty just waiting to be solved.

But in the meantime, LegitSi, now armed with this debug tool in hand, set out to AFK once more to kill the whitescreens once and for all, and in the process, find that he left his computer on for so damn long that CTRL+ALT+DEL had simply died on him! It was nothing to cry about though, for everything ran perfectly fine!

Join us next time for when LegitSi is able to use the power of inspect element to scare the whitescreens away once and for all, but in the process unable to fix the bug he so desired to fix.
 