### PR TITLE
More textual overlap fixes + more styling changes

### DIFF
--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -1,19 +1,28 @@
 <div class="row justify-content-center no-gutters" data-bind="if: App.game.gameState === GameConstants.GameState.dungeon">
     <div class="col no-gutters clickable" style="height: 280px; display: block;"
-        data-bind="click: function() { DungeonRunner.handleClick() }">
-        <h2 class="pageItemTitle mobileBattleTitle" style="display: block;">
+         data-bind="click: function() { DungeonRunner.handleClick() }">
+        <h2 class="pageItemTitle dungeonTitle" style="display: block;">
             <knockout data-bind="if: DungeonBattle.enemyPokemon() && DungeonBattle.enemyPokemon().health()">
                 <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': DungeonBattle.enemyPokemon() } }">Pokémon name</knockout>
                 <!-- ko if: !DungeonBattle.trainer() -->
                 <knockout data-bind="template: { name: 'caughtStatusTemplate', data: {'status': PartyController.getCaughtStatus(DungeonBattle.enemyPokemon().id)}}"></knockout>
                 <knockout style="position: relative; top: -1px;"
-                    data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(DungeonBattle.enemyPokemon().id) }}">
+                          data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(DungeonBattle.enemyPokemon().id) }}">
                 </knockout>
                 <!-- /ko -->
             </knockout>
             <knockout data-bind="if: !DungeonBattle.enemyPokemon() || !DungeonBattle.enemyPokemon().health()">
                 &nbsp;
             </knockout>
+
+            <div class="progress timer">
+                <div class="progress-bar bg-danger" role="progressbar"
+                     data-bind="attr:{ style: 'width:' + DungeonRunner.timeLeftPercentage() + '%' },
+                     css: { 'bg-danger' : DungeonRunner.timeLeftSeconds() < 20, 'bg-primary': DungeonRunner.timeLeftSeconds() >= 20 }"
+                     aria-valuemin="0" aria-valuemax="100">
+                     <span data-bind="text: DungeonRunner.timeLeftSeconds() + 's'" style="font-size: 12px;"></span>
+                </div>
+            </div>
 
             <knockout class="left">
                 <!-- ko if: DungeonBattle.trainer() -->
@@ -36,18 +45,10 @@
                 </span>
             </knockout>
             <!-- /ko -->
-            <div class="progress timer">
-                <div class="progress-bar bg-danger" role="progressbar"
-                     data-bind="attr:{ style: 'width:' + DungeonRunner.timeLeftPercentage() + '%' },
-                     css: { 'bg-danger': DungeonRunner.timeLeftSeconds() < 20, 'bg-primary': DungeonRunner.timeLeftSeconds() >= 20 }"
-                     aria-valuemin="0" aria-valuemax="100">
-                     <span data-bind="text: DungeonRunner.timeLeftSeconds() + 's'" style="font-size: 12px;"></span>
-                </div>
-            </div>
         </h2>
 
         <!-- ko if: (DungeonRunner.fighting() || DungeonBattle.catching)  -->
-        <div data-bind="if: DungeonBattle.enemyPokemon">
+        <div class="dungeon" data-bind="if: DungeonBattle.enemyPokemon">
             <div class="trainer" data-bind="if: DungeonBattle.trainer()">
                 <img data-bind="attr:{ src: DungeonBattle.trainer().image }" onerror="this.src='assets/images/npcs/specialNPCs/Mysterious Trainer.png';"/>
             </div>
@@ -68,7 +69,7 @@
                 <div class="progress-bar bg-danger" role="progressbar"
                      data-bind="attr:{ style: 'width:' + DungeonBattle.enemyPokemon().healthPercentage() + '%'}, css: { 'healthbar-boss': DungeonRunner.fightingBoss(), 'bg-danger': !DungeonRunner.fightingBoss()}"
                      aria-valuemin="0" aria-valuemax="100">
-                     <span data-bind="text: DungeonBattle.enemyPokemon().health().toLocaleString('en-US') + ' / ' + DungeonBattle.enemyPokemon().maxHealth().toLocaleString('en-US')" style="font-size: 12px;"></span>
+                    <span data-bind="text: DungeonBattle.enemyPokemon().health().toLocaleString('en-US') + ' / ' + DungeonBattle.enemyPokemon().maxHealth().toLocaleString('en-US')" style="font-size: 12px;"></span>
                 </div>
             </div>
         </div>
@@ -100,47 +101,47 @@
         </div>
         <!-- /ko -->
         <h2 class="pageItemFooter" style="display: block; font-size: 1rem;">
