### PR TITLE
Allowed the interaction keybind in dungeon to trigger even if it is not the last called keybind

### DIFF
--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -1,6 +1,6 @@
 <div class="row justify-content-center no-gutters" data-bind="if: App.game.gameState === GameConstants.GameState.dungeon">
     <div class="col no-gutters clickable" style="height: 280px; display: block;"
-        data-bind="click: function() { DungeonRunner.handleClick() }">
+        data-bind="click: function() { DungeonRunner.handleInteraction() }">
         <h2 class="pageItemTitle mobileBattleTitle" style="display: block;">
             <knockout data-bind="if: DungeonBattle.enemyPokemon() && DungeonBattle.enemyPokemon().health()">
                 <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': DungeonBattle.enemyPokemon() } }">Pokémon name</knockout>

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -2094,3 +2094,9 @@ export enum GemShops {
     FurfrouGemTrader,
     MagikarpJumpGemTrader,
 }
+
+export enum DungeonInteractionSource {
+    Click,
+    Keybind,
+    HeldKeybind,
+}

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -785,4 +785,9 @@ namespace GameConstants {
         FurfrouGemTrader,
         MagikarpJumpGemTrader,
     }
+    declare enum DungeonInteractionSource {
+        Click,
+        Keybind,
+        HeldKeybind,
+    }
 }

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -363,15 +363,8 @@ class GameController {
                             DungeonRunner.map.moveRight();
                             return e.preventDefault();
                         case Settings.getSetting('hotkey.dungeon.interact').value:
-                            if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTile.entrance) {
-                                DungeonRunner.dungeonLeave();
-                            } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTile.chest) {
-                                DungeonRunner.openChest();
-                            } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTile.boss && !DungeonRunner.fightingBoss()) {
-                                DungeonRunner.startBossFight();
-                            } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTile.ladder) {
-                                DungeonRunner.nextFloor();
-                            }
+                            DungeonRunner.handleInteraction(GameConstants.DungeonInteractionSource.Keybind);
+                            DungeonRunner.continuousInteractionInput = true;
                             return e.preventDefault();
                     }
                 }
@@ -508,6 +501,11 @@ class GameController {
                         Safari.stop('right');
                         return e.preventDefault();
                 }
+            }
+
+            if (key === Settings.getSetting('hotkey.dungeon.interact').value) {
+                DungeonRunner.continuousInteractionInput = false;
+                return e.preventDefault();
             }
 
             if (key === 'Space') {

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -17,6 +17,7 @@ class DungeonRunner {
     public static defeatedBoss: KnockoutObservable<string> = ko.observable(null);
     public static dungeonFinished: KnockoutObservable<boolean> = ko.observable(false);
     public static fightingLootEnemy: boolean;
+    public static continuousInteractionInput = false;
 
     public static initializeDungeon(dungeon) {
         if (!dungeon.isUnlocked()) {
@@ -85,6 +86,9 @@ class DungeonRunner {
         if (DungeonRunner.map.playerMoved()) {
             DungeonRunner.timeLeft(DungeonRunner.timeLeft() - GameConstants.DUNGEON_TICK);
             DungeonRunner.timeLeftPercentage(Math.floor(DungeonRunner.timeLeft() / (GameConstants.DUNGEON_TIME * FluteEffectRunner.getFluteMultiplier(GameConstants.FluteItemType.Time_Flute)) * 100));
+            if (DungeonRunner.continuousInteractionInput) {
+                DungeonRunner.handleInteraction(GameConstants.DungeonInteractionSource.HeldKeybind);
+            }
         }
         const currentFluteBonus = FluteEffectRunner.getFluteMultiplier(GameConstants.FluteItemType.Time_Flute);
         if (currentFluteBonus != DungeonRunner.timeBonus()) {
@@ -105,12 +109,12 @@ class DungeonRunner {
     }
 
     /**
-     * Handles the click event in the dungeon view
+     * Handles the interaction event in the dungeon view and from keybinds
      */
-    public static handleClick() {
-        if (DungeonRunner.fighting() && !DungeonBattle.catching()) {
+    public static handleInteraction(source: GameConstants.DungeonInteractionSource = GameConstants.DungeonInteractionSource.Click) {
+        if (DungeonRunner.fighting() && !DungeonBattle.catching() && source === GameConstants.DungeonInteractionSource.Click) {
             DungeonBattle.clickAttack();
-        } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTile.entrance) {
+        } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTile.entrance && source !== GameConstants.DungeonInteractionSource.HeldKeybind) {
             DungeonRunner.dungeonLeave();
         } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTile.chest) {
             DungeonRunner.openChest();


### PR DESCRIPTION
## Description
Players can now hold the key and do the dungeon without having to press it again.
You still need to in order to enter the dungeon again, though. Also, a continuously pressed key does not trigger the exit.

## Motivation and Context
A held key signal is ignored if another and unrelated one is then pressed. This causes the interaction keybind to turn useless in dungeons if not triggered each time the player has to interact with the chests, ladder and boss.
Doing dungeons will not be as annoying as it is now, requiring less repetitive actions.

## How Has This Been Tested?
Run some dungeons, clicking, pressing, not pressing, etc.. Everything worked fine.

## Types of changes
- UI improvement
