### PR TITLE
Accomodate longer pokemon names

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -239,7 +239,6 @@ aria-labelledby="pokedexModalLabel">
                                             <!-- /ko -->
                                             <img src="" width="80px" data-bind="css: { 'pokemon-not-seen': !PokedexHelper.pokemonSeen($data.id)(), 'pokemon-seen-but-not-caught': !App.game.party.alreadyCaughtPokemonByName(name) && PokedexHelper.pokemonSeen($data.id)() }, attr:{ src: PokemonHelper.getImage($data.id, App.game.party.alreadyCaughtPokemon($data.id, true) && !PokedexHelper.hideShinyImages())}">
                                             <!-- ko if: PokedexHelper.pokemonSeen($data.id) -->
-                                            <span class="pokedex-bottom-text" data-bind="text: PokemonHelper.displayName($data.name)">name</span>
                                             <a class="overlay" href="#pokemonStatisticsModal" data-toggle="modal" data-bind="click: () => {App.game.statistics.selectedPokemonID($data.id)},
                                                 tooltip: {
                                                     html: true,
@@ -258,6 +257,13 @@ aria-labelledby="pokedexModalLabel">
                                                     trigger: 'hover',
                                                     placement:'bottom'
                                                 }"></a>
+
+                                            <span class="pokedex-bottom-text text-truncate px-1" data-bind="text: PokemonHelper.displayName($data.name),
+                                                tooltip: {
+                                                    title: PokemonHelper.displayName($data.name),
+                                                    trigger: 'hover',
+                                                    placement: 'bottom'
+                                                }">name</span>
 
                                                 <!-- Category Button -->
                                                 <!-- ko if: App.game.party.alreadyCaughtPokemonByName($data.name) -->


### PR DESCRIPTION
## Description
As discussed on discord, applies `text-truncate` to the pokemon name span and adds a tooltip displaying the full name. Had to move the span to after the overlay for it to work correctly.

## Motivation and Context
Longer pokemon names could sometimes wrap to two or even three lines causing the sprite to be covered by text.

Closes #3836 

## How Has This Been Tested?
Verified text is truncated and tooltip appears on several browsers (firefox, edge) and on mobile.

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/5461da2c-2b7a-4848-a6e8-d275113d8af2)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/3ba241df-42af-4195-b2b5-be58232e014e)

## Types of changes
- UI improvement
