### PR TITLE
Category Improvements (part 2) - hatchery helper category filter

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -316,7 +316,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                     <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                                 </h5>
                                 <div class="card-body p-0">
-                                    <table class="table table-striped table-hover table-bordered table-sm m-0">
+                                    <table class="table table-striped table-hover table-bordered table-sm m-0" style="overflow: visible;">
                                         <thead>
                                             <tr>
                                                 <th colspan="2" class="text-center text-light bg-dark">

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -373,15 +373,6 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                     </div>
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                        <thead>
-                                            <tr>
-                                                <th colspan="2" class="text-center text-light bg-dark">
-                                                    <h5 class="m-0">Settings</h5>
-                                                </th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
                                             <tr>
                                                 <td class="text-left align-middle">Sort:</td>
                                                 <td class="text-center align-middle">
@@ -397,7 +388,39 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                                 data-bind="attr: { id: 'hatcheryHelperSortDirection' + $index() }, checked:  $data.sortDirection" />
                                                         </div>
                                                     </div>
-
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-left align-middle">
+                                                    Category:
+                                                    <div class="d-inline-block float-right"  data-bind="tooltip: {
+                                                        html: true,
+                                                        title: 'Hatchery Helpers <u>always</u> use the filters and settings selected in the Hatchery. Assigning a Helper to one or more categories will limit them to Pokémon in those categories <u>in addition</u> to the other Hatchery filters.',
+                                                        placement: 'top',
+                                                        trigger: 'hover'
+                                                    }">ⓘ</div>
+                                                </td>
+                                                <td class="text-center align-middle" style="max-width: 1px;">
+                                                    <knockout data-bind="template: { name: 'multiSelectDropdownTemplate',
+                                                        data: {
+                                                            id: `helper-category${$index()}`,
+                                                            options: PokemonCategories.categories(),
+                                                            optionsText: 'name',
+                                                            optionsValue: 'id',
+                                                            bindingField: $data.categories,
+                                                            buttonText: () => {
+                                                                return $data.categories().map(id => PokemonCategories.categories().find(c => c.id === id)?.name()).join('; ') || 'All Categories';
+                                                            },
+                                                            buttonClass: 'btn-secondary btn-sm',
+                                                            itemLabel: {
+                                                                class: 'text-white small',
+                                                                style: (item) => ({ 'background-color': item.color() })
+                                                            },
+                                                            showSelectAll: true,
+                                                            selectAllText: 'All Categories',
+                                                            selectAllClick: () => $data.categories([]),
+                                                        }}">
+                                                    </knockout>
                                                 </td>
                                             </tr>
                                         </tbody>
@@ -409,8 +432,6 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                             </tr>
                                         </tfoot>
                                     </table>
