### PR TITLE
Fix: Broken Safari fence tiles

### DIFF
--- a/src/scripts/safari/SafariBody.ts
+++ b/src/scripts/safari/SafariBody.ts
@@ -231,15 +231,43 @@ class FenceBody extends SandBody {
     }
 
     private openFence() {
+        const removedTiles = [];
         const options = [26, 28, 29, 31];
         const pick = Rand.fromArray(options);
         for (let i = 0; i < this.grid.length; i++) {
             for (let j = 0; j < this.grid[0].length; j++) {
                 if (this.grid[i][j] === pick) {
+                    if (pick == 28 || pick == 29) { // Only tiles connected to the left/right fence tiles are broken
+                        removedTiles.push({x: j, y: i});
+                    }
                     this.grid[i][j] = 0;
                 }
             }
         }
+        // Check tiles above and below the removed ones to avoid broken fences tiles
+        removedTiles?.map((pos) => {
+            const tileAbove = this.grid[pos.y - 1] ? this.grid[pos.y - 1][pos.x] : undefined;
+            const tileBelow = this.grid[pos.y + 1] ? this.grid[pos.y + 1][pos.x] : undefined;
+            switch (pick) {
+                case 28: // Left fence tile
+                    if (tileAbove === 25 || tileAbove === 35) {
+                        this.grid[pos.y - 1][pos.x] = 26;
+                    }
+                    if (tileBelow === 30 || tileBelow === 36) {
+                        this.grid[pos.y + 1][pos.x] = 26;
+                    }
+                    break;
+                case 29: // Right fence tile
+                    if (tileAbove === 27 || tileAbove === 34) {
+                        this.grid[pos.y - 1][pos.x] = 31;
+                    }
+                    if (tileBelow === 32 || tileBelow === 33) {
+                        this.grid[pos.y + 1][pos.x] = 31;
+                    }
+                    break;
+                default:
+            }
+        });
     }
 }
 

--- a/src/scripts/safari/SafariBody.ts
+++ b/src/scripts/safari/SafariBody.ts
@@ -254,12 +254,12 @@ class FenceBody extends SandBody {
                         this.grid[pos.y - 1][pos.x] = 26;
                     }
                     if (tileBelow === 30 || tileBelow === 36) {
-                        this.grid[pos.y + 1][pos.x] = 26;
+                        this.grid[pos.y + 1][pos.x] = 31;
                     }
                     break;
                 case 29: // Right fence tile
                     if (tileAbove === 27 || tileAbove === 34) {
-                        this.grid[pos.y - 1][pos.x] = 31;
+                        this.grid[pos.y - 1][pos.x] = 26;
                     }
                     if (tileBelow === 32 || tileBelow === 33) {
                         this.grid[pos.y + 1][pos.x] = 31;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
In the Safari, when fence tiles are generated, some of them are removed to create an entrance, if the removed tiles are either from the left or the right, the fence tiles at the corners look broken:

![image](https://github.com/pokeclicker/pokeclicker/assets/104547700/27e87239-d1e3-460d-be66-9ec2f97fcc0f)

Fixed tiles:

![image](https://github.com/pokeclicker/pokeclicker/assets/104547700/8ccff03b-080b-4a0a-bd69-666c4253473b)



## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Chopped fence looked weird


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
* Changed the code to generate only fences
* Create several Safari runs to check if the tiles look correctly



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Graphic fix
