### PR TITLE
Fix: Castform App showing future dates as 'passed'

### DIFF
--- a/src/modules/weather/WeatherApp.ts
+++ b/src/modules/weather/WeatherApp.ts
@@ -34,14 +34,13 @@ export default class WeatherApp {
      */
     public static generateRegionalForecast(region: Region, dateRange: number = WeatherApp.defaultDateRange, date: Date = new Date()) {
         const weatherForecastList = [];
-        const options: any = { dateStyle: 'full', timeStyle: 'short', hourCycle: 'h23' };
         // Creates forecasts for X hour
         for (let hour = 0; hour <= 23; hour += Weather.period) {
             const hourForecast = [];
             const newDate = new Date(date.setHours(hour, 0, 0, 0));
             // Gets the weather for every day for that hour
             for (let i = 0; i < dateRange; i++) {
-                const weatherForecastDate = new Date(newDate).toLocaleString('en-US', options).replace('at', ''); // 'at' is not valid for new Date()
+                const weatherForecastDate = new Date(newDate);
                 const weatherForecast = new WeatherForecast(weatherForecastDate, Weather.getWeather(region, newDate));
                 hourForecast.push(weatherForecast);
                 newDate.setDate(newDate.getDate() + 1);
@@ -108,7 +107,7 @@ export default class WeatherApp {
             // Full forecast
             // Set status to hasPassed if weather end date has passed already
             rf.weatherForecastList().flat().map((wf) => {
-                const weatherEndDate = new Date(new Date(wf.date).setHours(new Date(wf.date).getHours() + Weather.period, 0, 0, 0));
+                const weatherEndDate = new Date(new Date(wf.date).setHours(wf.date.getHours() + Weather.period, 0, 0, 0));
                 if (now > weatherEndDate) {
                     wf.setStatusHasPassed();
                 }

--- a/src/modules/weather/WeatherApp.ts
+++ b/src/modules/weather/WeatherApp.ts
@@ -34,13 +34,14 @@ export default class WeatherApp {
      */
     public static generateRegionalForecast(region: Region, dateRange: number = WeatherApp.defaultDateRange, date: Date = new Date()) {
         const weatherForecastList = [];
+        const options: any = { dateStyle: 'full', timeStyle: 'short', hourCycle: 'h23' };
         // Creates forecasts for X hour
         for (let hour = 0; hour <= 23; hour += Weather.period) {
             const hourForecast = [];
             const newDate = new Date(date.setHours(hour, 0, 0, 0));
             // Gets the weather for every day for that hour
             for (let i = 0; i < dateRange; i++) {
-                const weatherForecastDate = new Date(newDate).toLocaleString();
+                const weatherForecastDate = new Date(newDate).toLocaleString('en-US', options).replace('at', ''); // 'at' is not valid for new Date()
                 const weatherForecast = new WeatherForecast(weatherForecastDate, Weather.getWeather(region, newDate));
                 hourForecast.push(weatherForecast);
                 newDate.setDate(newDate.getDate() + 1);

--- a/src/modules/weather/WeatherForecast.ts
+++ b/src/modules/weather/WeatherForecast.ts
@@ -3,12 +3,12 @@ import WeatherForecastStatus from '../enums/WeatherForecastStatus';
 import WeatherType from './WeatherType';
 
 export default class WeatherForecast {
-    public date: string;
+    public date: Date;
     public weatherType: WeatherType;
     public status: Observable<WeatherForecastStatus>;
 
     constructor(
-        date: string, // Date as toLocaleString
+        date: Date,
         weatherType: WeatherType,
         status = WeatherForecastStatus.disabled,
     ) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Fixes https://github.com/pokeclicker/pokeclicker/issues/4378
I was able to reproduce the bug only in Firefox, not even other Gecko-based browsers.

The issue was about Firefox reading the dates as `DD/MM/YYYY` when the dates were saved in the observable as `MM/DD/YYYY` (the default format), ~~so I changed the format so the month is the word instead the number.~~

~~Before: `5/30/2023, 12:00:00 AM`~~
~~Now: `Tuesday, May 30, 2023  00:00`~~

Date object is stored now.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
* Check in Firefox and Edge if the bug is fixed
* Change the hour to see if something broke with the changes

## Screenshots
<details><summary>Firefox</summary>

![image](https://github.com/pokeclicker/pokeclicker/assets/104547700/9d63df96-425d-48de-83cc-0930036eb0bc)

</details>

<details><summary>Edge</summary>

![image](https://github.com/pokeclicker/pokeclicker/assets/104547700/9680a941-c36c-4d10-b9d9-c3e1a4cff560)


</details>

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix

