### PR TITLE
Friend Safari pokemon list generation optimizations

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -445,6 +445,8 @@ class Game {
                 BattleCafeController.spinsLeft(BattleCafeController.spinsPerDay());
                 // Generate the weather forecast
                 WeatherApp.initialize();
+                // Refresh Friend Safari Pokemon List
+                SafariPokemonList.generateKalosSafariList();
 
                 DayOfWeekRequirement.date(now.getDay());
             }

--- a/src/scripts/safari/SafariPokemonList.ts
+++ b/src/scripts/safari/SafariPokemonList.ts
@@ -4,16 +4,19 @@ type SafariType = {
 }
 
 class SafariPokemonList {
-    public static list: Record<GameConstants.Region, KnockoutObservable<Array<SafariType>>> = {};
+    public static list: Record<GameConstants.Region, KnockoutObservable<Array<SafariType>>> = {
+        [GameConstants.Region.kanto]: ko.observableArray(),
+        [GameConstants.Region.kalos]: ko.observableArray(),
+    };
 
     public static generateSafariLists() {
-        SafariPokemonList.list[GameConstants.Region.kanto] = ko.pureComputed(() => this.generateKantoSafariList());
-        SafariPokemonList.list[GameConstants.Region.kalos] = ko.pureComputed(() => this.generateKalosSafariList());
+        this.generateKantoSafariList();
+        this.generateKalosSafariList();
     }
 
-    private static generateKantoSafariList() : Array<SafariType> {
+    private static generateKantoSafariList() {
         // Lower weighted pokemon will appear less frequently, equally weighted are equally likely to appear
-        return [
+        const pokemon : SafariType[] = [
             {name: 'Nidoran(F)', weight: 15},
             {name: 'Nidorina', weight: 10 },
             {name: 'Nidoran(M)', weight: 25 },
@@ -31,15 +34,22 @@ class SafariPokemonList {
             {name: 'Marowak', weight: 5 },
             {name: 'Tangela', weight: 4 },
         ];
+
+        SafariPokemonList.list[GameConstants.Region.kanto](pokemon);
     }
 
-    private static generateKalosSafariList() : Array<SafariType> {
+    public static generateKalosSafariList() {
         SeededRand.seedWithDate(new Date());
-        const pokemon : SafariType[] = SeededRand.shuffleArray(App.game.party.caughtPokemon.map((p) => p.name)
-            .filter((p) => !PokemonHelper.hasEvableLocations(p) && Object.keys(PokemonHelper.getPokemonLocations(p)).length)
-            .map((p) => {
-                return {name: p, weight: 10};
-            })).slice(0, 5);
+        const pokemon: SafariType[] = [];
+        const shuffledPokemon = SeededRand.shuffleArray(App.game.party.caughtPokemon.map((p) => p.name));
+
+        for (let i = 0; i < shuffledPokemon.length && pokemon.length < 5; i++) {
+            const p = shuffledPokemon[i];
+            if (!PokemonHelper.hasEvableLocations(p) && Object.keys(PokemonHelper.getPokemonLocations(p)).length) {
+                pokemon.push({ name: p, weight: 10 });
+            }
+        }
+
         pokemon.push({ name: 'Shuckle', weight: 2 });
         pokemon.push({ name: 'Stunfisk', weight: 2 });
         pokemon.push({ name: 'Magmar', weight: 2 });
@@ -50,6 +60,7 @@ class SafariPokemonList {
         pokemon.push({ name: 'Golurk', weight: 2 });
         pokemon.push({ name: 'Marowak', weight: 2 });
         pokemon.push({ name: 'Lapras', weight: 2 });
-        return pokemon;
+
+        SafariPokemonList.list[GameConstants.Region.kalos](pokemon);
     }
 }


### PR DESCRIPTION
## Description
Improves two areas of the friend/kalos safari pokemon list generation:

1. It's quite slow when the player has a large party (2.2s w/ 1304 pokemon)

Current: The entire caught pokemon list is filtered and shuffled, then the first five pokemon are selected.

Optimized: The caught pokemon list will now be shuffled first then the first five pokemon that meet the friend safari requirements will be selected.

2. The list only needs to be generated once per day. Due to the computed nature it was being unnecessarily recalced when changing regions, when the weather changes, when a new pokemon is caught, and possibly at other times.

Safari pokemon lists are no longer computed and `generateKalosSafariList()` will be called when the day changes to refresh the list only when necessary.

## Motivation and Context
Noticeable lag caused by the old generation method.

## How Has This Been Tested?
Verified safari lists generate properly and that the kalos list refreshes when the day changes.

## Types of changes
- Optimization
