### PR TITLE
Added Safari Level

### DIFF
--- a/src/components/safariModal.html
+++ b/src/components/safariModal.html
@@ -26,6 +26,15 @@
                         />
                     </span>
                 </h4>
+                <div class='col-6'>
+                    <div>Lvl. <knockout data-bind='text: Safari.safariLevel()'></knockout></div>
+                    <div class="progress" style='height: 5px'>
+                        <div class="progress-bar bg-info" role="progressbar"
+                             data-bind="attr:{ style: 'width:' + Safari.percentToNextSafariLevel() + '%' }"
+                             aria-valuemin="0" aria-valuemax="100">
+                        </div>
+                    </div>
+                </div>
                 <button class='btn btn-danger modalClose' onclick='Safari.closeModal()'>Leave</button>
             </div>
 

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -16,6 +16,41 @@ class Safari {
     static balls: KnockoutObservable<number> = ko.observable().extend({ numeric: 0 });
     static activeRegion: KnockoutObservable<GameConstants.Region> = ko.observable(GameConstants.Region.none);
 
+    // Safari level
+    static maxSafariLevel = 40;
+    static safariExp: KnockoutComputed<number> = ko.pureComputed(() => {
+        return App.game.statistics.safariRocksThrown() * 10 +
+            App.game.statistics.safariBaitThrown() * 10;
+    });
+    static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => Math.floor(Safari.expToLevel(Safari.safariExp())));
+    static percentToNextSafariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
+        let expRequiredThisLevel = 0;
+        if (Safari.safariLevel() == 1) {
+            expRequiredThisLevel = 0;
+        } else {
+            let i = 0;
+            while (true) {
+                if (Safari.expToLevel(Safari.safariExp() - i) <= Safari.safariLevel()) {
+                    expRequiredThisLevel = Safari.safariExp() - i;
+                    break;
+                }
+                i++;
+            }
+        }
+
+        let expRequiredNextLevel = 0;
+        let i = 0;
+        while (true) {
+            if (Math.floor(Safari.expToLevel(Safari.safariExp() + i)) > Safari.safariLevel()) {
+                expRequiredNextLevel = Safari.safariExp() - i;
+                break;
+            }
+            i++;
+        }
+
+        return (Safari.safariExp() - expRequiredThisLevel) / (expRequiredNextLevel - expRequiredThisLevel) * 100;
+    });
+
     public static sizeX(): number {
         return Math.floor(document.querySelector('#safariModal .modal-dialog').scrollWidth / 32);
     }
@@ -462,6 +497,10 @@ class Safari {
             });
         }
         return false;
+    }
+
+    private static expToLevel(exp: number) {
+        return 9.5 * (1 + exp) ^ (0.1041);
     }
 }
 

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -22,33 +22,20 @@ class Safari {
         return App.game.statistics.safariRocksThrown() * 10 +
             App.game.statistics.safariBaitThrown() * 10;
     });
-    static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => Math.floor(Safari.expToLevel(Safari.safariExp())));
+    static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
+        let expUsed = 0;
+        for (let i = 1; i <= Safari.maxSafariLevel; i++) {
+            expUsed += Safari.expRequiredForLevel(i);
+            if (Safari.safariExp() <= expUsed) {
+                return i;
+            }
+        }
+        return Safari.maxSafariLevel;
+    });
     static percentToNextSafariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
-        let expRequiredThisLevel = 0;
-        if (Safari.safariLevel() == 1) {
-            expRequiredThisLevel = 0;
-        } else {
-            let i = 0;
-            while (true) {
-                if (Safari.expToLevel(Safari.safariExp() - i) <= Safari.safariLevel()) {
-                    expRequiredThisLevel = Safari.safariExp() - i;
-                    break;
-                }
-                i++;
-            }
-        }
-
-        let expRequiredNextLevel = 0;
-        let i = 0;
-        while (true) {
-            if (Math.floor(Safari.expToLevel(Safari.safariExp() + i)) > Safari.safariLevel()) {
-                expRequiredNextLevel = Safari.safariExp() - i;
-                break;
-            }
-            i++;
-        }
-
-        return (Safari.safariExp() - expRequiredThisLevel) / (expRequiredNextLevel - expRequiredThisLevel) * 100;
+        const expForNextLevel = Safari.expRequiredForLevel(Safari.safariLevel() + 1) - Safari.expRequiredForLevel(Safari.safariLevel() + 1);
+        const expThisLevel = Safari.safariExp() - Safari.expRequiredForLevel(Safari.safariLevel());
+        return expThisLevel / expForNextLevel * 100;
     });
 
     public static sizeX(): number {
@@ -499,8 +486,8 @@ class Safari {
         return false;
     }
 
-    private static expToLevel(exp: number) {
-        return 9.5 * (1 + exp) ^ (0.1041);
+    private static expRequiredForLevel(level: number) {
+        return 2000 * (1.2 ^ (level + 2) - 1);
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Safari level!
This PR will add safari level, where you gain exp by throwing bait/rocks and catching safari pokemon.
Rocks will become better with each level.
~~Different berries can be used as bait, depending on your level (the berries and their balance will be in an other PR).~~ Bait code is weird and will require a bit more. So that will also be in a new PR
This will effect animation speed, somehow. But that is a bigger project (and i am not exactly sure what to do), so that will be added in an other PR. But the current idea is that we have 2-3 items, that increases the animation speed, which are unlocked at specific levels.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Closes #3812
Hopefully this makes the safari zone more fun to do, so we can release friend safari without feeling bad


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Played through and used the different features to see that the EXP goes up


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- New feature
