### PR TITLE
Changed Leppa in Ruins of Alph from Epic to Common tier

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1856,12 +1856,12 @@ dungeonList['Ruins of Alph'] = new Dungeon('Ruins of Alph',
             {loot: 'Greatball'},
             {loot: 'Pecha'},
             {loot: 'Sitrus'},
+            {loot: 'Leppa'},
         ],
         rare: [
             {loot: 'Blue Shard'},
             {loot: 'Green Shard'},
         ],
-        epic: [{loot: 'Leppa'}],
         legendary: [
             {loot: 'SmallRestore', weight: 2},
             {loot: 'Star Piece'},


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Leppa berry in Ruins of Alph was Epic tier in Ruins of Alph which is strange when all other gen 1 berries in dungeons are Common tier. Changed it so it's now Common like the rest.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Consistency is nice.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I went to the dungeon to check if the item dropped properly. Also checked that the other items dropped.

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Consistency improvement.
