### PR TITLE
Fix Karp Jump temp battle sprites

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -3691,7 +3691,7 @@ TemporaryBattleList['Magikarp Jump Koylee'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Koylee',
-        imageName: 'Kareign',
+        imageName: 'Jump Champ Green',
         firstTimeRewardFunction: () => {
             Notifier.notify({
                 message: 'You were awarded a Magikarp Calico (Orange, White)!',
@@ -3712,7 +3712,7 @@ TemporaryBattleList['Magikarp Jump Karpella'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpella',
-        imageName: 'Karson',
+        imageName: 'Jump Champ Red',
         firstTimeRewardFunction: () => {
             Notifier.notify({
                 message: 'You were awarded a Magikarp Calico (Orange, White, Black)!',
@@ -3733,7 +3733,7 @@ TemporaryBattleList['Magikarp Jump Karpen'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpen',
-        imageName: 'Kareign',
+        imageName: 'Jump Champ Green',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 33),
         firstTimeRewardFunction: () => {
             Notifier.notify({
@@ -3755,7 +3755,7 @@ TemporaryBattleList['Magikarp Jump Tykarp'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Tykarp',
-        imageName: 'Koichiro',
+        imageName: 'Jump Champ Blue',
     }
 );
 
@@ -3767,7 +3767,7 @@ TemporaryBattleList['Magikarp Jump Karpress'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpress',
-        imageName: 'Karson',
+        imageName: 'Jump Champ Red',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 34),
     }
 );
@@ -3780,7 +3780,7 @@ TemporaryBattleList['Magikarp Jump Karami'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karami',
-        imageName: 'Kareign',
+        imageName: 'Jump Champ Green',
     }
 );
 
@@ -3792,7 +3792,7 @@ TemporaryBattleList['Magikarp Jump Karson'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karson',
-        imageName: 'Koichiro',
+        imageName: 'Jump Champ Blue',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 35),
     }
 );
@@ -3805,7 +3805,7 @@ TemporaryBattleList['Magikarp Jump Karpress 2'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpress',
-        imageName: 'Karson',
+        imageName: 'Jump Champ Red',
     }
 );
 
@@ -3817,7 +3817,7 @@ TemporaryBattleList['Magikarp Jump Karpen 2'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpen',
-        imageName: 'Kareign',
+        imageName: 'Jump Champ Green',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 36),
     }
 );
@@ -3830,7 +3830,7 @@ TemporaryBattleList['Magikarp Jump Karbuck'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karbuck',
-        imageName: 'Koichiro',
+        imageName: 'Jump Champ Blue',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 36),
         firstTimeRewardFunction: () => {
             Notifier.notify({
@@ -3852,7 +3852,7 @@ TemporaryBattleList['Magikarp Jump Skyhopper'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Skyhopper',
-        imageName: 'Karson',
+        imageName: 'Jump Champ Red',
     }
 );
 
@@ -3864,7 +3864,7 @@ TemporaryBattleList['Magikarp Jump Karpen 3'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpen',
-        imageName: 'Koichiro',
+        imageName: 'Jump Champ Blue',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 37),
     }
 );
@@ -3877,7 +3877,7 @@ TemporaryBattleList['Magikarp Jump Karpella 2'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpella',
-        imageName: 'Kareign',
+        imageName: 'Jump Champ Green',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 37),
     }
 );
@@ -3890,7 +3890,7 @@ TemporaryBattleList['Magikarp Jump Karbuck 2'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karbuck',
-        imageName: 'Karson',
+        imageName: 'Jump Champ Red',
     }
 );
 
@@ -3902,7 +3902,7 @@ TemporaryBattleList['Magikarp Jump Kareign'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Kareign',
-        imageName: 'Koichiro',
+        imageName: 'Jump Champ Blue',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 38),
     }
 );
@@ -3915,7 +3915,7 @@ TemporaryBattleList['Magikarp Jump Koylee 2'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Koylee',
-        imageName: 'Kareign',
+        imageName: 'Jump Champ Green',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 38),
     }
 );
@@ -3928,7 +3928,7 @@ TemporaryBattleList['Magikarp Jump Karpress 3'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpress',
-        imageName: 'Koichiro',
+        imageName: 'Jump Champ Blue',
         firstTimeRewardFunction: () => {
             Notifier.notify({
                 message: 'You were awarded a Magikarp Grey Diamonds!',
@@ -3949,7 +3949,7 @@ TemporaryBattleList['Magikarp Jump Karpen 4'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpen',
-        imageName: 'Karson',
+        imageName: 'Jump Champ Red',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 39),
     }
 );
@@ -3962,7 +3962,7 @@ TemporaryBattleList['Magikarp Jump Karpella 3'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Karpella',
-        imageName: 'Kareign',
+        imageName: 'Jump Champ Green',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 39),
         firstTimeRewardFunction: () => {
             Notifier.notify({
@@ -3984,7 +3984,7 @@ TemporaryBattleList['Magikarp Jump Skyhopper 2'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Skyhopper',
-        imageName: 'Koichiro',
+        imageName: 'Jump Champ Blue',
     }
 );
 
@@ -3996,7 +3996,7 @@ TemporaryBattleList['Magikarp Jump Tykarp 2'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Tykarp',
-        imageName: 'Karson',
+        imageName: 'Jump Champ Red',
         visibleRequirement: new RouteKillRequirement(10, GameConstants.Region.alola, 40),
         firstTimeRewardFunction: () => {
             Notifier.notify({


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Temporary Battle trainers sprites for Magikarp Jump weren't updated
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->
## Description
<!-- Describe your changes in detail -->
Changed all Karp Jump trainers sprite image paths to reference the new filenames
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Bug fix. Trainers need trainer sprites.
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
This has not been tested.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix