### PR TITLE
Adds Poké Spots to Orre

### DIFF
--- a/src/components/HoennSVG.html
+++ b/src/components/HoennSVG.html
@@ -1113,6 +1113,35 @@
             href:'assets/images/orre.png?v=$VERSION'
         }"></image>
 
+    <!-- ------ -->
+    <!-- ROUTES -->
+    <!-- ------ -->
+
+    <!--Rock Poké Spot-->
+    <%- include('templates/mapRoute',
+        { route: 135, region: 2
+        , width: 5, height: 4
+        , x: 83, y: 33, name: "RPS"
+        })
+    %>
+
+    <!--Oasis Poké Spot-->
+    <%- include('templates/mapRoute',
+        { route: 136, region: 2
+        , width: 5, height: 4
+        , x: 34, y: 34, name: "OPS"
+        })
+    %>
+
+    <!--Cave Poké Spot-->
+    <%- include('templates/mapRoute',
+        { route: 137, region: 2
+        , width: 4, height: 4
+        , x: 53, y: 17, name: "CPS"
+        })
+    %>
+
+
         <!-- ----- -->
         <!-- TOWNS -->
         <!-- ----- -->

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -666,7 +666,7 @@ export const Environments: Record<string, EnvironmentData> = {
     Cave: {
         [Region.kanto]: new Set([37, 39, 'Pewter City', 'Diglett\'s Cave', 'Mt. Moon', 'Rock Tunnel', 'Victory Road', 'Lost Cave', 'Altering Cave', 'Tanoby Ruins']),
         [Region.johto]: new Set(['Cianwood City', 'Ruins of Alph', 'Union Cave', 'Mt. Mortar', 'Dark Cave', 'Tohjo Falls', 'Victory Road Johto']),
-        [Region.hoenn]: new Set(['Rustboro City', 'Dewford Town', 'Rusturf Tunnel', 'Granite Cave', 'Meteor Falls', 'Jagged Pass', 'Seafloor Cavern', 'Victory Road Hoenn']),
+        [Region.hoenn]: new Set(['Rustboro City', 'Dewford Town', 'Rusturf Tunnel', 'Granite Cave', 'Meteor Falls', 'Jagged Pass', 'Seafloor Cavern', 'Victory Road Hoenn', 135]),
         [Region.sinnoh]: new Set(['Oreburgh City', 'Oreburgh Gate', 'Wayward Cave', 'Mt. Coronet', 'Mt. Coronet South', 'Iron Island', 'Mt. Coronet North', 'Victory Road Sinnoh']),
         [Region.unova]: new Set(['Relic Castle', 'Relic Passage', 'Seaside Cave', 'Victory Road Unova', 'Twist Mountain']),
         [Region.kalos]: new Set([9, 13, 'Connecting Cave', 'Kiloude City', 'Terminus Cave', 'Victory Road Kalos']),
@@ -677,7 +677,7 @@ export const Environments: Record<string, EnvironmentData> = {
     GemCave: {
         [Region.kanto]: new Set(['Viridian City', 'Cerulean Cave', 'Sunburst Island']),
         [Region.johto]: new Set(['Blackthorn City', 'Mt. Silver', 'Whirl Islands']),
-        [Region.hoenn]: new Set(['Cave of Origin', 'Sky Pillar', 'Sealed Chamber']),
+        [Region.hoenn]: new Set(['Cave of Origin', 'Sky Pillar', 'Sealed Chamber', 137]),
         [Region.sinnoh]: new Set(['Spear Pillar', 'Hall of Origin']),
         [Region.unova]: new Set(['Chargestone Cave', 'Mistralton Cave', 'Cave of Being']),
         [Region.kalos]: new Set(['Glittering Cave', 'Reflection Cave']),

--- a/src/modules/pokemons/RoamingPokemonList.ts
+++ b/src/modules/pokemons/RoamingPokemonList.ts
@@ -22,7 +22,7 @@ export default class RoamingPokemonList {
     public static roamerGroups: RoamingGroup[][] = [
         [new RoamingGroup('Kanto', [KantoSubRegions.Kanto]), new RoamingGroup('Kanto - Sevii Islands', [KantoSubRegions.Sevii123, KantoSubRegions.Sevii4567])],
         [new RoamingGroup('Johto', [JohtoSubRegions.Johto])],
-        [new RoamingGroup('Hoenn', [HoennSubRegions.Hoenn])],
+        [new RoamingGroup('Hoenn', [HoennSubRegions.Hoenn]), new RoamingGroup('Orre', [HoennSubRegions.Orre])],
         [new RoamingGroup('Sinnoh', [SinnohSubRegions.Sinnoh])],
         [new RoamingGroup('Unova', [UnovaSubRegions.Unova])],
         [new RoamingGroup('Kalos', [KalosSubRegions.Kalos])],

--- a/src/modules/routes/RouteData.ts
+++ b/src/modules/routes/RouteData.ts
@@ -1055,7 +1055,7 @@ Routes.add(new RegionRoute(
     undefined,
     HoennSubRegions.Orre,
     true,
-    1050000,
+    1500000,
 ));
 Routes.add(new RegionRoute(
     'Oasis Poké Spot', Region.hoenn, 136,
@@ -1066,7 +1066,7 @@ Routes.add(new RegionRoute(
     undefined,
     HoennSubRegions.Orre,
     true,
-    1050000,
+    1500000,
 ));
 Routes.add(new RegionRoute(
     'Cave Poké Spot', Region.hoenn, 137,
@@ -1077,7 +1077,7 @@ Routes.add(new RegionRoute(
     undefined,
     HoennSubRegions.Orre,
     true,
-    1050000,
+    1500000,
 ));
 
 /*

--- a/src/modules/routes/RouteData.ts
+++ b/src/modules/routes/RouteData.ts
@@ -1,6 +1,6 @@
 import BadgeEnums from '../enums/Badges';
 import {
-    Region, KantoSubRegions, getDungeonIndex, AlolaSubRegions, GalarSubRegions,
+    Region, KantoSubRegions, getDungeonIndex, AlolaSubRegions, GalarSubRegions, HoennSubRegions,
 } from '../GameConstants';
 import ClearDungeonRequirement from '../requirements/ClearDungeonRequirement';
 import GymBadgeRequirement from '../requirements/GymBadgeRequirement';
@@ -1045,6 +1045,39 @@ Routes.add(new RegionRoute(
         water: ['Tentacool', 'Wingull', 'Pelipper', 'Magikarp', 'Wailmer', 'Sharpedo', 'Horsea'],
     }),
     [new RouteKillRequirement(10, Region.hoenn, 133)],
+));
+Routes.add(new RegionRoute(
+    'Rock Poké Spot', Region.hoenn, 135,
+    new RoutePokemon({
+        land: ['Sandshrew', 'Gligar', 'Trapinch'],
+    }),
+    [new DevelopmentRequirement()],
+    undefined,
+    HoennSubRegions.Orre,
+    true,
+    1050000,
+));
+Routes.add(new RegionRoute(
+    'Oasis Poké Spot', Region.hoenn, 136,
+    new RoutePokemon({
+        land: ['Hoppip', 'Phanpy', 'Surskit'],
+    }),
+    [new DevelopmentRequirement()],
+    undefined,
+    HoennSubRegions.Orre,
+    true,
+    1050000,
+));
+Routes.add(new RegionRoute(
+    'Cave Poké Spot', Region.hoenn, 137,
+    new RoutePokemon({
+        land: ['Zubat', 'Aron', 'Wooper'],
+    }),
+    [new DevelopmentRequirement()],
+    undefined,
+    HoennSubRegions.Orre,
+    true,
+    1050000,
 ));
 
 /*


### PR DESCRIPTION
## Description
Added the three Poké Spots from Orre as routes for Orre with their canon pokémon.



## Motivation and Context
Eugene asked me nicely to add them



## How Has This Been Tested?
I go to Orre and the three poké stops are there and I can go there (but they don't work, Jaas is gonna check what's happening)




## Extra Notes
HP is a kind of random value since I don't know exactly the balance Eugene want to give these three routes. Requirement right now is DevRequirement for the same reason.