### PR TITLE
Safari Keybinds

### DIFF
--- a/src/components/safariBattleModal.html
+++ b/src/components/safariBattleModal.html
@@ -42,20 +42,31 @@
            <div class="modal-footer p-0 bg-dark text-light">
                 <div class="message" data-bind='html: SafariBattle.text'></div>
                 <div class="row" style="width: 100%;">
-                    <button type="button" class="btn btn-primary btn-block col-6 m-0" onclick="this.blur();SafariBattle.throwBall()" data-bind='disable: SafariBattle.busy(), text: "Ball (" + Safari.balls() + ")"'>Ball (30)</button>
-                    <div class="btn-group btn-block col-6 m-0 dropup" style="padding:0px;" data-bind="let: { baitType: ko.observable(BaitType.Bait) }">
-                        <button type="button" class='btn btn-primary btn-block' onclick="this.blur();" data-bind='{ click: function(){SafariBattle.throwBait(baitType());}, disable: BaitList[BaitType[baitType()]].amount() <= 0 || SafariBattle.busy() }'>
-                            <div style="display:inline"><img width=16px data-bind="attr: { src: BaitList[BaitType[baitType()]].image }"></div>
-                            <span data-bind="text: BaitList[BaitType[baitType()]].btnName">Bait (∞)</span>
+                    <button type="button" class="btn btn-primary btn-block col-6 m-0" onclick="this.blur();SafariBattle.throwBall()" data-bind="disable: SafariBattle.busy()">
+                        <span class="position-absolute small" style="left: 5px;" data-bind="text: `[${Settings.getSetting('hotkey.safari.ball').value}]`"></span>
+                        <knockout data-bind="text: `Ball (${Safari.balls()})`">Ball (30)</knockout>
+                    </button>
+                    <div class="btn-group btn-block col-6 m-0 dropup" style="padding:0px;">
+                        <button type="button" class='btn btn-primary btn-block' onclick="this.blur();"
+                            data-bind='{ click: function(){SafariBattle.throwBait();}, disable: SafariBattle.selectedBait().amount() <= 0 || SafariBattle.busy() }'>
+                            <span class="position-absolute small" style="left: 5px;" data-bind="text: `[${Settings.getSetting('hotkey.safari.bait').value}]`"></span>
+                            <div style="display:inline"><img width=16px data-bind="attr: { src: SafariBattle.selectedBait().image }"></div>
+                            <span data-bind="text: SafariBattle.selectedBait().btnName">Bait (∞)</span>
                         </button>
                         <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split active" data-bind="text: '&nbsp;'" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         </button>
-                        <div class="dropdown-menu dropdown-menu-right" data-bind="foreach: GameHelper.enumNumbers(BaitType)">
-                            <button class="dropdown-item" type="button" data-bind="click: function(){baitType($data)}, text: BaitList[BaitType[$data]].btnName"></button>
+                        <div class="dropdown-menu dropdown-menu-right" data-bind="foreach: GameHelper.enumStrings(BaitType)">
+                            <button class="dropdown-item" type="button" data-bind="click: function(){SafariBattle.selectedBait(BaitList[$data])}, text: BaitList[$data].btnName"></button>
                         </div>
                     </div>
-                    <button type="button" class="btn btn-primary btn-block col-6 m-0" onclick="this.blur();SafariBattle.throwRock()" data-bind="disable: SafariBattle.busy()">Rock (∞)</button>
-                    <button type="button" class="btn btn-primary btn-block col-6 m-0" onclick="this.blur();SafariBattle.run()" data-bind="disable: SafariBattle.busy()">Run</button>
+                    <button type="button" class="btn btn-primary btn-block col-6 m-0" onclick="this.blur();SafariBattle.throwRock()" data-bind="disable: SafariBattle.busy()">
+                        <span class="position-absolute small" style="left: 5px;" data-bind="text: `[${Settings.getSetting('hotkey.safari.rock').value}]`"></span>
+                        Rock (∞)
+                    </button>
+                    <button type="button" class="btn btn-primary btn-block col-6 m-0" onclick="this.blur();SafariBattle.run()" data-bind="disable: SafariBattle.busy()">
+                        <span class="position-absolute small" style="left: 5px;" data-bind="text: `[${Settings.getSetting('hotkey.safari.run').value}]`"></span>
+                        Run
+                    </button>
                 </div>
            </div>
        </div>

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -236,6 +236,15 @@
                                 </tr>
                             </tbody>
                             <thead>
+                                <tr><th colspan="2">Safari</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.safari.ball')}"></tr>
+                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.safari.bait')}"></tr>
+                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.safari.rock')}"></tr>
+                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.safari.run')}"></tr>
+                            </tbody>
+                            <thead>
                                 <tr><th colspan="2">Other</th></tr>
                             </thead>
                             <tbody>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -332,6 +332,11 @@ Settings.add(new HotkeySetting('hotkey.shop.max', 'Select max amount', 'M'));
 Settings.add(new HotkeySetting('hotkey.shop.reset', 'Reset amount', 'R'));
 Settings.add(new HotkeySetting('hotkey.shop.increase', 'Increase amount', 'I'));
 
+Settings.add(new HotkeySetting('hotkey.safari.ball', 'Throw Ball', 'C'));
+Settings.add(new HotkeySetting('hotkey.safari.bait', 'Throw Bait', 'B'));
+Settings.add(new HotkeySetting('hotkey.safari.rock', 'Throw Rock', 'R'));
+Settings.add(new HotkeySetting('hotkey.safari.run', 'Run', 'F'));
+
 // Discord
 Settings.add(new BooleanSetting('discord-rp.enabled', 'Discord RP enabled', true));
 Settings.add(new Setting('discord-rp.line-1', 'Discord line 1 text', [], 'Shinies: {caught_shiny}/{caught} {sparkle}'));

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -165,6 +165,18 @@ class GameController {
                     case Settings.getSetting('hotkey.dungeon.right').value:
                         Safari.move('right');
                         break;
+                    case Settings.getSetting('hotkey.safari.ball').value:
+                        SafariBattle.throwBall();
+                        break;
+                    case Settings.getSetting('hotkey.safari.bait').value:
+                        SafariBattle.throwBait();
+                        break;
+                    case Settings.getSetting('hotkey.safari.rock').value:
+                        SafariBattle.throwRock();
+                        break;
+                    case Settings.getSetting('hotkey.safari.run').value:
+                        SafariBattle.run();
+                        break;
                 }
 
                 // We don't want to process any other keys while in the Safari zone

--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -4,6 +4,7 @@ class SafariBattle {
     static text: KnockoutObservable<string> = ko.observable('What will you do?');
     static escapeAttempts = 0;
     static particle;
+    static selectedBait: KnockoutObservable<Bait> = ko.observable(BaitList.Bait);
 
     public static get enemy(): SafariPokemon {
         return SafariBattle._enemy();
@@ -28,7 +29,7 @@ class SafariBattle {
     }
 
     public static throwBall() {
-        if (!SafariBattle.busy()) {
+        if (Safari.inBattle() && !SafariBattle.busy()) {
             SafariBattle.busy(true);
             Safari.balls(Safari.balls() - 1);
 
@@ -153,10 +154,10 @@ class SafariBattle {
 
     }
 
-    public static throwBait(baitType: BaitType) {
-        if (!SafariBattle.busy()) {
+    public static throwBait() {
+        if (Safari.inBattle() && !SafariBattle.busy()) {
             SafariBattle.busy(true);
-            const bait: Bait = BaitList[BaitType[baitType]];
+            const bait = SafariBattle.selectedBait();
             if (bait.amount() <= 0) {
                 SafariBattle.text(`You don't have enough ${bait.name}`);
                 setTimeout(() => {
@@ -177,7 +178,7 @@ class SafariBattle {
     }
 
     public static throwRock() {
-        if (!SafariBattle.busy()) {
+        if (Safari.inBattle() && !SafariBattle.busy()) {
             SafariBattle.busy(true);
             SafariBattle.text(`You throw a rock at ${SafariBattle.enemy.displayName}`);
             GameHelper.incrementObservable(App.game.statistics.safariRocksThrown, 1);
@@ -217,7 +218,7 @@ class SafariBattle {
     }
 
     public static run() {
-        if (!SafariBattle.busy()) {
+        if (Safari.inBattle() && !SafariBattle.busy()) {
             SafariBattle.busy(true);
             SafariBattle.text('You flee.');
             setTimeout(SafariBattle.endBattle, 1500);


### PR DESCRIPTION
## Description
Adds keybinds to the Ball, Bait, Rock, and Run actions in the Safari.
Small refactor to Bait for this to work.

## Motivation and Context
Requested QoL improvement. Closes #4273 

## How Has This Been Tested?
Pressing a hotkey performs the appropriate action.
Selecting and using different bait works as before.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/993bdfc5-47ce-4397-9dac-e40b20a428a8)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/342fa6ce-ecdb-4a95-b893-feda6367b7b5)

## Types of changes
- New feature
