### PR TITLE
Safari Level

### DIFF
--- a/src/components/safariModal.html
+++ b/src/components/safariModal.html
@@ -26,6 +26,15 @@
                         />
                     </span>
                 </h4>
+                <div class='col-6'>
+                    <div>Lvl. <knockout data-bind='text: Safari.safariLevel()'></knockout></div>
+                    <div class="progress" style='height: 5px'>
+                        <div class="progress-bar bg-info" role="progressbar"
+                             data-bind="attr:{ style: 'width:' + Safari.percentToNextSafariLevel() + '%' }"
+                             aria-valuemin="0" aria-valuemax="100">
+                        </div>
+                    </div>
+                </div>
                 <button class='btn btn-danger modalClose' onclick='Safari.closeModal()'>Leave</button>
             </div>
 

--- a/src/modules/DataStore/StatisticStore/index.ts
+++ b/src/modules/DataStore/StatisticStore/index.ts
@@ -102,6 +102,7 @@ export default class Statistics implements Saveable {
     safariRocksThrown: KnockoutObservable<number>;
     safariBaitThrown: KnockoutObservable<number>;
     safariBallsThrown: KnockoutObservable<number>;
+    safariPokemonCaptured: KnockoutObservable<number>;
     safariStepsTaken: KnockoutObservable<number>;
     safariItemsObtained: KnockoutObservable<number>;
 
@@ -229,6 +230,7 @@ export default class Statistics implements Saveable {
         'safariRocksThrown',
         'safariBaitThrown',
         'safariBallsThrown',
+        'safariPokemonCaptured',
         'safariStepsTaken',
         'safariItemsObtained',
     ];

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -20,8 +20,8 @@ class Safari {
     static maxSafariLevel = 40;
     static safariExp: KnockoutComputed<number> = ko.pureComputed(() => {
         return App.game.statistics.safariRocksThrown() * 10 +
-            App.game.statistics.safariBaitThrown() * 10 + 
-            App.game.statistics.safariBallsThrown() * 5 + 
+            App.game.statistics.safariBaitThrown() * 10 +
+            App.game.statistics.safariBallsThrown() * 5 +
             App.game.statistics.safariPokemonCaptured() * 50;
     });
     static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => {

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -20,8 +20,8 @@ class Safari {
     static maxSafariLevel = 40;
     static safariExp: KnockoutComputed<number> = ko.pureComputed(() => {
         return App.game.statistics.safariRocksThrown() * 10 +
-            App.game.statistics.safariBaitThrown() * 10 +
-            App.game.statistics.safariBallsThrown() * 5 +
+            App.game.statistics.safariBaitThrown() * 5 +
+            App.game.statistics.safariBallsThrown() * 10 +
             App.game.statistics.safariPokemonCaptured() * 50;
     });
     static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => {

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -16,6 +16,28 @@ class Safari {
     static balls: KnockoutObservable<number> = ko.observable().extend({ numeric: 0 });
     static activeRegion: KnockoutObservable<GameConstants.Region> = ko.observable(GameConstants.Region.none);
 
+    // Safari level
+    static maxSafariLevel = 40;
+    static safariExp: KnockoutComputed<number> = ko.pureComputed(() => {
+        return App.game.statistics.safariRocksThrown() * 10 +
+            App.game.statistics.safariBaitThrown() * 10 + 
+            App.game.statistics.safariBallsThrown() * 5 + 
+            App.game.statistics.safariPokemonCaptured() * 50;
+    });
+    static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
+        for (let i = 1; i <= Safari.maxSafariLevel; i++) {
+            if (Safari.safariExp() < Safari.expRequiredForLevel(i)) {
+                return i - 1;
+            }
+        }
+        return Safari.maxSafariLevel;
+    });
+    static percentToNextSafariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
+        const expForNextLevel = Safari.expRequiredForLevel(Safari.safariLevel() + 1) - Safari.expRequiredForLevel(Safari.safariLevel());
+        const expThisLevel = Safari.safariExp() - Safari.expRequiredForLevel(Safari.safariLevel());
+        return expThisLevel / expForNextLevel * 100;
+    });
+
     public static sizeX(): number {
         return Math.floor(document.querySelector('#safariModal .modal-dialog').scrollWidth / 32);
     }
@@ -463,6 +485,10 @@ class Safari {
             });
         }
         return false;
+    }
+
+    private static expRequiredForLevel(level: number) {
+        return Math.ceil(2000 * (1.2 ** (level - 1) - 1));
     }
 }
 

--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -147,6 +147,7 @@ class SafariBattle {
 
     private static capturePokemon() {
         SafariBattle.text(`GOTCHA!<br>${SafariBattle.enemy.name} was caught!`);
+        GameHelper.incrementObservable(App.game.statistics.safariPokemonCaptured, 1);
         const pokemonID = PokemonHelper.getPokemonByName(SafariBattle.enemy.name).id;
         App.game.party.gainPokemonById(pokemonID, SafariBattle.enemy.shiny);
         const partyPokemon = App.game.party.getPokemon(pokemonID);

--- a/src/scripts/safari/SafariPokemonList.ts
+++ b/src/scripts/safari/SafariPokemonList.ts
@@ -38,7 +38,7 @@ class SafariPokemonList {
         const pokemon : SafariType[] = SeededRand.shuffleArray(App.game.party.caughtPokemon.map((p) => p.name)
             .filter((p) => !PokemonHelper.hasEvableLocations(p) && Object.keys(PokemonHelper.getPokemonLocations(p)).length)
             .map((p) => {
-                return {name: p, weight: 3};
+                return {name: p, weight: 10};
             })).slice(0, 5);
         pokemon.push({ name: 'Shuckle', weight: 2 });
         pokemon.push({ name: 'Stunfisk', weight: 2 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
Adds Safari Level to the Safari Zones, formula in images


## Motivation and Context
Allows locking things behind safari levels, and improvements to various safari elements based on level. Not in this PR, this is just the bones of the Level


## How Has This Been Tested?
Checked XP being gained for rock throwing, bait throwing, ball throwing, and mon catching. Checked that level does increase and the bar resets on a level.


## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/109317224/a04cde68-5f28-4cfe-9508-b7c7bb2137cb)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- New feature

