### PR TITLE
Fix non-visible temp battles affecting map overlay color

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattle.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattle.ts
@@ -30,7 +30,7 @@ class TemporaryBattle extends TownContent {
     public areaStatus() {
         if (!this.isUnlocked()) {
             return areaStatus.locked;
-        } else if (App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex(this.name)]() == 0) {
+        } else if (App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex(this.name)]() == 0 && this.isVisible()) {
             return areaStatus.unlockedUnfinished;
         } else {
             return areaStatus.completed;


### PR DESCRIPTION
## Description
In rare cases the player can capture the target of specific temp battles (Flowering Celebi, Red Gyarados, etc.) after the timer has expired resulting in the temp battle not being marked as complete but no longer being visible because the pokemon is caught. This causes the incomplete map color to permanently be displayed for the area where the temp battle should occur.

This change will also take into account the visibility of the temp battle when selecting the overlay color.

## Motivation and Context
An area being permanently displayed as incomplete sucks.

## How Has This Been Tested?
Loaded a file where this issue occurred and verified the incomplete color no longer displays.

## Types of changes
- Bug fix