-          <table width="100%">
-              <tr>
-                <td width="50%">
-                  <knockout data-bind="text: DungeonRunner.dungeon.name">Dungeon name</knockout>
-                  <!--If all Pokémon in the dungeon are caught-->
-                  <knockout data-bind="if: (!DungeonRunner.dungeonCompleted(DungeonRunner.dungeon, true) && DungeonRunner.dungeonCompleted(DungeonRunner.dungeon, false))">
-                      <img title="You have captured all Pokémon in this dungeon!" class="pokeball-smallest"
-                           src="assets/images/pokeball/Pokeball.svg"/>
-                  </knockout>
+            <table width="100%">
+                <tr>
+                    <td width="50%">
+                        <knockout data-bind="text: DungeonRunner.dungeon.name">Dungeon name</knockout>
+                        <!--If all Pokémon in the dungeon are caught-->
+                        <knockout data-bind="if: (!DungeonRunner.dungeonCompleted(DungeonRunner.dungeon, true) && DungeonRunner.dungeonCompleted(DungeonRunner.dungeon, false))">
+                            <img title="You have captured all Pokémon in this dungeon!" class="pokeball-smallest"
+                                 src="assets/images/pokeball/Pokeball.svg"/>
+                        </knockout>
 
-                  <!--If all Pokémon in the dungeon are caught shiny-->
-                  <knockout data-bind="if: DungeonRunner.dungeonCompleted(DungeonRunner.dungeon, true)">
-                      <img title="You have captured all Pokémon shiny in this dungeon!"
-                           class="pokeball-smallest"
-                           src="assets/images/pokeball/Pokeball-shiny.svg"/>
-                  </knockout>
+                        <!--If all Pokémon in the dungeon are caught shiny-->
+                        <knockout data-bind="if: DungeonRunner.dungeonCompleted(DungeonRunner.dungeon, true)">
+                            <img title="You have captured all Pokémon shiny in this dungeon!"
+                                 class="pokeball-smallest"
+                                 src="assets/images/pokeball/Pokeball-shiny.svg"/>
+                        </knockout>
 
-                  <!--Pokérus image-->
-                  <knockout data-bind="if: RouteHelper.minPokerusCheck(DungeonRunner.dungeon.allAvailablePokemon())">
-                      <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(DungeonRunner.dungeon.allAvailablePokemon())] + '.png',
+                        <!--Pokérus image-->
+                        <knockout data-bind="if: RouteHelper.minPokerusCheck(DungeonRunner.dungeon.allAvailablePokemon())">
+                            <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(DungeonRunner.dungeon.allAvailablePokemon())] + '.png',
                             title: RouteHelper.dungeonPokerusEVs(DungeonRunner.dungeon)}"
-                    src=""/>
-                  </knockout>
-                </td>
-                <td width="50%">
-                  <knockout data-bind="using: App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]()"</knockout>
-                  <knockout data-bind="text: $data.toLocaleString('en-US')">0</knockout>
-                  &nbsp;Clears
-                </td>
-              </tr>
-              <tr>
-                <td width="50%">
-                    <knockout data-bind="template: { name: 'pokemonAttackTemplate', data: { 'pokemon': Battle.enemyPokemon() } }"></knockout>
-                </td>
-                <td width="50%" data-bind="css: { 'text-muted': App.game.challenges.list.disableClickAttack.active() }">
-                    <span style="display: inline;">Click Attack:
-                        <span data-bind="text: App.game.party.calculateClickAttack().toLocaleString('en-US')"></span>
-                    </span>
-                </td>
-              </tr>
-          </table>
+                                 src=""/>
+                        </knockout>
+                    </td>
+                    <td width="50%">
+                        <knockout data-bind="using: App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]()"</knockout>
+                        <knockout data-bind="text: $data.toLocaleString('en-US')">0</knockout>
+                        &nbsp;Clears
+                    </td>
+                </tr>
+                <tr>
+                    <td width="50%">
+                        <knockout data-bind="template: { name: 'pokemonAttackTemplate', data: { 'pokemon': Battle.enemyPokemon() } }"></knockout>
+                    </td>
+                    <td width="50%" data-bind="css: { 'text-muted': App.game.challenges.list.disableClickAttack.active() }">
+                        <span style="display: inline;">Click Attack:
+                            <span data-bind="text: App.game.party.calculateClickAttack().toLocaleString('en-US')"></span>
+                        </span>
+                    </td>
+                </tr>
+            </table>
         </h2>
     </div>
 </div>

--- a/src/components/gymView.html
+++ b/src/components/gymView.html
@@ -1,4 +1,3 @@
-
 <div class="row justify-content-center no-gutters" data-bind="if: App.game.gameState === GameConstants.GameState.gym">
     <div class="col no-gutters clickable" data-bind="click: function() {GymBattle.clickAttack()}" style="height: 280px; display: block;">
         <h2 class="pageItemTitle mobileBattleTitle" style="display: block;">

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -8,12 +8,6 @@
             <h2 class="pageItemTitle">
               <knockout data-bind="text: player.town().name">Town Name</knockout>
               <knockout data-bind="if: player.town() instanceof DungeonTown && player.town().dungeon">
