### PR TITLE
Town for Hoenn main subregion

### DIFF
--- a/src/modules/subRegion/SubRegions.ts
+++ b/src/modules/subRegion/SubRegions.ts
@@ -57,7 +57,7 @@ SubRegions.addSubRegion(Region.kanto, new SubRegion('Sevii Islands 4567', KantoS
 
 SubRegions.addSubRegion(Region.johto, new SubRegion('Johto', JohtoSubRegions.Johto));
 
-SubRegions.addSubRegion(Region.hoenn, new SubRegion('Hoenn', HoennSubRegions.Hoenn));
+SubRegions.addSubRegion(Region.hoenn, new SubRegion('Hoenn', HoennSubRegions.Hoenn, undefined, 'Slateport City'));
 SubRegions.addSubRegion(Region.hoenn, new SubRegion('Orre', HoennSubRegions.Orre, new QuestLineStartedRequirement('Shadows in the Desert'), 'Outskirt Stand', undefined));
 
 SubRegions.addSubRegion(Region.sinnoh, new SubRegion('Sinnoh', SinnohSubRegions.Sinnoh));


### PR DESCRIPTION
## Description
I added the dock town as a start town to the main subregion of Hoenn.

## Motivation and Context
Going from Orre to the main land was not updating the player town because Hoenn subregion had no specified town to relocate the player at.

## How Has This Been Tested?
I just travelled from Orre to Hoenn, and from Hoenn to Orre.

## Types of changes
- Bug fix
