### PR TITLE
Fix safari area status

### DIFF
--- a/src/scripts/safari/SafariTownContent.ts
+++ b/src/scripts/safari/SafariTownContent.ts
@@ -12,17 +12,17 @@ class SafariTownContent extends TownContent {
         Safari.openModal();
     }
     public areaStatus(): areaStatus {
-        const pokemonStatusArray = [areaStatus.completed];
         if (!SafariPokemonList.list[player.region]) {
             return areaStatus.completed;
         }
+        const pokemonStatusArray = [areaStatus.completed];
         SafariPokemonList.list[player.region]().forEach(p => {
-            const currentStatus = PartyController.getCaughtStatusByName(p.name);
-            if (currentStatus == CaughtStatus.NotCaught) {
+            const caughtStatus = PartyController.getCaughtStatusByName(p.name);
+            if (caughtStatus == CaughtStatus.NotCaught) {
                 pokemonStatusArray.push(areaStatus.uncaughtPokemon);
-            } else if (currentStatus == CaughtStatus.Caught) {
+            } else if (caughtStatus == CaughtStatus.Caught) {
                 pokemonStatusArray.push(areaStatus.uncaughtShinyPokemon);
-            } else if (currentStatus < GameConstants.Pokerus.Resistant) {
+            } else if (PartyController.getPokerusStatusByName(p.name) < GameConstants.Pokerus.Resistant) {
                 pokemonStatusArray.push(areaStatus.missingResistant);
             }
         });


### PR DESCRIPTION
## Description
Safari zones would show as missing resistant on the map even if all pokemon were resistant.

## Motivation and Context
Fix bug

## How Has This Been Tested?
Loaded save w/ all kanto safari pokemon resistant - no color
Set one kanto safari pokemon to contagious - color overlay appeared
Set pokemon back to resistant - color overlay gone

## Types of changes
- Bug fix
