### PR TITLE
Added level tooltips and one safari level achievement

### DIFF
--- a/src/components/questModal.html
+++ b/src/components/questModal.html
@@ -9,7 +9,7 @@
                     </span>
                 </h5>
                 </div>
-                <div class='col-6'>
+                <div class='col-6' data-bind="tooltip : App.game.quests.questProgressTooltip()">
                     <div>Lvl. <knockout data-bind='text: App.game.quests.level'></knockout></div>
                     <div class="progress" style='height: 5px'>
                         <div class="progress-bar bg-info" role="progressbar"

--- a/src/components/safariModal.html
+++ b/src/components/safariModal.html
@@ -26,7 +26,7 @@
                         />
                     </span>
                 </h4>
-                <div class='col-6'>
+                <div class='col-6' data-bind="tooltip : Safari.safariProgressTooltip()">
                     <div>Lvl. <knockout data-bind='text: Safari.safariLevel()'></knockout></div>
                     <div class="progress" style='height: 5px'>
                         <div class="progress-bar bg-info" role="progressbar"

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -100,6 +100,7 @@ namespace GameConstants {
         'Hatchery',
         'Farming',
         'Underground',
+        'Safari',
         'Battle Frontier',
         'Protein',
         'Pokerus',

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -405,6 +405,7 @@ class AchievementHandler {
         AchievementHandler.addAchievement('This is not a Pokéball!', 'Throw 10 Rocks in a Safari Zone', new SafariRocksRequirement(10), 0.2);
         AchievementHandler.addAchievement('Hope it likes berries', 'Throw 10 Bait in a Safari Zone', new SafariBaitRequirement(10), 0.2);
         AchievementHandler.addAchievement('Gotta get your steps in!', 'Walk 100 Steps in a Safari Zone', new SafariStepsRequirement(100), 0.2);
+        AchievementHandler.addAchievement('Where Pinsir?', 'Reach Safari Level 5.', new SafariLevelRequirement(5), 0.2);
 
         /*
          * REGIONAL

--- a/src/scripts/achievements/SafariLevelRequirement.ts
+++ b/src/scripts/achievements/SafariLevelRequirement.ts
@@ -1,0 +1,13 @@
+class SafariLevelRequirement extends AchievementRequirement {
+    constructor(levelRequired: number) {
+        super(levelRequired, GameConstants.AchievementOption.more, GameConstants.AchievementType.Safari);
+    }
+
+    public getProgress() {
+        return Math.min(Safari.safariLevel(), this.requiredValue);
+    }
+
+    public hint(): string {
+        return `Needs safari level ${this.requiredValue}.`;
+    }
+}

--- a/src/scripts/achievements/SafariLevelRequirement.ts
+++ b/src/scripts/achievements/SafariLevelRequirement.ts
@@ -8,6 +8,6 @@ class SafariLevelRequirement extends AchievementRequirement {
     }
 
     public hint(): string {
-        return `Needs safari level ${this.requiredValue}.`;
+        return `Needs Safari Level ${this.requiredValue}.`;
     }
 }

--- a/src/scripts/quests/Quests.ts
+++ b/src/scripts/quests/Quests.ts
@@ -278,6 +278,12 @@ class Quests implements Saveable {
         return 100 * (this.xp() - requiredForCurrent) / (requiredForNext - requiredForCurrent);
     }
 
+    public questProgressTooltip() {
+        const level = this.level();
+        const xp = this.xp();
+        return {title : `${xp - this.levelToXP(level)} / ${this.levelToXP(level + 1) - this.levelToXP(level)}`, trigger : 'hover' };
+    }
+
     public isDailyQuestsUnlocked() {
         return QuestLineHelper.isQuestLineCompleted('Tutorial Quests');
     }

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -504,7 +504,7 @@ class Safari {
     }
 
     private static expRequiredForLevel(level: number) {
-        return Math.ceil(2000 * (1.2 ** level - 1) - 1));
+        return Math.ceil(2000 * (1.2 ** (level - 1) - 1));
     }
 }
 

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -25,16 +25,21 @@ class Safari {
             App.game.statistics.safariPokemonCaptured() * 50;
     });
     static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
+        const xp = Safari.safariExp();
         for (let i = 1; i <= Safari.maxSafariLevel; i++) {
-            if (Safari.safariExp() < Safari.expRequiredForLevel(i)) {
+            if (xp < Safari.expRequiredForLevel(i)) {
                 return i - 1;
             }
         }
         return Safari.maxSafariLevel;
     });
     static percentToNextSafariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
-        const expForNextLevel = Safari.expRequiredForLevel(Safari.safariLevel() + 1) - Safari.expRequiredForLevel(Safari.safariLevel());
-        const expThisLevel = Safari.safariExp() - Safari.expRequiredForLevel(Safari.safariLevel());
+        const level = Safari.safariLevel();
+        if (level === Safari.maxSafariLevel) {
+            return 100;
+        }
+        const expForNextLevel = Safari.expRequiredForLevel(level + 1) - Safari.expRequiredForLevel(level);
+        const expThisLevel = Safari.safariExp() - Safari.expRequiredForLevel(level);
         return expThisLevel / expForNextLevel * 100;
     });
 
@@ -487,8 +492,19 @@ class Safari {
         return false;
     }
 
+    static safariProgressTooltip() {
+        const tooltip = { trigger : 'hover', title : '' };
+        const level = Safari.safariLevel();
+        if (level == Safari.maxSafariLevel) {
+            tooltip.title = 'Max level reached';
+        } else {
+            tooltip.title = `${Safari.safariExp() - Safari.expRequiredForLevel(level)} / ${Safari.expRequiredForLevel(level + 1) - Safari.expRequiredForLevel(level)}`;
+        }
+        return tooltip;
+    }
+
     private static expRequiredForLevel(level: number) {
-        return Math.ceil(2000 * (1.2 ** (level - 1) - 1));
+        return Math.ceil(2000 * (1.2 ** (Math.min(Safari.maxSafariLevel, level) - 1) - 1));
     }
 }
 

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -504,7 +504,7 @@ class Safari {
     }
 
     private static expRequiredForLevel(level: number) {
-        return Math.ceil(2000 * (1.2 ** (Math.min(Safari.maxSafariLevel, level) - 1) - 1));
+        return Math.ceil(2000 * (1.2 ** level - 1) - 1));
     }
 }
 


### PR DESCRIPTION
## Description
- New tooltips for quest and safari : they tell the players about the XP amounts.
- Safari level requirement so we can lock things behind defined levels.
- Safari level achievement to introduce the requirement. More to come later, if needed.
- safari level display : the tooltip indicates that the max level has been reached, the progress bar stays filled whenever such thing happens.

## Motivation and Context
- Safari and quest levels look less obscur.
- Eugene needed a safari level requirement.

## How Has This Been Tested?
- Changed my levels to see how it acts.

## Types of changes
- New feature
- UI improvement