-                  <!-- ko if: QuestLineHelper.isQuestLineCompleted('Tutorial Quests') -->
-                  <knockout class="right" data-bind="using: App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(player.town().name)]()">
-                      <knockout data-bind="text: $data.toLocaleString('en-US')">0</knockout>
-                      <knockout data-bind="visible: QuestLineHelper.isQuestLineCompleted('Tutorial Quests')">clears</knockout>
-                  </knockout>
-                  <!-- /ko -->
                   <!--If all Pokémon in the dungeon are caught-->
                   <knockout data-bind="if: (!DungeonRunner.dungeonCompleted(player.town().dungeon, true) && DungeonRunner.dungeonCompleted(player.town().dungeon, false))">
                       <img title="You have captured all Pokémon in this dungeon!" class="pokeball-smallest"
@@ -70,7 +64,17 @@
                 <!-- /ko -->
            </div>
        </div>
-       <div class="col-5"></div>
+       <div class="col-4">
+           <knockout data-bind="if: player.town() instanceof DungeonTown && player.town().dungeon">
+               <!-- ko if: QuestLineHelper.isQuestLineCompleted('Tutorial Quests') -->
+               <knockout class="pageItemTitle" style="padding: 1px 8px 5px 8px" data-bind="using: App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(player.town().name)]()">
+                   <knockout data-bind="text: $data.toLocaleString('en-US')">0</knockout>
+                   <knockout data-bind="visible: QuestLineHelper.isQuestLineCompleted('Tutorial Quests')">clears</knockout>
+               </knockout>
+               <!-- /ko -->
+           </knockout>
+       </div>
+       <div class="col-1"></div>
        <div class="col-3 no-gutters">
            <div class="list-group" data-bind="foreach: player.town().npcs">
                <!-- ko if: $data.isVisible() -->

--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -129,7 +129,7 @@ class BattleFrontierRunner {
     public static pokemonLeftImages = ko.pureComputed(() => {
         let str = '';
         for (let i = 0; i < 3; i++) {
-            str += `<img class="pokeball-smallest" src="assets/images/pokeball/Pokeball.svg"${BattleFrontierBattle.pokemonIndex() > i ? ' style="filter: saturate(0);"' : ''}>`;
+            str += `<span><img class="pokeball-smallest" src="assets/images/pokeball/Pokeball.svg"${BattleFrontierBattle.pokemonIndex() > i ? ' style="filter: saturate(0);"' : ''}></span>`;
         }
         return str;
     })

--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -97,15 +97,36 @@
   background-color: #9b59b6;
 }
 
