### PR TITLE
Add EVs tooltip to pokerus status indicator

### DIFF
--- a/src/components/berryMasterModal.html
+++ b/src/components/berryMasterModal.html
@@ -56,8 +56,9 @@
                                             </knockout>
                                             <knockout data-bind="if: ($parent.item.itemType instanceof PokemonItem)">
                                                 <span style="position: relative; top: -1px;"
-                                                    data-bind="template: { name: 'pokerusStatusTemplate',
-                                                        data: { 'pokerus': $parent.item.itemType.getPokerusStatus(), 'width': '32px' }}">
+                                                    data-bind="template: { name: 'pokerusStatusTemplate', data: {
+                                                        'pokerus': $parent.item.itemType.getPokerusStatus(), 'width': '32px',
+                                                        'evs': App.game.party.getPokemonByName($parent.item.itemType.type)?.evs() }}">
                                                 </span>
                                             </knockout>
                                         </span>

--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -7,7 +7,9 @@
                 <!-- ko if: !DungeonBattle.trainer() -->
                 <knockout data-bind="template: { name: 'caughtStatusTemplate', data: {'status': PartyController.getCaughtStatus(DungeonBattle.enemyPokemon().id)}}"></knockout>
                 <knockout style="position: relative; top: -1px;"
-                    data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(DungeonBattle.enemyPokemon().id) }}">
+                    data-bind="template: { name: 'pokerusStatusTemplate', data: {
+                        'pokerus': PartyController.getPokerusStatus(DungeonBattle.enemyPokemon().id),
+                        'evs': App.game.party.getPokemon(DungeonBattle.enemyPokemon().id)?.evs() }}">
                 </knockout>
                 <!-- /ko -->
             </knockout>

--- a/src/components/safariBattleModal.html
+++ b/src/components/safariBattleModal.html
@@ -14,7 +14,9 @@
                                 <knockout data-bind="template: { name: 'pokemonNameTemplate', data: { 'pokemon': SafariBattle.enemy } }">Pokémon name</knockout>
                                 <knockout data-bind="template: { name: 'caughtStatusTemplate', data: {'status': PartyController.getCaughtStatus(SafariBattle.enemy.id)}}"></knockout>
                                 <knockout style="position: relative; top: -1px;"
-                                    data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': PartyController.getPokerusStatus(SafariBattle.enemy.id) }}">
+                                    data-bind="template: { name: 'pokerusStatusTemplate', data: {
+                                        'pokerus': PartyController.getPokerusStatus(SafariBattle.enemy.id),
+                                        'evs': App.game.party.getPokemon(SafariBattle.enemy.id)?.evs() }}">
                                 </knockout>
                           </knockout>
 

--- a/src/components/shopModal.html
+++ b/src/components/shopModal.html
@@ -84,7 +84,9 @@
                 }">
                <knockout data-bind="if: ($data instanceof PokemonItem)">
                     <span style="position: absolute; top: 12px; left: 20px;"
-                        data-bind="template: { name: 'pokerusStatusTemplate', data: { 'pokerus': $data.getPokerusStatus(), 'width': '32px' }}">
+                        data-bind="template: { name: 'pokerusStatusTemplate', data: {
+                            'pokerus': $data.getPokerusStatus(), 'width': '32px',
+                            'evs': App.game.party.getPokemonByName($data.type)?.evs() }}">
                     </span>
                </knockout>
                <knockout data-bind="if: ($data instanceof CaughtIndicatingItem)">

--- a/src/components/templates/pokerusStatusTemplate.html
+++ b/src/components/templates/pokerusStatusTemplate.html
@@ -1,7 +1,12 @@
 <script type="text/html" id="pokerusStatusTemplate">
     <knockout style="display: inline;">
         <!-- ko if: $data.pokerus -->
-        <img width="" src="" data-bind="attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[$data.pokerus]}.png`, width: $data.width }"/>
+        <img width="" src="" data-bind="attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[$data.pokerus]}.png`, width: $data.width },
+            tooltip: {
+                title:  $data.evs !== undefined ? `EVs: ${$data.evs.toLocaleString('en-US')}` : '',
+                trigger: 'hover',
+                placement: 'top',
+            }"/>
         <!-- /ko -->
     </knockout>
 </script>


### PR DESCRIPTION
## Description
Adds a tooltip displaying the amount of EVs a pokemon has to several locations that displays pokerus status including safari zone, shops, berry trades, and dungeon view.

## Motivation and Context
Nice to have and quicker than pulling up the pokedex to check, particularly when in the safari zone.

## How Has This Been Tested?
Checked each location the template is used to verify it displays correctly.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/0fe1a480-1ca4-4eb4-9a77-d240fc6ccef2)

## Types of changes
- UI improvement