-                                    <p class="card-text">
-                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/src/components/templates/multiSelectDropdownTemplate.html
+++ b/src/components/templates/multiSelectDropdownTemplate.html
@@ -1,0 +1,79 @@
+<script type="text/html" id="multiSelectDropdownTemplate">
+    <div class="dropdown">
+        <button class="btn btn-block dropdown-toggle text-left multiselect-dropdown" type="button" data-toggle="dropdown" data-bind="class: $data.buttonClass">
+            <div class="text-truncate pr-2" data-bind="text: typeof $data.buttonText === 'function' ? $data.buttonText() : $data.buttonText"></div>
+        </button>
+        <div class="dropdown-menu px-2">
+            <!-- ko if: $data.showSelectAll -->
+            <div class="text-center pb-1 mb-1 border-bottom border-secondary">
+                <button type="button" class="btn btn-secondary btn-sm btn-block"
+                    data-bind="text: (typeof $data.selectAllText === 'function' ? $data.selectAllText() : $data.selectAllText) || 'Select All',
+                        click: () => $data.selectAllClick?.()">Select All</button>
+            </div>
+            <!-- /ko -->
+            <div data-bind="foreach: $data.options">
+                <div class="form-check d-flex align-items-center">
+                    <input type="checkbox" class="form-check-input mt-0" style="cursor: pointer;"
+                        data-bind="
+                            attr: { id: `${$parent.id}-item${$index()}` },
+                            checked: $parent.bindingField,
+                            checkedValue: $data[$parent.optionsValue] ?? $data">
+                    <label class="form-check-label text-truncate w-100 p-1" style="max-width: 200px; cursor: pointer;"
+                        data-bind="
+                            text: $data[$parent.optionsText] ?? $data,
+                            attr: { for: `${$parent.id}-item${$index()}` },
+                            class: $parent.itemLabel?.class,
+                            style: $parent.itemLabel?.style?.($data)"
+                        onclick="event.stopPropagation();"></label>
+                </div>
+            </div>
+        </div>
+    </div>
+</script>
+
+
+<!--
+-------------------
+-- Example Usage --
+-------------------
+
+<knockout data-bind="template: { name: 'multiSelectDropdownTemplate',
+    data: {
+        id: `helper-category${$index()}`,
+        options: PokemonCategories.categories(),
+        optionsText: 'name',
+        optionsValue: 'id',
+        bindingField: $data.categories,
+        buttonText: () => {
+            return $data.categories().map(id => PokemonCategories.categories().find(c => c.id === id)?.name()).join('; ') || 'All Categories';
+        },
+        buttonClass: 'btn-secondary btn-sm',
+        itemLabel: {
+            class: 'text-white small',
+            style: (item) => ({ 'background-color': item.color() })
+        },
+        showSelectAll: true,
+        selectAllText: 'All Categories',
+        selectAllClick: () => $data.categories([]),
+    }}">
+</knockout>
+
+----------------
+-- Properties --
+----------------
+
+id - (Required) Unique identifier for this dropdown menu.
+options - (Required) Array of items to display on the dropdown.
+optionsText - (Optional) Property to use as the display text for the item. Will use the item itself if not defined.
+optionsValue - (Optional) Property to use as the value when the item is selected. Will use the item itself if not defined.
+bindingField - (Required) Observable array backing field for the selected items.
+buttonText - (Required) String or function to set the text of the dropdown button.
+buttonClass - (Optional) Additional classes to customize the dropdown button.
+itemLabel - (Optional)
+  class - (Optional) Additional classes to customize the item labels.
+  style - (Optional) Function to customize CSS styling of the item labels.
+showSelectAll - (Optional) Boolean value to display the Select All button. Default is false.
+selectAllText - (Optional) String or function to set the text of the Select All button. Default is 'Select All'.
+selectAllClick - (Optional) Function called when the Select All button is clicked.
+
+-->

--- a/src/components/templates/multiSelectDropdownTemplate.html
+++ b/src/components/templates/multiSelectDropdownTemplate.html
@@ -1,9 +1,10 @@
 <script type="text/html" id="multiSelectDropdownTemplate">
     <div class="dropdown">
-        <button class="btn btn-block dropdown-toggle text-left multiselect-dropdown" type="button" data-toggle="dropdown" data-bind="class: $data.buttonClass">
-            <div class="text-truncate pr-2" data-bind="text: typeof $data.buttonText === 'function' ? $data.buttonText() : $data.buttonText"></div>
+        <button class="btn btn-block dropdown-toggle text-left btn-multiselect-dropdown" type="button" data-toggle="dropdown" data-bind="class: $data.buttonClass">
+            <div class="text-truncate pr-2" style="position: relative; top: 1px;"
+                data-bind="text: typeof $data.buttonText === 'function' ? $data.buttonText() : $data.buttonText"></div>
         </button>
-        <div class="dropdown-menu px-2">
+        <div class="dropdown-menu multiselect-dropdown px-2">
             <!-- ko if: $data.showSelectAll -->
             <div class="text-center pb-1 mb-1 border-bottom border-secondary">
                 <button type="button" class="btn btn-secondary btn-sm btn-block"

--- a/src/index.html
+++ b/src/index.html
@@ -117,6 +117,7 @@
 @import "templates/pokemonGenderTemplate.html"
 @import "templates/pokemonAttackTemplate.html"
 @import "templates/pokemonGenderStatisticTemplate.html"
+@import "templates/multiSelectDropdownTemplate.html"
 
 <div id="game" class="container loading" data-bind="css: {'container': Settings.getSetting('gameDisplayStyle').observableValue() === 'standard3', 'container-fluid': Settings.getSetting('gameDisplayStyle').observableValue() !== 'standard3'}">
     <div class="row justify-content-center">

