### PR TITLE
Fix entering active safari session from different regions

### DIFF
--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -168,8 +168,12 @@ class Safari {
     }
 
     public static openModal() {
-        App.game.gameState = GameConstants.GameState.safari;
-        $('#safariModal').modal({backdrop: 'static', keyboard: false});
+        if (Safari.inProgress() && Safari.activeRegion() !== player.region) {
+            this.safariReset();
+        } else {
+            App.game.gameState = GameConstants.GameState.safari;
+            $('#safariModal').modal({backdrop: 'static', keyboard: false});
+        }
     }
 
     public static startSafari() {


### PR DESCRIPTION
## Description
When starting a safari session in one region then traveling to a different region and entering the safari there the player will be placed back in the safari session from the original region. For example, enter the safari in kanto then travel to kalos and enter the friend safari, you will be placed back in the kanto session.

This change will correctly prompt the player to abandon their current session to begin a new session in the current region.

## Motivation and Context
'tis a bug and should be fixed

## How Has This Been Tested?
Loaded safari normally. Left and re-entered safari in the same region. Left and tried entering safari in a different region. Prompted to reset the session.

## Types of changes
- Bug fix
