### PR TITLE
Fixed some typos (NPC and Challenge)

### DIFF
--- a/src/modules/challenges/Challenges.ts
+++ b/src/modules/challenges/Challenges.ts
@@ -13,7 +13,7 @@ export default class Challenges implements Saveable {
         disableBattleItems: new Challenge('No Battle Item', 'Disables the usage of Battle Items'),
         disableMasterballs: new Challenge('No Master Ball', 'Disables the usage of Master Balls'),
         disableOakItems: new Challenge('No Oak Item', 'Disables the usage of all Oak Items'),
-        disableGems: new Challenge('No Gem', 'Disables the usage of Gems for increasing damage multipliers'),
+        disableGems: new Challenge('No Gem', 'Disables the usage of Gems to increase damage multipliers'),
         disableVitamins: new Challenge('No Vitamins', 'Disables the usage of Vitamins'),
         slowEVs: new Challenge('Slow EVs', 'Gain EVs 10x slower'),
         realEvolutions: new Challenge('Real evolutions', 'Your Pokémon go away, when they evolve'),

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -1638,7 +1638,7 @@ const TohjoFallsCelebiTimeDistortion = new NPC('Investigate the Time Distortion'
 });
 
 const Conductor = new NPC('Conductor', [
-    'We\'re working on construction of a Magent Train line to shuttle people <b>east to Kanto</b>. Once it\'s completed, people will be able to get to Saffron City in record time!',
+    'We\'re working on construction of a Magnet Train line to shuttle people <b>east to Kanto</b>. Once it\'s completed, people will be able to get to Saffron City in record time!',
 ], { image: 'assets/images/npcs/Rail Staff.png' });
 
 const ProfElm = new ProfNPC('Prof. Elm',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Fixed Conductor NPC's text (in Goldenrod) that said Magent instead of Magnet. Fixed Challenge Mode's Gem's tooltip since it should be "to increase" instead of "for increasing".

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Typos look bad. Gotta fix them.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I went to the NPC to check the new text. I hovered over the Gems in Challenge Modes to read the tooltip.

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Typo fix.
