### PR TITLE
Added Description to MegaStoneItem

### DIFF
--- a/src/modules/items/MegaStoneItem.ts
+++ b/src/modules/items/MegaStoneItem.ts
@@ -37,7 +37,12 @@ export default class MegaStoneItem extends Item {
     get image(): string {
         return `assets/images/megaStone/${MegaStoneType[this.megaStone]}.png`;
     }
+
     isSoldOut(): boolean {
         return player.hasMegaStone(this.megaStone);
+    }
+
+    get description(): string {
+        return this._description || `A Mega Stone for ${this.basePokemon}.`;
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Added a description to MegaStoneItem that's the same used for the Hoenn Mega Stones. This makes a description show up for the Wiki instead of being blank.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Adding a description to the items makes it so the description column in the Wiki doesn't show blank, which looked bad and didn't help.



## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Opened the console and checked some Mega Stones to see if they displayed the correct text.