### PR TITLE
Fixed broken image in Detective Pikachu Quest Line

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -2475,6 +2475,7 @@ TemporaryBattleList['Aipom Alley'] = new TemporaryBattle(
     undefined,
     {
         hideTrainer: true,
+        imageName: 'specialNPCs/Aipom Alley',
     }
 );
 TemporaryBattleList['Mime Interview'] = new TemporaryBattle(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Aipom Alley.png wasn't showing correctly in the appropriate quest step since it was missing the imageName in the temporary battle. This fixes that.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Image was broken and that's not good.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Redid the quest line until I hit the spot where the image should show, and it did.

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
