### PR TITLE
Fix challenge pop up notification

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -510,10 +510,10 @@ class Update implements Saveable {
             setTimeout(async () => {
                 // Check if player wants to activate the new challenge modes
                 if (!await Notifier.confirm({ title: 'Regional Attack Debuff (recommended)', message: 'New challenge mode added Regional Attack Debuff.\n\nLowers Pokémon attack based on native region and highest reached region.\n\nThis is the default and recommended way to play, but is now an optional challenge.\n\nPlease choose if you would like this challenge mode to be enabled or disabled (cannot be re-enabled later)', confirm: 'Disable', cancel: 'Enable' })) {
-                    App.game.challenges.list.regionalAttackDebuff.disable();
+                    App.game.challenges.list.regionalAttackDebuff.activate();
                 }
                 if (!await Notifier.confirm({ title: 'Require Complete Pokédex (recommended)', message: 'New challenge mode added Require Complete Pokédex.\n\nRequires a complete regional pokédex before moving on to the next region.\n\nThis is the default and recommended way to play, but is now an optional challenge.\n\nPlease choose if you would like this challenge mode to be enabled or disabled (cannot be re-enabled later)', confirm: 'Disable', cancel: 'Enable' })) {
-                    App.game.challenges.list.requireCompletePokedex.disable();
+                    App.game.challenges.list.requireCompletePokedex.activate();
                 }
             }, GameConstants.SECOND);
         },

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -509,10 +509,10 @@ class Update implements Saveable {
 
             setTimeout(async () => {
                 // Check if player wants to activate the new challenge modes
-                if (!await Notifier.confirm({ title: 'Regional Attack Debuff (recommended)', message: 'New challenge mode added Regional Attack Debuff.\n\nLowers Pokémon attack based on native region and highest reached region.\n\nThis is the default and recommended way to play, but is now an optional challenge.\n\nPlease choose if you would like this challenge mode to be enabled or disabled (cannot be re-enabled later)', confirm: 'enable', cancel: 'disable' })) {
+                if (!await Notifier.confirm({ title: 'Regional Attack Debuff (recommended)', message: 'New challenge mode added Regional Attack Debuff.\n\nLowers Pokémon attack based on native region and highest reached region.\n\nThis is the default and recommended way to play, but is now an optional challenge.\n\nPlease choose if you would like this challenge mode to be enabled or disabled (cannot be re-enabled later)', confirm: 'Disable', cancel: 'Enable' })) {
                     App.game.challenges.list.regionalAttackDebuff.disable();
                 }
-                if (!await Notifier.confirm({ title: 'Require Complete Pokédex (recommended)', message: 'New challenge mode added Require Complete Pokédex.\n\nRequires a complete regional pokédex before moving on to the next region.\n\nThis is the default and recommended way to play, but is now an optional challenge.\n\nPlease choose if you would like this challenge mode to be enabled or disabled (cannot be re-enabled later)', confirm: 'enable', cancel: 'disable' })) {
+                if (!await Notifier.confirm({ title: 'Require Complete Pokédex (recommended)', message: 'New challenge mode added Require Complete Pokédex.\n\nRequires a complete regional pokédex before moving on to the next region.\n\nThis is the default and recommended way to play, but is now an optional challenge.\n\nPlease choose if you would like this challenge mode to be enabled or disabled (cannot be re-enabled later)', confirm: 'Disable', cancel: 'Enable' })) {
                     App.game.challenges.list.requireCompletePokedex.disable();
                 }
             }, GameConstants.SECOND);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
Changes pop up notification on old recommended challenges. Followed the enable notification format of Slow EVs. Capitalized Enable and disable. 



## Motivation and Context
Buttons inconsistent when importing very sold saves before recommended challenges were options. Fix capitalization of enable and disable. 


## How Has This Been Tested?
Tested with old save files to see differences.


## Screenshots (optional):
Current Slow EV used as blueprint to create consistency 
![slow EV](https://github.com/pokeclicker/pokeclicker/assets/100386196/f2e46495-eea9-4e17-bcfe-d9e02b09827f)

Old debuff
![old debuff](https://github.com/pokeclicker/pokeclicker/assets/100386196/0f0f948b-8059-4c8f-b5a9-f53e61c36066)

New debuff
![DEBUFF](https://github.com/pokeclicker/pokeclicker/assets/100386196/4a6fc12b-b8c8-4497-a4a5-3bb5a55d968d)

Old completed pokedex
![old pokedex](https://github.com/pokeclicker/pokeclicker/assets/100386196/7cd177b9-d92d-4509-ba94-0fccd3b531a8)

New complete pokedex
![pokedex](https://github.com/pokeclicker/pokeclicker/assets/100386196/8dcef362-a3c5-4689-94a3-f7b43b03166e)


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
- UI improvement
