### PR TITLE
Fix: Safari caught message showing Pokémon name instead display name

### DIFF
--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -146,7 +146,7 @@ class SafariBattle {
     }
 
     private static capturePokemon() {
-        SafariBattle.text(`GOTCHA!<br>${SafariBattle.enemy.name} was caught!`);
+        SafariBattle.text(`GOTCHA!<br>${SafariBattle.enemy.displayName} was caught!`);
         GameHelper.incrementObservable(App.game.statistics.safariPokemonCaptured, 1);
         const pokemonID = PokemonHelper.getPokemonByName(SafariBattle.enemy.name).id;
         App.game.party.gainPokemonById(pokemonID, SafariBattle.enemy.shiny);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
After catching a Pokémon in the Safari, the caught message will show their actual name instead their display name, this means it will show the english names regardless the selected language or in Nidoran case, (M)/(F) instead ♂/♀.



## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Consistency.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
* Caught a Pokémon with another language selected to see if it changed.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://github.com/pokeclicker/pokeclicker/assets/104547700/32226885-4b12-43e6-b510-302593b1c106)


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
