### PR TITLE
Safari Zone Tweaks

### DIFF
--- a/src/modules/requirements/SafariCatchRequirement.ts
+++ b/src/modules/requirements/SafariCatchRequirement.ts
@@ -1,0 +1,16 @@
+import * as GameConstants from '../GameConstants';
+import AchievementRequirement from './AchievementRequirement';
+
+export default class SafariCatchRequirement extends AchievementRequirement {
+    constructor(value: number, option: GameConstants.AchievementOption = GameConstants.AchievementOption.more) {
+        super(value, option, GameConstants.AchievementType.Safari);
+    }
+
+    public getProgress() {
+        return Math.min(App.game.statistics.safariPokemonCaptured(), this.requiredValue);
+    }
+
+    public hint(): string {
+        return `${this.requiredValue} Pokémon needs to be captured in a Safari Zone.`;
+    }
+}

--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -186,6 +186,7 @@ import SafariBaitRequirement from './requirements/SafariBaitRequirement';
 import SafariStepsRequirement from './requirements/SafariStepsRequirement';
 import SafariRocksRequirement from './requirements/SafariRocksRequirement';
 import SafariItemsRequirement from './requirements/SafariItemsRequirement';
+import SafariCatchRequirement from './requirements/SafariCatchRequirement';
 import ItemRequirement from './requirements/ItemRequirement';
 
 Object.assign(<any>window, {

--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -384,5 +384,6 @@ Object.assign(<any>window, {
     SafariStepsRequirement,
     SafariRocksRequirement,
     SafariItemsRequirement,
+    SafariCatchRequirement,
     ItemRequirement,
 });

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -421,6 +421,10 @@ class AchievementHandler {
         AchievementHandler.addAchievement('Chasing the Chansey', 'Reach Safari Level 15.', new SafariLevelRequirement(15), 0.5);
         AchievementHandler.addAchievement('Catch Animation Enthusiast', 'Reach Safari Level 30.', new SafariLevelRequirement(30), 1);
 
+        AchievementHandler.addAchievement('Just Keep Chuckin\' Balls', 'Catch 50 Pokémon in a Safari Zone', new SafariCatchRequirement(50), 0.1);
+        AchievementHandler.addAchievement('Strategic Chucker', 'Catch 100 Pokémon in a Safari Zone', new SafariCatchRequirement(100), 0.2);
+        AchievementHandler.addAchievement('Master of the Safari', 'Catch 250 Pokémon in a Safari Zone', new SafariCatchRequirement(250), 0.4);
+
         /*
          * REGIONAL
          */

--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -22,7 +22,8 @@ class Safari {
         return App.game.statistics.safariRocksThrown() * 10 +
             App.game.statistics.safariBaitThrown() * 5 +
             App.game.statistics.safariBallsThrown() * 10 +
-            App.game.statistics.safariPokemonCaptured() * 50;
+            App.game.statistics.safariPokemonCaptured() * 50 +
+            App.game.statistics.safariItemsObtained() * 10;
     });
     static safariLevel: KnockoutComputed<number> = ko.pureComputed(() => {
         const xp = Safari.safariExp();

--- a/src/scripts/safari/SafariPokemon.ts
+++ b/src/scripts/safari/SafariPokemon.ts
@@ -59,7 +59,7 @@ class SafariPokemon implements PokemonInterface {
 
     public get catchFactor(): number {
         const oakBonus = App.game.oakItems.calculateBonus(OakItemType.Magic_Ball);
-        let catchF = this.baseCatchFactor + oakBonus;
+        let catchF = this.baseCatchFactor + oakBonus + (this.levelModifier * 17.5);
         if (this.eating > 0) {
             catchF /= 2 - this.levelModifier;
         }

--- a/src/scripts/safari/SafariPokemon.ts
+++ b/src/scripts/safari/SafariPokemon.ts
@@ -59,7 +59,7 @@ class SafariPokemon implements PokemonInterface {
 
     public get catchFactor(): number {
         const oakBonus = App.game.oakItems.calculateBonus(OakItemType.Magic_Ball);
-        let catchF = this.baseCatchFactor + oakBonus + (this.levelModifier * 17.5);
+        let catchF = this.baseCatchFactor + oakBonus + (this.levelModifier * 10);
         if (this.eating > 0) {
             catchF /= 2 - this.levelModifier;
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
Adds a mild catch boost based on Safari Level, capping out just under 14% at level 40
Adds a Catch Achievement in the Safari Zone
Adds XP gains from picking up Safari Items


## Motivation and Context
Improves Safari Experience for all involved, asked to add these by Dev.


## How Has This Been Tested?
Checked that Achievements show up and increment, and that the boost is present for catch rate


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->

- New feature

