### PR TITLE
Hide uncaught base forms from Pokedex if alternate non-regional form is caught

### DIFF
--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -119,7 +119,9 @@ class PokedexHelper {
                 return false;
             }
             // Hide uncaught base forms if alternate non-regional form is caught
-            if (!alreadyCaught && pokemon.id == Math.floor(pokemon.id) && App.game.party._caughtPokemon().some((p) => Math.floor(p.id) == pokemon.id) && hasBaseFormInSameRegion()) {
+            if (!alreadyCaught && pokemon.id == Math.floor(pokemon.id) &&
+                App.game.party._caughtPokemon().some((p) => Math.floor(p.id) == pokemon.id && PokemonHelper.calcNativeRegion(p.name) == nativeRegion)
+            ) {
                 return false;
             }
 


### PR DESCRIPTION
## Description
Hides uncaught base form pokemon from the pokedex after obtaining an alternate form with the same native region.

This appears to already be intended but was not working correctly.

## Motivation and Context
This was previously fixed at one point then was unintentionally busted again.
Frequent questions and confusion regarding Unown (A) appearing as uncaught when players are trying to complete the Johto pokedex while having caught a different Unown.

## How Has This Been Tested?
Unown (A) no longer shows as uncaught after capturing any other Unown.
Alolan & Galarian regional forms (still) appear independently from their earlier forms when uncaught.

## Types of changes
- Bug fix
