### PR TITLE
Fix hatcher helpers using Region Debuff filter

### DIFF
--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -216,7 +216,7 @@ class HatcheryHelpers {
             if (egg.isNone()) {
                 // Check if there's a pokemon we can chuck into an egg
                 const compare = PartyController.compareBy(helper.sortOption(), helper.sortDirection(),
-                    App.game.challenges.list.regionalAttackDebuff.active() ? BreedingController.regionalAttackDebuff() : -1);
+                    App.game.challenges.list.regionalAttackDebuff.active() ? BreedingController.regionalAttackDebuff() : GameConstants.Region.none);
 
                 const categories = helper.categories();
                 const useHatcheryFilters = helper.useHatcheryFilters();

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -216,7 +216,7 @@ class HatcheryHelpers {
             if (egg.isNone()) {
                 // Check if there's a pokemon we can chuck into an egg
                 const compare = PartyController.compareBy(helper.sortOption(), helper.sortDirection(),
-                    +Settings.getSetting('breedingRegionalAttackDebuffSetting').value);
+                    App.game.challenges.list.regionalAttackDebuff.active() ? BreedingController.regionalAttackDebuff() : -1);
 
                 const categories = helper.categories();
                 const useHatcheryFilters = helper.useHatcheryFilters();


### PR DESCRIPTION
## Description
The _Regional Debuff_ filter is available in the hatchery when the regional debuff challenge is enabled. Disabling this challenge hides the filter (making it impossible to change) and any selected value will be ignored by the hatchery filters & sorting. Hatchery helpers were still taking the selected value into account when selecting pokemon to hatch even when the challenge was disabled, leading to some odd results.

## Motivation and Context
Fixes an uncommon bug.

## How Has This Been Tested?
Loaded a file where this issue was occurring and verified the filter was not used by helpers when selecting pokemon.

## Types of changes
- Bug fix