--- a/src/modules/party/Category.ts
+++ b/src/modules/party/Category.ts
@@ -75,6 +75,15 @@ export default class PokemonCategories implements Saveable {
                 p.category = 0;
             }
         });
+
+        // Remove category from hatchery helper filters if selected
+        App.game.breeding.hatcheryHelpers.available().forEach((helper) => {
+            const idx = helper.categories().indexOf(cat.id);
+            if (idx > -1) {
+                helper.categories().splice(idx, 1);
+            }
+        });
+
         // Remove subscriber
         cat.subscriber?.dispose();
         // Remove category
@@ -84,7 +93,7 @@ export default class PokemonCategories implements Saveable {
             PokedexFilters.category.value(-1);
             Settings.setSettingByName('pokedexCategoryFilter', PokedexFilters.category.value());
         }
-        
+
         if (BreedingFilters.category.value() === cat.id) {
             BreedingFilters.category.value(-1);
             Settings.setSettingByName('breedingCategoryFilter', BreedingFilters.category.value());

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -34,6 +34,7 @@ class HatcheryHelper {
     public attackEfficiency: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 1 });
     public prevBonus: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 0 });
     public nextBonus: KnockoutObservable<number> = ko.observable(1).extend({ numeric: 0 });
+    public categories: KnockoutObservableArray<number> = ko.observableArray([]);
     // public level: number;
     // public experience: number;
 
@@ -149,6 +150,7 @@ class HatcheryHelper {
             sortOption: this.sortOption(),
             sortDirection: this.sortDirection(),
             hatched: this.hatched(),
+            categories: this.categories(),
         };
     }
 
@@ -160,6 +162,7 @@ class HatcheryHelper {
         this.sortOption(json.sortOption || 0);
         this.sortDirection(json.sortDirection || false);
         this.hatched(json.hatched || 0);
+        this.categories(json.categories || []);
     }
 }
 
@@ -212,8 +215,9 @@ class HatcheryHelpers {
                 const compare = PartyController.compareBy(helper.sortOption(), helper.sortDirection(),
                     +Settings.getSetting('breedingRegionalAttackDebuffSetting').value);
 
+                const categories = helper.categories();
                 const pokemon = App.game.party.caughtPokemon.reduce((best, pokemon) => {
-                    if (!pokemon.isHatchable()) {
+                    if (!pokemon.isHatchable() || (categories.length && categories.indexOf(pokemon.category) === -1)) {
                         return best;
                     }
                     if (best === null) {

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -785,3 +785,10 @@ button.btn-circle {
   opacity: .25;
   pointer-events: none;
 }
+
+// Position the down arrow on the custom multi-select dropdown
+button.multiselect-dropdown::after {
+  position: absolute;
+  right: 5px;
+  top: 45%;
+}

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -787,7 +787,7 @@ button.btn-circle {
 }
 
 // Position the down arrow on the custom multi-select dropdown
-button.multiselect-dropdown::after {
+button.btn-multiselect-dropdown::after {
   position: absolute;
   right: 5px;
   top: 45%;

--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -194,6 +194,12 @@
       color: black;
     }
   }
+
+  .multiselect-dropdown {
+    .form-check-input {
+      margin-left: 0 !important;
+    }
+  }
 }
 
 .slate {


### PR DESCRIPTION
## Description
Adds the ability to assign hatchery helpers to one or more category.
Also includes a new multi-select dropdown template that (in my opinion) functions better than the current multi-select we use for the Region filter. The region filter can be swapped to use this at a later time.

## Motivation and Context
Players often ask for more ways to control which pokemon helpers hatch. This should satisfy most wants without having to implement full filtering per-helper while also improving the usefulness of categories.

## How Has This Been Tested?
Select/deselect categories from a helper.
Reloaded the save - categories were still selected.
Helpers grab the correct pokemon
Verified dropdown worked on *all* themes, on firefox & edge, and on mobile
Delete a category - it was removed from any helpers that had it selected

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/c9d461f1-9971-4c17-a2e1-ef4536bb23e5)

## Types of changes
- New feature
