### PR TITLE
Additional Held Item filters

### DIFF
--- a/src/components/heldItemModal.html
+++ b/src/components/heldItemModal.html
@@ -1,5 +1,5 @@
 <div class="modal noselect fade" id="heldItemModal" tabindex="-1" role="dialog" aria-labelledby="heldItemModal">
-    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-sm" role="document">
+    <div class="modal-dialog modal-dialog-scrollable modal-sm" role="document">
         <div class="modal-content">
             <!-- ko if: modalUtils.observableState['heldItemModal'] === 'show' -->
             <div class="modal-header bg-dark text-light" style='justify-content: space-around;'>
@@ -8,14 +8,14 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="modal-body p-0">
+            <div class="modal-body p-0" style="background-color: inherit;">
                 <img data-bind="attr: { src: HeldItem.heldItemSelected().image }" width="40%"/>
                 <br/>
-                <div class="sticky-top bg-dark text-light">
+                <div class="sticky-top" style="background-color: inherit;">
                   <div class="btn-group btn-block m-0" role="group" aria-label="Basic example">
                     <button class="btn btn-block btn-secondary btn-static" data-bind="text: HeldItem.heldItemSelected().displayName + ': ' + player.amountOfItem(HeldItem.heldItemSelected().name)"></button>
                   </div>
-                  <div class="input-group" data-bind="with: Settings.getSetting('heldItemSort')">
+                  <div class="input-group px-1 mt-1" data-bind="with: Settings.getSetting('heldItemSort')">
                       <select autocomplete="off" class="custom-select" onchange="Settings.setSettingByName(this.name, SortOptions[SortOptions[this.value]])"
                           data-bind="foreach: $data.options, attr: {name}, selectedOptions: [$data.observableValue()]">
                           <option data-bind="text: $data.text, value: $data.value"></option>
@@ -30,14 +30,41 @@
                               onchange="Settings.setSettingByName('heldItemSortDirection', this.checked)"/>
                       </div>
                   </div>
-                  <div class="form-check form-check-inline align-middle">
-                    <input type="checkbox" id="hide-holding-item-pokemon" class="form-check-input" data-bind="checked: Settings.getSetting('heldItemHideHoldingPokemon').observableValue()" onchange="Settings.setSettingByName('heldItemHideHoldingPokemon', this.checked)" />
-                    <label for="hide-holding-item-pokemon" class="form-check-label">Hide Pokémon holding an item</label>
-                  </div>
-                  <div class="form-group mb-1">
+                  <div class="form-group px-1 mt-1 mb-0">
                     <input id="heldItemSearch" autocomplete="off" class="form-control" placeholder="Search"
