### PR TITLE
Display multipliers in Statistics Modal

### DIFF
--- a/src/components/statisticsModal.html
+++ b/src/components/statisticsModal.html
@@ -8,26 +8,66 @@
                 </button>
             </div>
             <div class="modal-body p-0">
-                <table class="table table-striped table-hover table-bordered table-sm m-0">
-                    <thead>
-                      <tr>
-                        <th>Statistic</th>
-                        <th>Amount</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td class="text-left">Time Played</td>
-                        <td class="text-left tight text-muted" data-bind="html: GameConstants.formatSecondsToTime(App.game.statistics['secondsPlayed']())">-</td>
-                      </tr>
-                      <!-- ko foreach: App.game.statistics.observables -->
-                      <tr>
-                        <td class="text-left" data-bind="text: GameConstants.camelCaseToString($data)">-</td>
-                        <td class="text-left tight text-muted" data-bind="text: App.game.statistics[$data]().toLocaleString('en-US')">-</td>
-                      </tr>
-                      <!-- /ko -->
-                    </tbody>
-                </table>
+                <ul class="nav nav-tabs nav-fill">
+                    <li class="nav-item"><a class="nav-link active" href="#statisticsModalStatsPane" data-toggle="tab">Stats</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#statisticsModalMultipliersPane" data-toggle="tab">Multipliers</a></li>
+                </ul>
+                <div class="tab-content">
+                    <!-- Stats Pane -->
+                    <div class="tab-pane active" id="statisticsModalStatsPane">
+                        <table class="table table-striped table-hover table-bordered table-sm m-0">
+                            <thead>
+                            <tr>
+                                <th>Statistic</th>
+                                <th>Amount</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="text-left">Time Played</td>
+                                <td class="text-left tight text-muted" data-bind="html: GameConstants.formatSecondsToTime(App.game.statistics['secondsPlayed']())">-</td>
+                            </tr>
+                            <!-- ko foreach: App.game.statistics.observables -->
+                            <tr>
+                                <td class="text-left" data-bind="text: GameConstants.camelCaseToString($data)">-</td>
+                                <td class="text-left tight text-muted" data-bind="text: App.game.statistics[$data]().toLocaleString('en-US')">-</td>
+                            </tr>
+                            <!-- /ko -->
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <!-- Multipliers Pane -->
+                    <div class="tab-pane" id="statisticsModalMultipliersPane">
+                        <table class='table table-sm table-hover m-0'>
+                            <!-- ko foreach: Object.entries(App.game.multiplier.multipliers) -->
+                                <thead>
+                                    <tr>
+                                        <th colspan="2" class="clickable text-left table-dark text-light" data-toggle="collapse" data-bind="attr: { 'href': '#collapse-multiplier-' + $index() }">
+                                            <h3>
+                                                <knockout data-bind="text: GameConstants.camelCaseToString($data[0])"></knockout>
+                                                <div class="float-right">
+                                                    <knockout data-bind="text: `${App.game.multiplier.getBonus($data[0]).toFixed(2)}x`"></knockout>
+                                                </div>
+                                            </h3>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody data-bind="class: 'collapse', attr: { id: 'collapse-multiplier-' + $index()}">
+                                    <!-- ko foreach: $data[1] -->
+                                        <tr data-bind="if: $data.bonusFunction() !== 1">
+                                            <td data-bind="text: $data.source"></td>
+                                            <td data-bind="text: `${$data.bonusFunction().toFixed(2)}x`"></td>
+                                        </tr>
+                                    <!-- /ko -->
+                                    <tr data-bind="if: !$data[1].some(({ bonusFunction }) => bonusFunction() !== 1)">
+                                        <td colspan="2">You have no active multipliers of this type</td>
+                                    </tr>
+                                </tbody>
+                            <!-- /ko -->
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/modules/effectEngine/effectEngineRunner.ts
+++ b/src/modules/effectEngine/effectEngineRunner.ts
@@ -18,7 +18,7 @@ export default class EffectEngineRunner {
     public static initialize(multiplier: Multiplier, items: BattleItem[]) {
         items.forEach((item) => {
             if (item.multiplierType) {
-                multiplier.addBonus(item.multiplierType, () => (this.isActive(item.name)() ? item.multiplyBy : 1));
+                multiplier.addBonus(item.multiplierType, () => (this.isActive(item.name)() ? item.multiplyBy : 1), item.displayName);
             }
         });
     }

--- a/src/modules/multiplier/Multiplier.ts
+++ b/src/modules/multiplier/Multiplier.ts
@@ -5,18 +5,21 @@ export type GetMultiplierFunction = (useBonus: boolean) => number;
 export type MultTypeString = keyof typeof MultiplierType;
 
 export default class Multiplier {
-    private multipliers: Record<MultTypeString, Array<GetMultiplierFunction>>;
+    private multipliers: Record<MultTypeString, Array<{
+        bonusFunction: GetMultiplierFunction,
+        source: string,
+    }>>;
     constructor() {
         this.multipliers = GameHelper.objectFromEnumStrings(MultiplierType, () => []);
     }
 
-    addBonus(type: MultTypeString, bonusFunction: GetMultiplierFunction) {
-        this.multipliers[type].push(bonusFunction);
+    addBonus(type: MultTypeString, bonusFunction: GetMultiplierFunction, source: string) {
+        this.multipliers[type].push({ bonusFunction, source });
     }
 
     // useBonus is passed to the multiplier function to let it know if we are actually going to use the bonus it gives.
     // This is so that we can calculate the bonus without gaining oakitem exp or logging statistics
     getBonus(type: MultTypeString, useBonus: boolean = false): number {
-        return this.multipliers[type].reduce((bonus: number, getMult: GetMultiplierFunction) => bonus * getMult(useBonus), 1);
+        return this.multipliers[type].reduce((bonus: number, { bonusFunction }) => bonus * bonusFunction(useBonus), 1);
     }
 }

--- a/src/modules/oakItems/OakItems.ts
+++ b/src/modules/oakItems/OakItems.ts
@@ -185,7 +185,7 @@ export default class OakItems implements Feature {
     }
 
     private addMultiplier(type: keyof typeof MultiplierType, item: OakItemType) {
-        this.multiplier.addBonus(type, this.createMultiplierFunction(item));
+        this.multiplier.addBonus(type, this.createMultiplierFunction(item), this.itemList[item].displayName);
     }
 
     private createMultiplierFunction(item: OakItemType): GetMultiplierFunction {

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -507,9 +507,10 @@ class AchievementHandler {
         // subscribe to filters so that when the player changes a filter it automatically refilters the list
         Object.keys(this.filter).forEach(e => (<KnockoutObservable<any>> this.filter[e]).subscribe(() => this.filterAchievementList()));
 
-        multiplier.addBonus('exp', () => 1 + this.achievementBonus());
-        multiplier.addBonus('money', () => 1 + this.achievementBonus());
-        multiplier.addBonus('dungeonToken', () => 1 + this.achievementBonus());
+        const multiplierSource = 'Achievements';
+        multiplier.addBonus('exp', () => 1 + this.achievementBonus(), multiplierSource);
+        multiplier.addBonus('money', () => 1 + this.achievementBonus(), multiplierSource);
+        multiplier.addBonus('dungeonToken', () => 1 + this.achievementBonus(), multiplierSource);
     }
 
     static load() {

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -53,10 +53,11 @@ class Farming implements Feature {
         this.externalAuras[AuraType.Ev] = ko.pureComputed<number>(() => this.multiplyPlotAuras(AuraType.Ev));
         this.externalAuras[AuraType.Repel] = ko.pureComputed<number>(() => this.addPlotAuras(AuraType.Repel));
 
-        this.multiplier.addBonus('shiny', () => this.externalAuras[AuraType.Shiny]());
-        this.multiplier.addBonus('eggStep', () => this.externalAuras[AuraType.Egg]());
-        this.multiplier.addBonus('roaming', () => this.externalAuras[AuraType.Roaming]());
-        this.multiplier.addBonus('ev', () => this.externalAuras[AuraType.Ev]());
+        const multiplierSource = 'Farm Aura';
+        this.multiplier.addBonus('shiny', () => this.externalAuras[AuraType.Shiny](), multiplierSource);
+        this.multiplier.addBonus('eggStep', () => this.externalAuras[AuraType.Egg](), multiplierSource);
+        this.multiplier.addBonus('roaming', () => this.externalAuras[AuraType.Roaming](), multiplierSource);
+        this.multiplier.addBonus('ev', () => this.externalAuras[AuraType.Ev](), multiplierSource);
 
         this.highestUnlockedBerry = ko.pureComputed(() => {
             for (let i = GameHelper.enumLength(BerryType) - 2; i >= 0; i--) {

--- a/src/scripts/gems/FluteEffectRunner.ts
+++ b/src/scripts/gems/FluteEffectRunner.ts
@@ -8,7 +8,7 @@ class FluteEffectRunner {
         GameHelper.enumStrings(GameConstants.FluteItemType).forEach((itemName: GameConstants.FluteItemType) => {
             const item = (ItemList[itemName] as FluteItem);
             if (item.multiplierType) {
-                multiplier.addBonus(item.multiplierType, () => this.getFluteMultiplier(itemName));
+                multiplier.addBonus(item.multiplierType, () => this.getFluteMultiplier(itemName), item.displayName);
             }
             if (this.isActive(itemName)()) {
                 GameHelper.incrementObservable(this.numActiveFlutes,1);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Show total multiplier for shiny, exp, money etc and sources contributing to them in the Statistics modal


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Saves people a bit of time and effort calculating this manually.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Checking the Multipliers tab in game and toggling flutes, adding berries etc to confirm it updates.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![Screenshot_2023-05-12_18-34-10](https://github.com/pokeclicker/pokeclicker/assets/4183969/cbdbbce6-6ed3-4210-b702-e23935289af0)



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- New feature
- UI Addition