-// Mobile screen specific stylings
-@media (max-width: 768px) {
-  .dungeon-enemy {
-    margin-top: -15px;
-  }
+.dungeonTitle {
+    height: 29%;
 
-  .progress.hitpoints.dungeonhitpoints {
-    bottom: 65px;
-  }
+    .left {
+        margin-top: 55px;
+    }
+
+    .right {
+        margin-top: 53px;
+    }
+}
+
+.hitpoints {
+    bottom: 85px;
+}
+
+.pageItemFooter {
+    font-size: 14px !important;
+}
+
+.dungeon-enemy {
+margin-top: -15px;
+}
+
+.progress.hitpoints.dungeonhitpoints {
+bottom: 65px;
+}
+
+.dungeon-chest {
+margin-top: 5px;
 }
 
 .dungeon-board {
@@ -115,8 +136,6 @@
 }
 
 .dungeon-chest {
-  margin-top: 25px;
-
   @media (max-width: 768px) {
     margin-top: 20px;
     position: absolute;
@@ -138,11 +157,7 @@
 }
 
 .dungeon-button {
-  margin-top: 80px;
-
-  @media (max-width: 768px) {
-    margin-top: 50px;
-  }
+  margin-top: 50px;
 }
 
 .dungeon-pokemon-locked {

--- a/src/styles/gyms.less
+++ b/src/styles/gyms.less
@@ -12,11 +12,15 @@
   height: 100%;
 }
 
-// Applied to gym, dungeon, and tempBattle trainer sprites
+// Applied to gym and tempBattle trainer sprites
 .trainer {
   position: absolute;
   left: 65%;
   top: 25%;
+}
+
+.dungeon .trainer {
+  top: 30%;
 }
 
 .stop-auto {
@@ -26,7 +30,7 @@
 }
 
 // Mobile screen specific stylings
-@media (max-width: 768px) {
+@media (max-width: 1200px) {
   .trainer {
     top: 30%
   }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -61,7 +61,7 @@
 }
 
 // Mobile screen specific stylings
-@media (max-width: 768px) {
+@media (max-width: 1200px) {
   #gameTitle {
     margin-right: 160px;
   }
@@ -69,8 +69,12 @@
   .mobileBattleTitle {
     height: 29%;
 
-    .left, .right {
-      margin-top: 52px;
+    .left {
+    margin-top: 55px;
+    }
+
+    .right {
+        margin-top: 53px;
     }
   }
 
@@ -441,16 +445,20 @@ img {
   .timer {
     position: absolute;
     width: 100%;
-    height: 20px;
-    top: 36px;
+    height: 18px;
+    top: 38px;
   }
 
   .pokeball-animated {
     margin-top: 25px;
 
-    @media (max-width: 768px) {
+    @media (max-width: 1200px) {
       margin-top: 10px;
     }
+  }
+
+  .dungeon .pokeball-animated {
+    margin-top: 10px;
   }
 
   .catchChance {

--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -104,8 +104,11 @@
     font-size: 12px !important;
   }
 
-  .pageItemTitle {
-    font-size: 30px !important;
+  //Tight buttons were floating away on Desktop
+  .tight {
+    .btn {
+      padding: unset !important;
+    }
   }
 }
 


### PR DESCRIPTION
Continuation of the issues present in #4318
Fixes #1619 for Dungeons. 
Fixes Discord bug report "Dungeon Name covers clear count"

### **Breakdown of changes:** 
Images are Before / After when provided.


**Dungeon Start Screen:**
- No. of Clears moved away from header top right to a centred middle row. Small own dark background. 

![DungeonStart](https://github.com/pokeclicker/pokeclicker/assets/58609098/4b2dd7d6-bca4-4f47-8233-86d4ca57562c)

**Lux:** 
Only briefly had a glance at Lux as I found that it shared classes and conflicted with the above change this PR. So I took a glance, fixed that conflict and also fixed another blatantly obvious issue with the OakItems loadout padding.

- Fixed OakItems loadout 'tight' buttons floating away due to excessive padding. 
- Removed pageItemTitle hardcoding of size to 30px due to added conflicts. Should be redundant now anyway, most elements should be moved away now that resulted in this theme having textual overlap in the first place. 


**Mobile Compatability extended:** 
- Extended mobile media queries from 765px to 1200px for battles. The reason being once you reach 992px (Tablet / iPads) the game goes from 1 column to 3 columns. This reverts the width of the main central column back to mobile dimensions, which results in the mobile issues to start occuring again without the fix targetting that viewport. 
	Impacts: Dungeon battles, Gym Battles, Trainer Battles, Battle Frontier, Temporary battles. 
- Battle Frontier pokeball generates with Span wrapping now for consistency. (Was inconsistent between battles)
- Dungeon Trainer / Pokeballs CSS seperated to line these up on same x axis. (Was uneven)

![TrainersGyms](https://github.com/pokeclicker/pokeclicker/assets/58609098/71f2c13b-bdb1-4fcd-b0fc-7604d1191b85)

Note: We could feasibly move the Trainer name from my previous PR to the second line here. However, think it's more effort than it's worth since this specific change is only impacting devices between 765px to 1200px. I don't like this change for Desktop as it's not needed and I prefer how it looks at present. This is only done out of neccesity. 

**Timer:** 
- Timer height slightly lower and thinner. See any of the images attached. It was cutting off the tails of y, g, q, etc and special characters in other languages. It still does, however, it's better than what it was before. If nobody has complained about it before, then it's probably not a major issue regardless but should improve clarity ever so slightly. 

Note: Could potentially lower 1px further which would eliminate all clipping, but then we'd need to add padding to extend the background colour, which introduces an extremely odd bug varying on the modal open / close status for any placed above this screen. ie, achievements by default. Issue varies on whether or not an achievement is selected and the length of said achievement. Opted for not having a headache here due to the lack of bug reports in the first place. 

**Dungeon:** 
Arguably the biggest changes here as it impacts Desktop. #1619 fix. 

- Dungeon has had it's 'Mobile Compatability' changes extended to now be the default style. 
The reason being that due to such limited space, there's no other feasible way I can think of to support that amount of content without clipping and overlap. The mobile compatability that was in place in my tests actually worked quite well with some touch-ups. My focus was on trainers / boss battles. The Dungeon Chest will need reviewed to determine if you want that to be copied over also. 

(On mobile, the chest is on the left and the button to open it on the right. On desktop, the chest sits above the button centred. It's a tight fit now, but I think it looks fine) 

Dungeon Trainers: 

![DungeonTrainers](https://github.com/pokeclicker/pokeclicker/assets/58609098/ee7daab3-3563-4808-935e-934dea96a127)


I think that covers everything. :) 