### PR TITLE
Farm Quest Buffs to make them potentially worth doing

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -282,7 +282,7 @@ const questBase = 1; // change this to scale all quest points
 // Currency → QP reward amounts
 export const GAIN_MONEY_BASE_REWARD = questBase * 0.0017;
 export const GAIN_TOKENS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 55;
-export const GAIN_FARM_POINTS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 90;
+export const GAIN_FARM_POINTS_BASE_REWARD = GAIN_MONEY_BASE_REWARD * 360;
 
 export const HATCH_EGGS_BASE_REWARD = questBase * 33;
 export const SHINY_BASE_REWARD = questBase * 3000;

--- a/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
+++ b/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
@@ -16,7 +16,7 @@ class HarvestBerriesQuest extends Quest implements QuestInterface {
 
     public static generateData(): any[] {
         // Getting available Berries (always include Gen 1 Berries)
-        const availableBerries = App.game.farming.berryData.filter(berry => App.game.farming.unlockedBerries[berry.type]() && berry.growthTime[3] < 12000 || berry.type < BerryType.Persim);
+        const availableBerries = App.game.farming.berryData.filter(berry => (App.game.farming.unlockedBerries[berry.type]() && berry.growthTime[3] < 12000) || berry.type < BerryType.Persim);
         const berry = SeededRand.fromArray(availableBerries);
 
         const maxAmt = Math.min(300, Math.ceil(432000 / berry.growthTime[3]));

--- a/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
+++ b/src/scripts/quests/questTypes/HarvestBerriesQuest.ts
@@ -16,7 +16,7 @@ class HarvestBerriesQuest extends Quest implements QuestInterface {
 
     public static generateData(): any[] {
         // Getting available Berries (always include Gen 1 Berries)
-        const availableBerries = App.game.farming.berryData.filter(berry => App.game.farming.unlockedBerries[berry.type]() || berry.type < BerryType.Persim);
+        const availableBerries = App.game.farming.berryData.filter(berry => App.game.farming.unlockedBerries[berry.type]() && berry.growthTime[3] < 12000 || berry.type < BerryType.Persim);
         const berry = SeededRand.fromArray(availableBerries);
 
         const maxAmt = Math.min(300, Math.ceil(432000 / berry.growthTime[3]));
@@ -29,10 +29,10 @@ class HarvestBerriesQuest extends Quest implements QuestInterface {
 
     private static calcReward(amount: number, berryType: BerryType): number {
         const harvestTime = App.game.farming.berryData[berryType].growthTime[3];
-        const harvestAmt = Math.max(4, Math.ceil(App.game.farming.berryData[berryType].harvestAmount));
+        const harvestAmt = Math.max(4, Math.ceil(App.game.farming.berryData[berryType].harvestAmount / 2));
         const plantAmt = amount / harvestAmt;
         const fieldAmt = plantAmt / App.game.farming.plotList.length;
-        const reward = Math.ceil(fieldAmt * Math.pow(harvestTime, .7) * 10);
+        const reward = Math.ceil(fieldAmt * Math.pow(harvestTime, .7) * 30);
         return super.randomizeReward(reward);
     }
 


### PR DESCRIPTION
## Description
Boosts the overall QP gains from FP quests to make them comparable to other high-attention tasks like dungeon grinding.

FP gain quest tuned so that getting ~3000 FP gives ~2000 QP, which takes ~12 minutes of focused attention. quest can also be completed by AFK farmhands or tearing down existing farm plants, each of which has an opportunity cost.

Berry specific harvesting missions have been boosted along similar lines, increasing rewards to make berry harvesting quests now potentially desirable. Late game users may still skip them due to the opportunity cost of tearing down farms, but this brings them from the realm of "skip for sure" to "maybe do".

## Motivation and Context
Make farm quests worth doing, in keeping with #4332 as discussed by CCs and devs.


## How Has This Been Tested?
Ran a few dozen quest resets and the values were about as expected.

41 bluk for 528 QP
246 bluk for 3151 QP
188 bluk for 2718 QP
63 pinap for 454 QP
40 Pomeg for 1886 QP
46 aguav for 360 QP
246 nanab for 2427 QP
253 wepear for 3547 QP
281 pecha for 1581 QP
250 Aspear for 2040 QP
191 Chesto for 715 QP
203 Leppa for 2633 QP
191 bluk for 2630 QP
128 pecha for 688 QP
28 Grepa for 1348 QP
33 Leppa for 471 QP
41 pomeg for 2130 QP
183 Iapapa for 1667 QP

Average FQ value is now 4x higher, giving an average of 1680 QP for 2850 FP

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Rebalance
