### PR TITLE
Exclude unavailable/uncaught pokemon from (Friend) Safari area status

### DIFF
--- a/src/scripts/safari/SafariTownContent.ts
+++ b/src/scripts/safari/SafariTownContent.ts
@@ -18,6 +18,9 @@ class SafariTownContent extends TownContent {
         const pokemonStatusArray = [areaStatus.completed];
         const pokerusUnlocked = Settings.getSetting(`--${areaStatus[areaStatus.missingResistant]}`).isUnlocked();
         SafariPokemonList.list[player.region]().forEach(p => {
+            if (!p.isAvailable()) {
+                return;
+            }
             const caughtStatus = PartyController.getCaughtStatusByName(p.name);
             if (caughtStatus == CaughtStatus.NotCaught) {
                 pokemonStatusArray.push(areaStatus.uncaughtPokemon);


### PR DESCRIPTION
## Description
With the changes to the friend safari rotation uncaught pokemon can be selected but will not be available until caught elsewhere. These uncaught pokemon were affecting the area color on the map. This change will exclude uncaught/unavailable pokemon from being considered in the area status.

## Motivation and Context
Unobtained pokemon are technically not there and cannot be caught so they shouldn't affect the area status.

## How Has This Been Tested?
Checked that the map overlay color was not affected by uncaught pokemon but did accurately reflect missing shiny and missing resistant.
