### PR TITLE
Add descriptions to pokeball and pokeblocks for wiki

### DIFF
--- a/src/modules/items/PokeBlock.ts
+++ b/src/modules/items/PokeBlock.ts
@@ -8,4 +8,8 @@ export default class PokeBlock extends Item {
         super(`PokeBlock_${PokeBlockColor[color]}`, basePrice, currency);
         this.type = color;
     }
+    
+    get description(): string {
+        return this._description || `Unobtainable item for future uses`;
+    }
 }

--- a/src/modules/items/PokeBlock.ts
+++ b/src/modules/items/PokeBlock.ts
@@ -10,6 +10,6 @@ export default class PokeBlock extends Item {
     }
     
     get description(): string {
-        return this._description || `Unobtainable item for future uses`;
+        return this._description || 'Unobtainable item for future uses';
     }
 }

--- a/src/modules/items/PokeballItem.ts
+++ b/src/modules/items/PokeballItem.ts
@@ -6,15 +6,12 @@ export default class PokeballItem extends Item {
     type: PokeballType;
 
     constructor(type: PokeballType, basePrice: number, currency: Currency = Currency.money, options?: ShopOptions, displayName?: string) {
-        super(PokeballType[type], basePrice, currency, options, displayName, undefined, 'pokeball');
+        super(PokeballType[type], basePrice, currency, options, displayName, 'A ball for catching Pokémon.', undefined, 'pokeball');
         this.type = type;
     }
 
     gain(amt: number) {
         App.game.pokeballs.gainPokeballs(this.type, amt);
     }
-    
-    get description(): string {
-        return this._description || `A ball for catch Pokémon. Can be bought in shops or find in dungeons.`;
-    }
+
 }

--- a/src/modules/items/PokeballItem.ts
+++ b/src/modules/items/PokeballItem.ts
@@ -6,7 +6,7 @@ export default class PokeballItem extends Item {
     type: PokeballType;
 
     constructor(type: PokeballType, basePrice: number, currency: Currency = Currency.money, options?: ShopOptions, displayName?: string) {
-        super(PokeballType[type], basePrice, currency, options, displayName, 'A ball for catching Pokémon.', undefined, 'pokeball');
+        super(PokeballType[type], basePrice, currency, options, displayName, 'A ball for catching Pokémon.', 'pokeball');
         this.type = type;
     }
 

--- a/src/modules/items/PokeballItem.ts
+++ b/src/modules/items/PokeballItem.ts
@@ -13,4 +13,8 @@ export default class PokeballItem extends Item {
     gain(amt: number) {
         App.game.pokeballs.gainPokeballs(this.type, amt);
     }
+    
+    get description(): string {
+        return this._description || `A ball for catch Pokémon. Can be bought in shops or find in dungeons.`;
+    }
 }


### PR DESCRIPTION

## Description
Add a generic description to pokeballs and add a description to pokeblocks saying they aren't obtanible


## Motivation and Context
After pant added descriptions to megastones most items had a description. This add more descriptions

## Types of changes
- Wiki improvement 
