### PR TITLE
More textual overlap fixes + more styling changes

### DIFF
--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -1,19 +1,28 @@
 <div class="row justify-content-center no-gutters" data-bind="if: App.game.gameState === GameConstants.GameState.dungeon">
     <div class="col no-gutters clickable" style="height: 280px; display: block;"
         data-bind="click: function() { DungeonRunner.handleClick() }">
-        <h2 class="pageItemTitle mobileBattleTitle" style="display: block;">
+        <h2 class="pageItemTitle dungeonTitle" style="display: block;">
             <knockout data-bind="if: DungeonBattle.enemyPokemon() && DungeonBattle.enemyPokemon().health()">
                 <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': DungeonBattle.enemyPokemon() } }">Pokémon name</knockout>
                 <!-- ko if: !DungeonBattle.trainer() -->
                 <knockout data-bind="template: { name: 'caughtStatusTemplate', data: {'status': PartyController.getCaughtStatus(DungeonBattle.enemyPokemon().id)}}"></knockout>
                 <knockout style="position: relative; top: -1px;"
-                    data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(DungeonBattle.enemyPokemon().id) }}">
+                          data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(DungeonBattle.enemyPokemon().id) }}">
                 </knockout>
                 <!-- /ko -->
             </knockout>
             <knockout data-bind="if: !DungeonBattle.enemyPokemon() || !DungeonBattle.enemyPokemon().health()">
                 &nbsp;
             </knockout>
+
+            <div class="progress timer">
+                <div class="progress-bar bg-danger" role="progressbar"
+                     data-bind="attr:{ style: 'width:' + DungeonRunner.timeLeftPercentage() + '%' },
+                     css: { 'bg-danger' : DungeonRunner.timeLeftSeconds() < 20, 'bg-primary': DungeonRunner.timeLeftSeconds() >= 20 }"
+                     aria-valuemin="0" aria-valuemax="100">
+                     <span data-bind="text: DungeonRunner.timeLeftSeconds() + 's'" style="font-size: 12px;"></span>
+                </div>
+            </div>
 
             <knockout class="left">
                 <!-- ko if: DungeonBattle.trainer() -->
@@ -36,18 +45,10 @@
                 </span>
             </knockout>
             <!-- /ko -->
-            <div class="progress timer">
-                <div class="progress-bar bg-danger" role="progressbar"
-                     data-bind="attr:{ style: 'width:' + DungeonRunner.timeLeftPercentage() + '%' },
-                     css: { 'bg-danger': DungeonRunner.timeLeftSeconds() < 20, 'bg-primary': DungeonRunner.timeLeftSeconds() >= 20 }"
-                     aria-valuemin="0" aria-valuemax="100">
-                     <span data-bind="text: DungeonRunner.timeLeftSeconds() + 's'" style="font-size: 12px;"></span>
-                </div>
-            </div>
         </h2>
 
         <!-- ko if: (DungeonRunner.fighting() || DungeonBattle.catching)  -->
-        <div data-bind="if: DungeonBattle.enemyPokemon">
+        <div class="dungeon" data-bind="if: DungeonBattle.enemyPokemon">
             <div class="trainer" data-bind="if: DungeonBattle.trainer()">
                 <img data-bind="attr:{ src: DungeonBattle.trainer().image }" onerror="this.src='assets/images/npcs/specialNPCs/Mysterious Trainer.png';"/>
             </div>

--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -1,6 +1,6 @@
 <div class="row justify-content-center no-gutters" data-bind="if: App.game.gameState === GameConstants.GameState.dungeon">
     <div class="col no-gutters clickable" style="height: 280px; display: block;"
-        data-bind="click: function() { DungeonRunner.handleClick() }">
+        data-bind="click: function() { DungeonRunner.handleInteraction() }">
         <h2 class="pageItemTitle dungeonTitle" style="display: block;">
             <knockout data-bind="if: DungeonBattle.enemyPokemon() && DungeonBattle.enemyPokemon().health()">
                 <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': DungeonBattle.enemyPokemon() } }">Pokémon name</knockout>

--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -129,7 +129,7 @@ class BattleFrontierRunner {
     public static pokemonLeftImages = ko.pureComputed(() => {
         let str = '';
         for (let i = 0; i < 3; i++) {
-            str += `<img class="pokeball-smallest" src="assets/images/pokeball/Pokeball.svg"${BattleFrontierBattle.pokemonIndex() > i ? ' style="filter: saturate(0);"' : ''}>`;
+            str += `<span><img class="pokeball-smallest" src="assets/images/pokeball/Pokeball.svg"${BattleFrontierBattle.pokemonIndex() > i ? ' style="filter: saturate(0);"' : ''}></span>`;
         }
         return str;
     })

--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -97,25 +97,42 @@
   background-color: #9b59b6;
 }
 
-// Mobile screen specific stylings
-@media (max-width: 768px) {
-  .dungeon-enemy {
-    margin-top: -15px;
+.dungeonTitle {
+  height: 29%;
+
+  .left {
+    margin-top: 55px;
   }
 
-  .progress.hitpoints.dungeonhitpoints {
-    bottom: 65px;
+  .right {
+    margin-top: 52px;
   }
+}
+
+.hitpoints {
+  bottom: 85px;
+}
+
+.pageItemFooter {
+  font-size: 14px !important;
+}
+
+.dungeon-enemy {
+  margin-top: -15px;
+}
+
+.progress.hitpoints.dungeonhitpoints {
+  bottom: 65px;
 }
 
 .dungeon-board {
-  width: 100%;
-  padding: 20px;
-  margin: auto;
+    width: 100%;
+    padding: 20px;
+    margin: auto;
 }
 
 .dungeon-chest {
-  margin-top: 25px;
+  margin-top: 5px;
 
   @media (max-width: 768px) {
     margin-top: 20px;
@@ -138,11 +155,7 @@
 }
 
 .dungeon-button {
-  margin-top: 80px;
-
-  @media (max-width: 768px) {
-    margin-top: 50px;
-  }
+  margin-top: 50px;
 }
 
 .dungeon-pokemon-locked {

--- a/src/styles/gyms.less
+++ b/src/styles/gyms.less
@@ -12,11 +12,15 @@
   height: 100%;
 }
 
-// Applied to gym, dungeon, and tempBattle trainer sprites
+// Applied to gym and tempBattle trainer sprites
 .trainer {
   position: absolute;
   left: 65%;
   top: 25%;
+}
+
+.dungeon .trainer {
+    top: 30%;
 }
 
 .stop-auto {
@@ -26,7 +30,7 @@
 }
 
 // Mobile screen specific stylings
-@media (max-width: 768px) {
+@media (max-width: 1200px) {
   .trainer {
     top: 30%
   }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -61,7 +61,7 @@
 }
 
 // Mobile screen specific stylings
-@media (max-width: 768px) {
+@media (max-width: 1200px) {
   #gameTitle {
     margin-right: 160px;
   }
@@ -69,8 +69,12 @@
   .mobileBattleTitle {
     height: 29%;
 
-    .left, .right {
-      margin-top: 52px;
+    .left {
+      margin-top: 55px;
+    }
+
+    .right {
+      margin-top: 53px;
     }
   }
 
@@ -441,16 +445,20 @@ img {
   .timer {
     position: absolute;
     width: 100%;
-    height: 20px;
-    top: 36px;
+    height: 18px;
+    top: 38px;
   }
 
   .pokeball-animated {
     margin-top: 25px;
 
-    @media (max-width: 768px) {
+    @media (max-width: 1200px) {
       margin-top: 10px;
     }
+  }
+
+  .dungeon .pokeball-animated {
+    margin-top: 10px;
   }
 
   .catchChance {


### PR DESCRIPTION
Continuation of the issues present in #4318
Fixes #1619 for Dungeons. (This bug impacts all viewports.)

From the last submission of this, i've split off 2 changes to their own and improved PRs. 
What remains i've re-tested and simplified slightly and i'm happy to have as one change now due to interlocking styling changes. 
I recreated my branch to clean up the commits and it was pretty quick to copy over all the changes and test.

## **Breakdown of changes:** 
Images are Before / After when provided.


### **Mobile Compatability extended:** 
- Extended mobile media queries from 765px to 1200px for battles. The reason being once you reach 992px (Tablets, Laptops, etc) the game goes from 1 column to 3 columns. This reverts the width of the main central column back to mobile dimensions, which results in the mobile issues to start occuring again without the fix targetting that viewport. 
	**Impacts: Dungeon battles, Gym Battles, Trainer Battles, Battle Frontier, Temporary battles.**
	
- Battle Frontier pokeball generates with Span wrapping now for consistency. (Resulted in different heights)

- Dungeon Trainer / Pokeballs CSS made unique to line these up on same y axis. (Was uneven)

![TrainersGyms](https://github.com/pokeclicker/pokeclicker/assets/58609098/71f2c13b-bdb1-4fcd-b0fc-7604d1191b85)

### **Timer:** 
- Timer height slightly lower and thinner. See any of the images attached. It was cutting off the tails of y, g, q, etc and special characters in other languages. It still does for some, however, it's better than what it was before. If nobody has complained about it before, then it's probably not a major issue regardless but should improve clarity ever so slightly. 

### **Dungeon:** 
Arguably the biggest changes here as it impacts Desktop. #1619 fix. 

- Dungeon has had it's 'Mobile Compatability' changes extended to now be the default style. 
The reason being that due to such limited space, there's no other feasible way I can think of to support that amount of content without clipping and overlap. The mobile compatability that was in place in my tests actually worked quite well with some touch-ups. My focus was on trainers / boss battles. The Dungeon Chest will need reviewed to determine if you want that to be copied over also. 

(On mobile, the chest is on the left and the button to open it on the right. On desktop, the chest sits above the button centred. It's a tight fit now, but I think it looks fine) 

Dungeon Trainers: 

![DungeonTrainers](https://github.com/pokeclicker/pokeclicker/assets/58609098/ee7daab3-3563-4808-935e-934dea96a127)

Chests:
![Chest](https://github.com/pokeclicker/pokeclicker/assets/58609098/157642bd-ccaf-45fc-84a2-a80a9d09136e)
