### PR TITLE
Safari items now only spawn on capture

### DIFF
--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -151,7 +151,7 @@ class SafariBattle {
         App.game.party.gainPokemonById(pokemonID, SafariBattle.enemy.shiny);
         const partyPokemon = App.game.party.getPokemon(pokemonID);
         partyPokemon.effortPoints += App.game.party.calculateEffortPoints(partyPokemon, SafariBattle.enemy.shiny, GameConstants.SAFARI_EP_YIELD);
-
+        Safari.spawnItemCheck();
     }
 
     public static throwBait() {
@@ -249,7 +249,6 @@ class SafariBattle {
         $('#safariBattleModal').one('hidden.bs.modal', () => {
             Safari.inBattle(false);
             SafariBattle.busy(false);
-            Safari.spawnItemCheck();
         }).modal('hide');
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Before, safari items had a 50/50 to spawn each time you left a battle. Now they have a 50/50 each time you catch a mon.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
It fits with Eugenes balance of items, and it was kinda weird that the most optimal item farming method was to just run from pokemon


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I have seen items spawn after catching a mon, and i have lost/fled from a lot of battles, without items spawning



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Rebalance
