### PR TITLE
Fix access of Primal Reversion questline to be before mega-evolving Rayquaza

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1728,7 +1728,7 @@ class QuestLineHelper {
     }
 
     public static createPrimalReversionQuestLine() {
-        const primalReversionQuestLine = new QuestLine('Primal Reversion', 'Teams Aqua and Magma have been trying to unlock the Primal power of Groudon and Kyogre.', new MultiRequirement([new QuestLineStepCompletedRequirement('The Delta Episode', 30), new ObtainedPokemonRequirement('Groudon'), new ObtainedPokemonRequirement('Kyogre')]), GameConstants.BulletinBoards.Hoenn);
+        const primalReversionQuestLine = new QuestLine('Primal Reversion', 'Teams Aqua and Magma have been trying to unlock the Primal power of Groudon and Kyogre.', new MultiRequirement([new QuestLineStepCompletedRequirement('The Delta Episode', 28), new ObtainedPokemonRequirement('Groudon'), new ObtainedPokemonRequirement('Kyogre')]), GameConstants.BulletinBoards.Hoenn);
 
         const talkToMrStone1 = new TalkToNPCQuest(MrStone1, 'Talk to Mr. Stone in Slateport City.');
         primalReversionQuestLine.addQuest(talkToMrStone1);


### PR DESCRIPTION
## Description
As title, accidentally put the access step too late


## Motivation and Context
Return to intended behavior



## How Has This Been Tested?
It hasn't, but it's one number changed



## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes

- Bug fix
