### PR TITLE
Friend Safari fixed rotation

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -275,6 +275,8 @@ export const LEGAL_WALK_BLOCKS = [
 
 export const SAFARI_OUT_OF_BALLS = 'Game Over!<br>You have run out of safari balls to use.';
 
+export const FRIEND_SAFARI_POKEMON = 5;
+
 // Quests
 
 // Numbers calculated by Dimava assumes ability to 1 shot on high routes and some use oak items,

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -127,8 +127,8 @@ namespace GameConstants {
     declare const SAFARI_BATTLE_CHANCE: number;
     declare const SAFARI_BASE_POKEBALL_COUNT: number;
     declare const LEGAL_WALK_BLOCKS: number[];
-    declare const FRIEND_SAFARI_POKEMON: number;
     declare const SAFARI_OUT_OF_BALLS: string;
+    declare const FRIEND_SAFARI_POKEMON: number;
     declare const GAIN_MONEY_BASE_REWARD: number;
     declare const HATCH_EGGS_BASE_REWARD: number;
     declare const SHINY_BASE_REWARD: number;

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -127,6 +127,7 @@ namespace GameConstants {
     declare const SAFARI_BATTLE_CHANCE: number;
     declare const SAFARI_BASE_POKEBALL_COUNT: number;
     declare const LEGAL_WALK_BLOCKS: number[];
+    declare const FRIEND_SAFARI_POKEMON: number;
     declare const SAFARI_OUT_OF_BALLS: string;
     declare const GAIN_MONEY_BASE_REWARD: number;
     declare const HATCH_EGGS_BASE_REWARD: number;

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -431,9 +431,9 @@ class PokemonHelper extends TmpPokemonHelper {
         return encounterTypes;
     }
 
-    public static hasEvableLocations = (pokemonName: PokemonNameType) => {
+    public static isObtainableAndNotEvable = (pokemonName: PokemonNameType) => {
         const locations = PokemonHelper.getPokemonLocations(pokemonName);
-        return locations[PokemonLocationType.Dungeon] ||
+        const isEvable = locations[PokemonLocationType.Dungeon] ||
             locations[PokemonLocationType.DungeonBoss] ||
             locations[PokemonLocationType.DungeonChest] ||
             (locations[PokemonLocationType.Evolution] as EvoData[])?.some((evo) => evo.trigger === EvoTrigger.STONE) || // Only stone evolutions gives EVs
@@ -442,6 +442,6 @@ class PokemonHelper extends TmpPokemonHelper {
             locations[PokemonLocationType.Safari] ||
             locations[PokemonLocationType.Shop] ||
             locations[PokemonLocationType.Wandering];
-
+        return !isEvable && Object.keys(locations).length;
     };
 }

--- a/src/scripts/safari/SafariPokemon.ts
+++ b/src/scripts/safari/SafariPokemon.ts
@@ -114,10 +114,8 @@ class SafariPokemon implements PokemonInterface {
 
     public static random() {
         // Get a random pokemon from current region and zone for Safari Zone
-        const pokemon = Rand.fromWeightedArray(
-            SafariPokemonList.list[Safari.activeRegion()](),
-            SafariPokemonList.list[Safari.activeRegion()]().map(p => p.weight)
-        );
+        const safariPokemon = SafariPokemonList.list[Safari.activeRegion()]().filter((p) => p.isAvailable());
+        const pokemon = Rand.fromWeightedArray(safariPokemon, safariPokemon.map(p => p.weight));
         return new SafariPokemon(pokemon.name);
     }
 

--- a/src/scripts/safari/SafariPokemonList.ts
+++ b/src/scripts/safari/SafariPokemonList.ts
@@ -1,10 +1,17 @@
-type SafariType = {
-    name: PokemonNameType,
-    weight: number
+class SafariEncounter {
+    constructor(
+        public name: PokemonNameType,
+        public weight: number,
+        private requireCaught = false
+    ) {}
+
+    public isAvailable(): boolean {
+        return !this.requireCaught ? true : App.game.party.alreadyCaughtPokemonByName(this.name);
+    }
 }
 
 class SafariPokemonList {
-    public static list: Record<GameConstants.Region, KnockoutObservable<Array<SafariType>>> = {
+    public static list: Record<GameConstants.Region, KnockoutObservable<Array<SafariEncounter>>> = {
         [GameConstants.Region.kanto]: ko.observableArray(),
         [GameConstants.Region.kalos]: ko.observableArray(),
     };
@@ -16,23 +23,23 @@ class SafariPokemonList {
 
     private static generateKantoSafariList() {
         // Lower weighted pokemon will appear less frequently, equally weighted are equally likely to appear
-        const pokemon : SafariType[] = [
-            {name: 'Nidoran(F)', weight: 15},
-            {name: 'Nidorina', weight: 10 },
-            {name: 'Nidoran(M)', weight: 25 },
-            {name: 'Nidorino', weight: 10 },
-            {name: 'Exeggcute', weight: 20 },
-            {name: 'Paras', weight: 5 },
-            {name: 'Parasect', weight: 15 },
-            {name: 'Rhyhorn', weight: 10 },
-            {name: 'Chansey', weight: 4 },
-            {name: 'Scyther', weight: 4 },
-            {name: 'Pinsir', weight: 4 },
-            {name: 'Kangaskhan', weight: 15 },
-            {name: 'Tauros', weight: 10 },
-            {name: 'Cubone', weight: 10 },
-            {name: 'Marowak', weight: 5 },
-            {name: 'Tangela', weight: 4 },
+        const pokemon : SafariEncounter[] = [
+            new SafariEncounter('Nidoran(F)', 15),
+            new SafariEncounter('Nidorina', 10),
+            new SafariEncounter('Nidoran(M)', 25),
+            new SafariEncounter('Nidorino', 10),
+            new SafariEncounter('Exeggcute', 20),
+            new SafariEncounter('Paras', 5),
+            new SafariEncounter('Parasect', 15),
+            new SafariEncounter('Rhyhorn', 10),
+            new SafariEncounter('Chansey', 4),
+            new SafariEncounter('Scyther', 4),
+            new SafariEncounter('Pinsir', 4),
+            new SafariEncounter('Kangaskhan', 15),
+            new SafariEncounter('Tauros', 10),
+            new SafariEncounter('Cubone', 10),
+            new SafariEncounter('Marowak', 5),
+            new SafariEncounter('Tangela', 4),
         ];
 
         SafariPokemonList.list[GameConstants.Region.kanto](pokemon);
@@ -45,23 +52,24 @@ class SafariPokemonList {
                 && PokemonHelper.calcNativeRegion(p.name) <= GameConstants.MAX_AVAILABLE_REGION));
 
         const batchCount = Math.ceil(shuffledPokemon.length / GameConstants.FRIEND_SAFARI_POKEMON);
-        const startIndex = (Math.floor((new Date()).getTime() / (24 * 60 * 60 * 1000)) % batchCount) * GameConstants.FRIEND_SAFARI_POKEMON;
+        const now = new Date();
+        const startIndex = (Math.floor((now.getTime() - now.getTimezoneOffset() * 60 * 1000) / (24 * 60 * 60 * 1000)) % batchCount) * GameConstants.FRIEND_SAFARI_POKEMON;
         const endIndex = startIndex + GameConstants.FRIEND_SAFARI_POKEMON;
 
-        const pokemon: SafariType[] = shuffledPokemon.slice(startIndex, endIndex).map((p) => {
-            return { name: p.name, weight: 10, locked: !App.game.party.alreadyCaughtPokemonByName(p.name) };
+        const pokemon: SafariEncounter[] = shuffledPokemon.slice(startIndex, endIndex).map((p) => {
+            return new SafariEncounter(p.name, 10, true);
         });
 
-        pokemon.push({ name: 'Shuckle', weight: 2 });
-        pokemon.push({ name: 'Stunfisk', weight: 2 });
-        pokemon.push({ name: 'Magmar', weight: 2 });
-        pokemon.push({ name: 'Maractus', weight: 2 });
-        pokemon.push({ name: 'Klefki', weight: 2 });
-        pokemon.push({ name: 'Breloom', weight: 2 });
-        pokemon.push({ name: 'Woobat', weight: 2 });
-        pokemon.push({ name: 'Golurk', weight: 2 });
-        pokemon.push({ name: 'Marowak', weight: 2 });
-        pokemon.push({ name: 'Lapras', weight: 2 });
+        pokemon.push(new SafariEncounter('Shuckle', 2));
+        pokemon.push(new SafariEncounter('Stunfisk', 2));
+        pokemon.push(new SafariEncounter('Magmar', 2));
+        pokemon.push(new SafariEncounter('Maractus', 2));
+        pokemon.push(new SafariEncounter('Klefki', 2));
+        pokemon.push(new SafariEncounter('Breloom', 2));
+        pokemon.push(new SafariEncounter('Woobat', 2));
+        pokemon.push(new SafariEncounter('Golurk', 2));
+        pokemon.push(new SafariEncounter('Marowak', 2));
+        pokemon.push(new SafariEncounter('Lapras', 2));
 
         SafariPokemonList.list[GameConstants.Region.kalos](pokemon);
     }

--- a/src/scripts/safari/SafariPokemonList.ts
+++ b/src/scripts/safari/SafariPokemonList.ts
@@ -39,16 +39,18 @@ class SafariPokemonList {
     }
 
     public static generateKalosSafariList() {
-        SeededRand.seedWithDate(new Date());
-        const pokemon: SafariType[] = [];
-        const shuffledPokemon = SeededRand.shuffleArray(App.game.party.caughtPokemon.map((p) => p.name));
+        SeededRand.seed(+player.trainerId);
+        const shuffledPokemon = SeededRand.shuffleArray(
+            pokemonList.filter((p) => PokemonHelper.isObtainableAndNotEvable(p.name)
+                && PokemonHelper.calcNativeRegion(p.name) <= GameConstants.MAX_AVAILABLE_REGION));
 
-        for (let i = 0; i < shuffledPokemon.length && pokemon.length < 5; i++) {
-            const p = shuffledPokemon[i];
-            if (!PokemonHelper.hasEvableLocations(p) && Object.keys(PokemonHelper.getPokemonLocations(p)).length) {
-                pokemon.push({ name: p, weight: 10 });
-            }
-        }
+        const batchCount = Math.ceil(shuffledPokemon.length / GameConstants.FRIEND_SAFARI_POKEMON);
+        const startIndex = (Math.floor((new Date()).getTime() / (24 * 60 * 60 * 1000)) % batchCount) * GameConstants.FRIEND_SAFARI_POKEMON;
+        const endIndex = startIndex + GameConstants.FRIEND_SAFARI_POKEMON;
+
+        const pokemon: SafariType[] = shuffledPokemon.slice(startIndex, endIndex).map((p) => {
+            return { name: p.name, weight: 10, locked: !App.game.party.alreadyCaughtPokemonByName(p.name) };
+        });
 
         pokemon.push({ name: 'Shuckle', weight: 2 });
         pokemon.push({ name: 'Stunfisk', weight: 2 });

--- a/src/scripts/towns/SafariPokemonNPC.ts
+++ b/src/scripts/towns/SafariPokemonNPC.ts
@@ -15,13 +15,22 @@ class SafariPokemonNPC extends NPC {
             return 'Huh!? This is a restricted area, kid. You can\'t be here!';
         }
 
-        let pokemonHTML = SafariPokemonList.list[this.region]()
-            .map(p => `<img width="72" src="assets/images/pokemon/${PokemonHelper.getPokemonByName(p.name).id}.png" />`);
+        let pokemonHTML = SafariPokemonList.list[this.region]().map((p) => {
+            let html = `<img width="72" class="d-block ${!p.isAvailable() ? 'dungeon-pokemon-locked' : ''}" src="assets/images/pokemon/${PokemonHelper.getPokemonByName(p.name).id}.png" />`;
+            if (this.region === GameConstants.Region.kalos) {
+                const partyPokemon = App.game.party.getPokemonByName(p.name);
+                if (partyPokemon?.pokerus) {
+                    html += `<img class="d-block mx-auto" src="assets/images/breeding/pokerus/${GameConstants.Pokerus[partyPokemon.pokerus]}.png" />`;
+                }
+                return `<div class="mb-1">${html}</div>`;
+            }
+            return html;
+        });
 
         if (this.region === GameConstants.Region.kalos) {
-            pokemonHTML = pokemonHTML.slice(0, 5); // display just the daily pokemon for friend safari
+            pokemonHTML = pokemonHTML.slice(0, GameConstants.FRIEND_SAFARI_POKEMON); // display just the daily pokemon for friend safari
         }
 
-        return super.dialogHTML + pokemonHTML.join('');
+        return `${super.dialogHTML}<div class="d-flex flex-wrap justify-content-around">${pokemonHTML.join('')}</div>`;
     }
 }

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -5672,6 +5672,7 @@ const VivillonPhotobook = new NPC('Vivillon Photobook', [
 
 const KalosSafariRanger = new SafariPokemonNPC('Safari Ranger', [
     'We\'ve had sightings of several unique Pokémon today along with the usual familiar faces!',
+    'These Pokémon will hide from trainers unless captured elsewhere first.',
 ], GameConstants.Region.kalos, 'assets/images/npcs/Pokemon Ranger (female).png');
 
 const FriendlyAttendant = new NPC('Friendly Attendant', [


### PR DESCRIPTION
## Description
Per discussion on discord this changes the friend safari rotation from random based on the players caught pokemon to a daily fixed rotation (seeded by trainer id & shuffled) of all available non-EVable pokemon. Currently there are 126 (127 on dev) pokemon that can appear in the friend safari so 26 days for everything to appear.

Added the ability for pokemon to be "locked" in the safari until caught elsewhere. As the friend safari is no longer based on caught pokemon, it's possible for pokemon to be selected that have not been caught by the player yet. These pokemon will be in the pool but cannot be encountered.

Updated the Safari Ranger NPC to handle the previously mentioned "locked" pokemon - they will appear as a silhouette and also added dialog to indicate they must first be caught elsewhere. The friend safari NPC will also now display the pokerus status icon below each pokemon.

Removed the `PokemonHelper.hasEvableLocations()` function in favor of one called `PokemonHelper.isObtainableAndNotEvable()` to speed up the `pokemonList` filter and so we aren't calling `getPokemonLocations` twice for every pokemon. Will look into speeding it up even more in a different PR, it takes about 1.1s to run on my machine.

## Motivation and Context
Removes the completely RNG element that could result in waiting months, or longer, for some pokemon to appear in the pool.

## How Has This Been Tested?
Went to friend safari, removed one of the daily pokemon from my party and verified it no longer appeared as an encounter and was shown as a silhouette in the NPC list.

Time traveled to verify the pool changed at midnight and it correctly rotates through the pool.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/97db5fbe-2ccb-4788-95b5-eef7b573aef1)

## Types of changes
- Feature change
