### PR TITLE
Allude to the existence of the weather institute in Delta ep

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1749,7 +1749,7 @@ class QuestLineHelper {
         const talkToSteven = new TalkToNPCQuest(PrimalSteven, 'Talk to Steven in the Granite Cave to learn more avout the Primal Murals.');
         primalReversionQuestLine.addQuest(talkToSteven);
 
-        const talkToStern1 = new TalkToNPCQuest(Stern1, 'Find Captain Stern at Sea Mauville during a thunderstorm.');
+        const talkToStern1 = new TalkToNPCQuest(Stern1, 'Find Captain Stern at Sea Mauville during Thunderstorm Weather.');
         primalReversionQuestLine.addQuest(talkToStern1);
 
         const fightStern = new CustomQuest (1, 0, 'Fight Captain Stern at Sea Mauville.', () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Captain Stern')]());
@@ -1814,7 +1814,7 @@ class QuestLineHelper {
             [
                 fightPrimalGroudon,
                 fightPrimalKyogre,
-            ], 'Defeat the Primal Reversions. They will pause their rampage under the right weather conditions.'));
+            ], 'Defeat the Primal Reversions. Predict their rampage by monitoring the weather at the Weather Institute.'));
 
         const talkToMrStone2 = new TalkToNPCQuest(MrStone2, 'Talk to Mr. Stone in Slateport City.');
         primalReversionQuestLine.addQuest(talkToMrStone2);

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2629,6 +2629,14 @@ const Stern1 = new NPC('Captain Stern', [
     requirement: new MultiRequirement([new WeatherRequirement([WeatherType.Thunderstorm]), new QuestLineStepCompletedRequirement('Primal Reversion', 3), new QuestLineStepCompletedRequirement('Primal Reversion', 5, GameConstants.AchievementOption.less)]),
 });
 
+const SternSubstitute = new NPC('Deck Swabber', [
+    'Hoy thar, matey! What\'s that? You lookin\' for Cap\'n Stern, are ya? That ol\' Jack Tar! A loose cannon \'e is! You\'ll only see \'im ashore in a Thunderstorm. \'E\'ll say it\'s all due to protocol but the trut\' is lightnin\' scares \'im stem to stern! Didn\' \'ear that from me \'ough...',
+    '',
+    'If ya feel like meetin\' \'im, the fine folks at the Weather Insitute can tell you when the next storm\'s brewin\'.',
+], {image: 'assets/images/npcs/Janitor.png',
+    requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Primal Reversion', 3), new QuestLineStepCompletedRequirement('Primal Reversion', 5, GameConstants.AchievementOption.less)]),
+});
+
 const Stern2 = new NPC('Captain Stern', [
     'I see you can be trusted with the mysteries of the sea!',
     'I have been seeing a lot of strange activity around the Seafloor Cavern recently. Whirlpools, thunderstorms, and all nature of strange beasts.',
@@ -2761,7 +2769,7 @@ TownList['Sea Mauville'] = new Town(
     [TemporaryBattleList['Delta Giovanni'], TemporaryBattleList['Captain Stern']],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.hoenn, 109)],
-        npcs: [SeaMauvilleRocket1, SeaMauvilleRocket2, Stern1, Stern2, Stern3],
+        npcs: [SeaMauvilleRocket1, SeaMauvilleRocket2, Stern1, SternSubstitute, Stern2, Stern3],
     }
 );
 TownList['Verdanturf Town'] = new Town(


### PR DESCRIPTION
## Summary
<!-- Provide a general summary of your changes in the Title above -->
Adds the helpful info that the Weather Institute can predict weather when it is needed in the Delta Episode quest.
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->
## Description
<!-- Describe your changes in detail -->
- an NPC when you have to defeat Captain Stern in TownList.ts and the explicit phrase "Thunderstorm Weather" in QuestLineHelper.ts
- an updated QuestLineStep description when you have to defeat the Primals in QuestLineHelper.ts
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This was a request by a dev. It helps inform players of when they can expect to proceed further in the Delta Episode quest.
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
This hasn't been tested.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
N/A
## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UX Clarification