### PR TITLE
Made clicking a Pokémon in Damage Calculator open Stats

### DIFF
--- a/src/components/damageCalculatorModal.html
+++ b/src/components/damageCalculatorModal.html
@@ -1,5 +1,5 @@
 <script type="text/html" id="damageDetailTemplate">
-  <tr>
+  <tr data-toggle="modal" href="#pokemonStatisticsModal" data-bind="click: () => { App.game.statistics.selectedPokemonID($data.id) }" >
       <td>
           <img class="smallImage" data-bind="attr:{ src: PokemonHelper.getImage($data.id) }" src=""/>
       <td class="text-nowrap">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
After seeing that Pokémon List allows the player to open the relevant Pokémon statistics modal, I thought it would be equally as good to let Damage Calculator do the same since, unlike Pokémon List, the Pokémon here are always displayed no matter if they are being bred / in the queue or not.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Damage Calculator lets you see your damage so letting you see a more detailed version of that using the individual Pokémon Statistic modal made sense to me.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I opened the Damage Calculator then clicked a Pokémon. Statistics modal opened.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![calculator-to-stats](https://github.com/pokeclicker/pokeclicker/assets/106291026/41f9fefe-ec71-48f1-9e93-6952475beabf)


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
