### PR TITLE
Fix: Wandering Pokémon icon broken in notifications

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1796,7 +1796,7 @@ class Farming implements Feature {
             case FarmNotificationType.Wander:
                 const pokemon = wander?.shiny ? `shiny ${wander?.pokemon}` : wander?.pokemon;
                 message = `A wild ${pokemon} has wandered onto the farm!`;
-                image = PokemonHelper.getImage(wander?.pokemon, wander?.shiny);
+                image = PokemonHelper.getImage(PokemonHelper.getPokemonByName(wander?.pokemon).id, wander?.shiny);
                 type = wander?.shiny ? NotificationConstants.NotificationOption.warning : NotificationConstants.NotificationOption.success;
                 sound = NotificationConstants.NotificationSound.Farming.wandering_pokemon;
                 setting = NotificationConstants.NotificationSetting.Farming.wandering_pokemon;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the <!- angle brackets -> will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Pokémon icon in wandering notification is broken since `PokemonHelper.getImage()` gets the Pokémon name instead the ID.



## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
* Gets wandering notification


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://user-images.githubusercontent.com/104547700/236081346-4c0952ae-c8f2-4a59-b526-84aebb59e66f.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* Bug fix
