### PR TITLE
Remove Pinkan Pikachu from Sevii dex achievement

### DIFF
--- a/src/modules/requirements/SeviiCaughtRequirement.ts
+++ b/src/modules/requirements/SeviiCaughtRequirement.ts
@@ -8,8 +8,8 @@ export default class SeviiCaughtRequirement extends AchievementRequirement {
 
     public getProgress() {
         return Math.min(App.game.party.caughtPokemon
-            .filter((p) => p.name.includes('Pinkan') && p.name != 'Pinkan Pikachu'
-            || p.name.includes('Valencian')
+            .filter((p) => p.name.startsWith('Pinkan') && p.name != 'Pinkan Pikachu'
+            || p.name.startsWith('Valencian')
             || p.name === 'Crystal Onix'
             || p.name === 'Ash\'s Butterfree'
             || p.name === 'Pink Butterfree')
@@ -18,6 +18,6 @@ export default class SeviiCaughtRequirement extends AchievementRequirement {
     }
 
     public hint(): string {
-        return `${this.requiredValue} unique Pokémon need to be caught.`;
+        return `${this.requiredValue} unique Sevii Pokémon need to be caught.`;
     }
 }

--- a/src/modules/requirements/SeviiCaughtRequirement.ts
+++ b/src/modules/requirements/SeviiCaughtRequirement.ts
@@ -8,7 +8,7 @@ export default class SeviiCaughtRequirement extends AchievementRequirement {
 
     public getProgress() {
         return Math.min(App.game.party.caughtPokemon
-            .filter((p) => p.name.includes('Pinkan')
+            .filter((p) => p.name.includes('Pinkan') && p.name != 'Pinkan Pikachu'
             || p.name.includes('Valencian')
             || p.name === 'Crystal Onix'
             || p.name === 'Ash\'s Butterfree'

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -494,9 +494,9 @@ class AchievementHandler {
          */
         addGymAchievements(GameConstants.RegionGyms[GameConstants.Region.final], GameConstants.ExtraAchievementCategories.sevii, 'Sevii Islands');
         AchievementHandler.addAchievement('Sevii Trainer', 'Catch 15 unique Pokémon native to the Sevii Islands.', new SeviiCaughtRequirement(15, false), 3, GameConstants.ExtraAchievementCategories.sevii);
-        AchievementHandler.addAchievement('Sevii Master', 'Catch 35 unique Pokémon native to the Sevii Islands.', new SeviiCaughtRequirement(35, false), 6, GameConstants.ExtraAchievementCategories.sevii);
+        AchievementHandler.addAchievement('Sevii Master', 'Catch 34 unique Pokémon native to the Sevii Islands.', new SeviiCaughtRequirement(34, false), 6, GameConstants.ExtraAchievementCategories.sevii);
         AchievementHandler.addAchievement('Sevii Shiny Trainer', 'Catch 15 unique Shiny Pokémon native to the Sevii Islands.', new SeviiCaughtRequirement(15, true), 5, GameConstants.ExtraAchievementCategories.sevii);
-        AchievementHandler.addAchievement('Sevii Shiny Master', 'Catch 35 unique Shiny Pokémon native to the Sevii Islands.', new SeviiCaughtRequirement(35, true), 9, GameConstants.ExtraAchievementCategories.sevii);
+        AchievementHandler.addAchievement('Sevii Shiny Master', 'Catch 34 unique Shiny Pokémon native to the Sevii Islands.', new SeviiCaughtRequirement(34, true), 9, GameConstants.ExtraAchievementCategories.sevii);
 
         addGymAchievements(GameConstants.RegionGyms[GameConstants.Region.final + 1], GameConstants.ExtraAchievementCategories.magikarpJump, 'Magikarp Jump');
 


### PR DESCRIPTION
## Summary
<!-- Provide a general summary of your changes in the Title above -->
Makes it so that Pinkan Pikachu is no longer needed for the Sevii dex completion achievement.
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->
## Description
<!-- Describe your changes in detail -->
Changed Sevii Caught Requirement to exclude Pinkan Pikachu
Lowered the number of Sevii pokemon needed in Achievement Handler from 35 to 34
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Pinkan Pikachu is only obtainable after Kalos, leaving many players playing through Sevii confused as to what pokemon they were missing.
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested whether obtaining a Pinkan Pikachu increased the achievement counter, and it did not.
Tested whether the achievement counter counts 34 pokemon, and it does.
_Note: This was not tested with the shiny achievement._
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix