### PR TITLE
Typo and Event order

### DIFF
--- a/src/modules/specialEvents/SpecialEvent.ts
+++ b/src/modules/specialEvents/SpecialEvent.ts
@@ -98,7 +98,7 @@ export default class SpecialEvent {
         }
         Notifier.confirm({
             title: 'Do you want to start this event early?',
-            message: `Starting '${this.title}' early will cost you ${price} QP for 24 hours of event time..`,
+            message: `Starting '${this.title}' early will cost you ${price} QP for 24 hours of event time.`,
         }).then((result: boolean) => {
             if (result) {
                 App.game.wallet.loseAmount({ amount: price, currency: Currency.questPoint });

--- a/src/scripts/specialEvents/SpecialEvents.ts
+++ b/src/scripts/specialEvents/SpecialEvents.ts
@@ -113,6 +113,18 @@ SpecialEvents.newEvent('Easter', 'Encounter Surprise Togepi for a limited time w
     new Date(new Date().getFullYear(), 3, 29, 23), () => {
     }
 );
+/* Golden Week
+    Dungeon.ts:
+        Bulbasaur (Rose) in Flower Paradise
+    */
+        SpecialEvents.newEvent('Golden Week', 'Enjoy your time off in the "Golden Week"! Travel tip: Visit the Flower Paradise in Sinnoh on your well earned vacation and enjoy the bloom of roses.',
+        // Start
+        new Date(new Date().getFullYear(), 3, 29, 1), () => {
+        },
+        // End
+        new Date(new Date().getFullYear(), 4, 6, 23), () => {
+        }
+    );    
 /* First Event
     RoamingPokemonList.ts:
         Flying Pikachu
@@ -194,17 +206,5 @@ SpecialEvents.newEvent('Merry Christmas!', 'Encounter Santa Snorlax roaming the 
     },
     // End
     new Date(new Date().getFullYear(), 11, 30, 23), () => {
-    }
-);
-/* Golden Week
-    Dungeon.ts:
-        Bulbasaur (Rose) in Flower Paradise
-    */
-SpecialEvents.newEvent('Golden Week', 'Enjoy your time off in the "Golden Week"! Travel tip: Visit the Flower Paradise in Sinnoh on your well earned vacation and enjoy the bloom of roses.',
-    // Start
-    new Date(new Date().getFullYear(), 3, 29, 1), () => {
-    },
-    // End
-    new Date(new Date().getFullYear(), 4, 6, 23), () => {
     }
 );


### PR DESCRIPTION
## Description
There was an extra period in the Event Calendar
Also moved Golden Week to after Easter so it shows up on the wiki in order because I didn't want to make a PR that only removed one period...

## Motivation and Context
- Saw the extra dot, asked Jaas about it. It shouldn't be there
- Saw the event wiki page, wondered why Golden Week was last, realized it was last in the code

## How Has This Been Tested?
This has not been tested yet. Actually I think I see an error... will mark as draft for now.

## Types of changes
- Typo
- Wiki data
