### PR TITLE
Hide Contest Shop

### DIFF
--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2848,7 +2848,7 @@ TownList['Lilycove City'] = new Town(
     'Lilycove City',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Hoenn,
-    [DepartmentStoreShop, HoennContestShop],
+    [DepartmentStoreShop], // HoennContestShop
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.hoenn, 121)],
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
Hides the contest shop from view, beyond Dev requirement. This way, no one will see uncaught map colors or a shop name that they cannot access.


## Motivation and Context
To prevent an unavailable bit of content from being seen.



## How Has This Been Tested?
Ran lint tests, loaded a save file and the Contest Shop does not appear in Lilycove City anymore.



## Screenshots (optional):
N/A



## Types of changes
- Bug fix, kinda