-                        data-bind="textInput: Settings.getSetting('heldItemSearchFilter').observableValue"
-                    />
+                        data-bind="textInput: Settings.getSetting('heldItemSearchFilter').observableValue" />
+                  </div>
+                  <div class="small px-1 pb-2 my-1" style="overflow-x: hidden;">
+                    <div class="form-row px-1">
+                        <div class="form-group col-6 m-0 px-1 py-0">
+                            <label class="mb-1" for="held-item-region-filter">Region</label>
+                            <select id="held-item-region-filter" name="heldItemRegionFilter" autocomplete="off" class="custom-select custom-select-sm" onchange="Settings.setSettingByName(this.name, +this.value)">
+                                <!-- ko foreach: Settings.getSetting('heldItemRegionFilter').options.filter(r => r.value <= player.highestRegion()) -->
+                                <option data-bind="attr: { value: $data.value, selected: Settings.getSetting('heldItemRegionFilter').value === $data.value }, text: $data.text">Region</option>
+                                <!-- /ko -->
+                            </select>
+                        </div>
+                        <div class="form-group col-6 m-0 px-1 py-0">
+                            <label class="mb-1" for="held-item-type-filter">Type</label>
+                            <select id="held-item-type-filter" name="heldItemTypeFilter" autocomplete="off" class="custom-select custom-select-sm" onchange="Settings.setSettingByName(this.name, +this.value)">
+                                <!-- ko foreach: Settings.getSetting('heldItemTypeFilter').options -->
+                                <option data-bind="attr: { value: $data.value, selected: Settings.getSetting('heldItemTypeFilter').value === $data.value }, text: $data.text">Type</option>
+                                <!-- /ko -->
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-check align-middle mt-1">
+                        <input type="checkbox" id="hide-holding-item-pokemon" class="form-check-input"
+                            data-bind="checked: Settings.getSetting('heldItemHideHoldingPokemon').observableValue()"
+                            onchange="Settings.setSettingByName('heldItemHideHoldingPokemon', this.checked)" />
+                        <label for="hide-holding-item-pokemon" class="form-check-label">Hide Pokémon holding an item</label>
+                    </div>
+                    <div class="form-check align-middle mt-1">
+                        <input type="checkbox" id="show-this-item-pokemon" class="form-check-input"
+                            data-bind="checked: Settings.getSetting('heldItemShowHoldingThisItem').observableValue()"
+                            onchange="Settings.setSettingByName('heldItemShowHoldingThisItem', this.checked)" />
+                        <label for="show-this-item-pokemon" class="form-check-label">Show <u>only</u> Pokémon holding this item</label>
+                    </div>
                   </div>
                 </div>
                 <table class="table table-striped table-hover table-bordered table-sm m-0">

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -206,7 +206,6 @@ Settings.add(new BooleanSetting('vitaminHideShinyPokemon', 'Hide shiny Pokémon'
 Settings.add(new Setting<string>('vitaminSearchFilter', 'Search', [], ''));
 Settings.add(new Setting<number>('vitaminRegionFilter', 'Region', [new SettingOption('All', -2), ...Settings.enumToNumberSettingOptionArray(Region)], -2));
 Settings.add(new Setting<number>('vitaminTypeFilter', 'Type', [new SettingOption('All', -2), ...Settings.enumToNumberSettingOptionArray(PokemonType, (t) => t !== 'None')], -2));
-Settings.add(new BooleanSetting('heldItemHideHoldingPokemon', 'Hide Pokémon holding an item', false));
 
 // Held Item Sorting
 const heldItemSortSettings = Object.keys(SortOptionConfigs).map((opt) => (
@@ -215,6 +214,10 @@ const heldItemSortSettings = Object.keys(SortOptionConfigs).map((opt) => (
 Settings.add(new Setting<number>('heldItemSort', 'Sort:', heldItemSortSettings, SortOptions.id));
 Settings.add(new BooleanSetting('heldItemSortDirection', 'reverse', false));
 Settings.add(new Setting<string>('heldItemSearchFilter', 'Search', [], ''));
+Settings.add(new Setting<number>('heldItemRegionFilter', 'Region', [new SettingOption('All', -2), ...Settings.enumToNumberSettingOptionArray(Region)], -2));
+Settings.add(new Setting<number>('heldItemTypeFilter', 'Type', [new SettingOption('All', -2), ...Settings.enumToNumberSettingOptionArray(PokemonType, (t) => t !== 'None')], -2));
+Settings.add(new BooleanSetting('heldItemHideHoldingPokemon', 'Hide Pokémon holding an item', false));
+Settings.add(new BooleanSetting('heldItemShowHoldingThisItem', 'Show only Pokémon holding this item', false));
 
 // Breeding Filters
 Object.keys(BreedingFilters).forEach((key) => {

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -392,7 +392,19 @@ class PartyPokemon implements Saveable {
         if (!new RegExp(Settings.getSetting('heldItemSearchFilter').observableValue() , 'i').test(this.displayName)) {
             return true;
         }
+        if (Settings.getSetting('heldItemRegionFilter').observableValue() > -2) {
+            if (PokemonHelper.calcNativeRegion(this.name) !== Settings.getSetting('heldItemRegionFilter').observableValue()) {
+                return true;
+            }
+        }
+        const type = Settings.getSetting('heldItemTypeFilter').observableValue();
+        if (type > -2 && !pokemonMap[this.name].type.includes(type)) {
+            return true;
+        }
         if (Settings.getSetting('heldItemHideHoldingPokemon').observableValue() && this.heldItem()) {
+            return true;
+        }
+        if (Settings.getSetting('heldItemShowHoldingThisItem').observableValue() && this.heldItem() !== HeldItem.heldItemSelected()) {
             return true;
         }
 


### PR DESCRIPTION
## Description
Adds additional filters to the held item modal and a few small UI adjustments (mainly spacing).

## Motivation and Context
Improves functionality and makes managing held items a bit easier/quicker. There have been a few requests for these additional filters.

Closes #4191 

## How Has This Been Tested?
Tested that the filters work correctly.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/c3b7e145-46ae-49ee-986c-542b5291bf40)

## Types of changes
- New feature
- UI improvement
