### PR TITLE
Fix hatchery not displaying pokemon nicknames

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -239,7 +239,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                             <img src="" width="80px" data-bind="attr:{ src: PokemonHelper.getImage($data.id) }">
                                             <span class="pokedex-bottom-text" data-bind="text: BreedingController.getDisplayValue($data)">value</span>
                                             <a class="overlay" href="#breed" data-bind="click: function() { App.game.breeding.addPokemonToHatchery($data); App.game.breeding.checkCloseModal();}"></a>
-                                            <span class="pokedex-top-text text-truncate px-1" data-bind="text: PokemonHelper.displayName($data.name),
+                                            <span class="pokedex-top-text text-truncate px-1" data-bind="text: $data.displayName,
                                                 tooltip: {
                                                     title: PokemonHelper.displayName($data.name),
                                                     trigger: 'hover',


### PR DESCRIPTION
## Description
Prior to #4305 the hatchery would display the pokemon nickname if one was set. This was most likely an unintended change so I have changed it back to displaying the nickname.

## Motivation and Context
Reverting unintended change

## How Has This Been Tested?
Gave a pokemon a nickname and verified it displayed in the hatchery modal

## Types of changes
- UI
