### PR TITLE
[accessibility colorblindness] change ladder tile color

### DIFF
--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -79,7 +79,7 @@
 }
 
 .tile-ladder {
-    background-color: #747252;
+    background-color: #5b5a40;
 
     &::after {
       position: absolute;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the <!- angle brackets -> will not show up in the final comment. Check the Preview tab to confirm -->

## Description
Change the color of ladder background to a bit darker shade to make it easier to tell apart for people with some kinds of colorblinds



## Motivation and Context
Have been told time ago that the ladder tile was impossible to see by a colorblind user. Now that I had a bit of time decided to take the simple task to make another of my classic prs changing less than a line and voilà! Here we are, changing just a color. Taking more time to fill this pokeclicker recipe blog than actually changing that color. But hope it can help



## How Has This Been Tested?
Using colbis website to simulate the different kinds of colorblindness



## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![Screenshot_20230503-154759](https://user-images.githubusercontent.com/114853432/235941341-75e8ee4c-a173-4694-a22a-6936a9b7e5b5.jpg)
![Screenshot_20230503-154753](https://user-images.githubusercontent.com/114853432/235941356-5662b0b6-56db-4ad0-8a1c-45a4aee03eaa.jpg)
![Screenshot_20230503-154804](https://user-images.githubusercontent.com/114853432/235941367-1c1d9ad8-e41a-468c-a815-446b5eab6de7.jpg)

The choosen color is C5 tile in this screenshots


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Accessibility 
