### PR TITLE
[FIX] Restarting Zeros ambition when shards are sold

### DIFF
--- a/src/scripts/quests/Quest.ts
+++ b/src/scripts/quests/Quest.ts
@@ -127,6 +127,10 @@ abstract class Quest {
         // Subscribe to the new focus
         this.focusValue = this._focus();
         this.focusSub = this._focus.subscribe?.((newValue) => {
+            // If we aren't actively completing this quests, don't do anything
+            if (!this.inProgress()) {
+                return;
+            }
             // If the focus goes down, adjust our initial value
             if (newValue < this.focusValue) {
                 this.initial(this.initial() - (this.focusValue - newValue));


### PR DESCRIPTION
## Description
Fix selling shards restarting quests

## Motivation and Context
Fixes #4497
Fixes #4482

## How Has This Been Tested?
Loaded save where quest was completed, traded shards at Aether Paradise, quest did not restart.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/7288322/5d3745e3-c26a-4ce9-9333-9139c9e3c732)

## Types of changes
- Bug fix

## Example save where bug occurs
[[v0.10.12] PokeClicker 2023-07-13 22_34_22.txt](https://github.com/pokeclicker/pokeclicker/files/12044947/v0.10.12.PokeClicker.2023-07-13.22_34_22.txt)

