### PR TITLE
Orre typos

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1059,7 +1059,7 @@ class QuestLineHelper {
         const fightFolly = new CustomQuest(1, 0, 'Fight Folly the Shady Guy in Phenac City', () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Folly')]());
         orreColosseumQuestLine.addQuest(fightFolly);
 
-        const checkSack = new TalkToNPCQuest(Sack, 'Check the see what is in the mysterious sack.'); // Step 3
+        const checkSack = new TalkToNPCQuest(Sack, 'Check what is in the mysterious sack.'); // Step 3
         orreColosseumQuestLine.addQuest(checkSack);
 
         const defeatShadowsPhenac = new CustomQuest(10, 0, 'Defeat 10 trainers who are using Shadow Pokémon in Phenac City.', () => App.game.statistics.totalShadowPokemonDefeated());
@@ -1097,7 +1097,7 @@ class QuestLineHelper {
         const freePlusle = new TalkToNPCQuest(FreePlusle, 'Free Duking\'s Plusle.'); //Step 13
         orreColosseumQuestLine.addQuest(freePlusle);
 
-        const talkToRui2 = new TalkToNPCQuest(Rui2, 'Discuss your next move with Rui at the Pyrite Colosseum.');
+        const talkToRui2 = new TalkToNPCQuest(Rui2, 'Discuss your next move with Rui at Pyrite Colosseum.');
         orreColosseumQuestLine.addQuest(talkToRui2);
 
         const clearAgatePeons = new CustomQuest (3, 0, 'Defeat the Team Cipher Peons looting Agate Village.', () =>
@@ -1126,13 +1126,13 @@ class QuestLineHelper {
 
         const fightTheUnder = new CustomQuest(1, 0, 'Track down the TV broadcast coming The Under in Pyrite Town. Clear The Under.', () => App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('The Under')](), undefined, undefined,
             {
-                clearedMessage: 'Aiyeeeeh! How dare you! How could I get bested by a mere boy? Remember this! I\'ll get you back for this!',
+                clearedMessage: 'Aiyeeeeh! How dare you! How could I get bested by a mere child? Remember this! I\'ll get you back for this!',
                 npcDisplayName: 'Venus',
                 npcImageName: 'Cipher Admin (Venus)',
             });
         orreColosseumQuestLine.addQuest(fightTheUnder);
 
-        const searchTheStudio = new TalkToNPCQuest(SearchTheStudio, 'Search Venus\'s Studio in the Under for clues.'); // Step 21
+        const searchTheStudio = new TalkToNPCQuest(SearchTheStudio, 'Search Venus\' Studio in the Under for clues.'); // Step 21
         orreColosseumQuestLine.addQuest(searchTheStudio);
 
         const fightCipherLab = new CustomQuest(1, 0, 'Follow the secret tunnel to the Cipher Lab and clear out the enemies.', () => App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Cipher Lab')](), undefined, undefined,

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1152,7 +1152,7 @@ class QuestLineHelper {
         const fightRealgamColosseum = new CustomQuest(10, 0, 'Team Cipher\'s leaders have holed up in the Realgam Colosseum. Fight them to end this once and for all!', () => App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex('Realgam Colosseum')]());
         orreColosseumQuestLine.addQuest(fightRealgamColosseum);
 
-        const watchEviceEscape = new TalkToNPCQuest(EviceEscape, 'Just when you have him cornered, Evice radios in a helicopter. Watch him escape the Realgam Colosseum.'); // Step 26
+        const watchEviceEscape = new TalkToNPCQuest(EviceEscape, 'Just when you have him cornered, Evice calls in a helicopter. Watch him escape the Realgam Colosseum.'); // Step 26
         orreColosseumQuestLine.addQuest(watchEviceEscape);
 
         App.game.quests.questLines().push(orreColosseumQuestLine);

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2769,8 +2769,8 @@ const ExploreStand = new NPC('Explore the Outskirt Stand', [
 });
 const Willie = new NPC('Willie', [
     'Well partner, that was some dang fancy fighting, I\'ll tell you what.',
-    'I dunno what your plans are round these parts, but you\'d best keep an eye out for some of them dang ole Shadow Pokémon.',
-    'I hear they are weaker than normal Pokémon but can hold fancy incense. But if you manage to purify their souls, they will get a bit stronger!',
+    'I dunno what your plans are round these parts, but you\'d best keep an eye out for some of them dang ole Shadow Pokémon. Give a stranger enough of a whooping an\' ya might see yourself face to face with one in a dungeon next time!',
+    'I hear they are weaker than normal Pokémon but can hold a fancy incense. If you manage to purify their souls, they\'ll get a wee bit stronger!',
 ], {image: 'assets/images/npcs/Willie.png',
     requirement: new QuestLineStepCompletedRequirement('Shadows in the Desert', 1),
 });
@@ -2860,24 +2860,19 @@ const EviceEscape = new NPC('Watch Evice Escape', [
 ], {image: 'assets/images/npcs/other/EviceHelicopter.png',
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 25), new QuestLineCompletedRequirement('Shadows in the Desert', GameConstants.AchievementOption.less)]),
 });
-const OutskirtCowboy = new NPC('Cowboy', [
-    'Howdy, partner! Welcome to Orre!',
-    'Wild Pokémon are few and far between \'round these parts, but we make due!',
-    'Most everyone here will be happy to battle ya! But we know when we\'re beat, and will bow out of a fight once we\'ve been thoroughly licked.',
-]);
-const OldManPhenac = new NPC('Old Man', [
-    'There\'s been a lot of crime around here recently.',
-    'Some folks have been currupting their Pokémon and making them commit evil acts.',
-    'Those Pokémon would be better off in the hands of a loving trainer.',
-]);
+const PhenacRoller = new NPC('Cool Dude', [
+    'There\'s been a lot of crime around here recently. But nothing I can\'t handle!',
+    'Some folks have been corrupting their Pokémon and making them commit totally jank acts.',
+    'Those Pokémon would be better off in the hands of a radical trainer who knows how use Catch Filters, like me!',
+], {image: 'assets/images/npcs/Roller Boy.png'});
 const OrreRoamerNPC = new RoamerNPC('Fateen\'s Fortune Telling', [
     'I sense the presence of rare Pokémon at the {ROUTE_NAME}! Hurry, before the fates intervene!',
 ], GameConstants.Region.hoenn, RoamingPokemonList.findGroup(GameConstants.Region.hoenn, GameConstants.HoennSubRegions.Orre), 'assets/images/npcs/Psychic (female).png');
-const AgateOldMan = new NPC('Old Man', [
-    'This town is pretty quite. Most folks here are retired trainers.',
+const AgateAthlete = new NPC('Jogger', [
+    'This town is pretty quiet. Most folks here are retired trainers.',
     'We\'re always happy to help out any young folks who come through though!',
-    'Our only real tourist attraction is the Relic Stone north of town.',
-]);
+    'Our only real tourist attraction is the Relic Stone north of town. Just passing by it is enough to make you feel calmer.',
+], {image: 'assets/images/npcs/Athlete (male).png'});
 const RelicSage = new NPC('Relic Stone Sage', [
     'This stone has the power to cleanse and purify the spirits of Pokémon.',
     'If you train with your Pokémon, you will gain spiritual energy, or "Flow". You can use this Flow to purify your Pokémon.',
@@ -3134,7 +3129,7 @@ TownList['Outskirt Stand'] = new Town(
     [OutskirtStandShop, TemporaryBattleList.Willie],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion), new QuestLineStartedRequirement('Shadows in the Desert')],
-        npcs: [ExploreStand, OutskirtCowboy, Willie],
+        npcs: [ExploreStand, Willie],
     }
 );
 
@@ -3145,7 +3140,7 @@ TownList['Phenac City'] = new Town(
     [PhenacCityShop, new MoveToDungeon(dungeonList['Phenac Stadium']), new MoveToDungeon(dungeonList['Phenac City Battles']), TemporaryBattleList.Folly],
     {
         requirements: [new QuestLineStepCompletedRequirement('Shadows in the Desert', 1)],
-        npcs: [OldManPhenac, Sack, EsCade1, Rui1],
+        npcs: [PhenacRoller, Sack, EsCade1, Rui1],
     }
 );
 
@@ -3167,7 +3162,7 @@ TownList['Agate Village'] = new Town(
     [AgateVillageShop, new MoveToTown('Relic Stone'), new MoveToDungeon(dungeonList['Relic Cave']), TemporaryBattleList['Cipher Peon Doven'], TemporaryBattleList['Cipher Peon Silton'], TemporaryBattleList['Cipher Peon Kass']],
     {
         requirements: [new QuestLineStepCompletedRequirement('Shadows in the Desert', 14)],
-        npcs: [AgateOldMan],
+        npcs: [AgateAthlete],
     }
 );
 

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2762,8 +2762,8 @@ const ZinniaOrigin = new NPC('Zinnia', [
 
 const ExploreStand = new NPC('Explore the Outskirt Stand', [
     '<i>You look around the Outskirt Stand, and see two shady figures shuffling off into the horizon. As you move to get a closer look, some guy steps in your way.</i>',
-    'Hey! You\'re new around these parts, and I don\'t take too kindly to strangers!',
-    'You\'ll have to prove your worth, or my name ain\'t Willie!',
+    'Hey there! You\'re a fresh face \'round these parts, aren\'tcha!',
+    'You\'ll have to let me welcome you with a battle, or my name ain\'t Willie!',
 ], {image: 'assets/images/npcs/Willie.png',
     requirement: new MultiRequirement([new QuestLineStartedRequirement('Shadows in the Desert'), new QuestLineStepCompletedRequirement('Shadows in the Desert', 1, GameConstants.AchievementOption.less)]),
 });
@@ -2799,10 +2799,9 @@ const Rui1 = new NPC('Rui', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 5), new QuestLineStepCompletedRequirement('Shadows in the Desert', 7, GameConstants.AchievementOption.less)]),
 });
 const Duking1 = new NPC('Duking', [
-    '<i>Sniff...</i>.',
-    'I\'m not crying, these are allergies. Shut up.',
-    'I just... Some really mean guys kidnapped my beloved Plusle. It really has me upset.',
-    'They told me that I had to let they have free reign in town, or there would be trouble. They\'re out at the Colosseum causing trouble.',
+    '<i>Grr...</i>.',
+    'Those masked trainers went and kidnapped my beloved Plusle! How dare they!',
+    'They told me that I had to let them have free reign in town, or there would be trouble. They\'re out at the Colosseum causing trouble.',
 ], {image: 'assets/images/npcs/Duking.png',
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 7), new QuestLineStepCompletedRequirement('Shadows in the Desert', 9, GameConstants.AchievementOption.less)]),
 });

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2784,7 +2784,7 @@ const Sack = new NPC('Check the sack', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 2), new QuestLineStepCompletedRequirement('Shadows in the Desert', 4, GameConstants.AchievementOption.less)]),
 });
 const EsCade1 = new NPC('Mayor Es Cade', [
-    'Ah, you must be travelers! Welcome to Phenac City! I am Es Cade, the Mayor. Now, you wanted to see me. Is there something that I may be able to assist you with?',
+    'Ah, you must be travelers! Welcome to Phenac City! I am Es Cade, the Mayor. Now, you wanted to see me? Is there something that I may be able to assist you with?',
     'O-o-o-oh, my! Shadow Pokémon? And they attack people?! Now if that were true, that would be truly frightening. However, that is a little hard to believe.',
     'I understand your concern, though. I will order an investigation at once.',
     'I promise you, we will obtain useful information about those sinister Pokémon. While we do so, I heartily recommend that you visit our Stadium, the symbol of our civic pride!',
@@ -2827,7 +2827,7 @@ const Rui2 = new NPC('Rui', [
 });
 const GrandpaEagun1 = new NPC('Grandpa Eagun', [
     'Rui! And you are? $playername$? Nice to meet you!',
-    'Thank you both for saving me from those goons. They were disrupting the beace and tranquility of this whole area.',
+    'Thank you both for saving me from those goons. They were disrupting the peace and tranquility of this whole area.',
     '$playername$, if you ever have troubled or downright evil Pokémon, take them to the nearby Relic Stone. Its power, combined with the power of friendship you share with your Pokémon, may purify their souls.',
 ], {image: 'assets/images/npcs/Old Man.png',
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 16), new QuestLineStepCompletedRequirement('Shadows in the Desert', 18, GameConstants.AchievementOption.less)]),
@@ -2839,7 +2839,7 @@ const Rui3 = new NPC('Rui', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 18), new QuestLineStepCompletedRequirement('Shadows in the Desert', 20, GameConstants.AchievementOption.less)]),
 });
 const SearchTheStudio = new NPC('Search The Studio', [
-    '<i>Scripts litter Venus\'s desk, as well as other, more suspicious files addressing what trainers in town have which Pokémon. There are also several letters labeled  "Mayor\'s Office".</i>',
+    '<i>Scripts litter Venus\' desk, as well as other, more suspicious files addressing what trainers in town have which Pokémon. There are also several letters labeled "Mayor\'s Office".</i>',
     '<i>Rui calls to you from across the room:</i>',
     'Hey $playername$! I found a button! I\'m gonna press it!',
     '<i>An explosion rocks the room, revealing a tunnel out of a secret entrance. The scripts and letters are scattered all over the studio, making them impossible to sort out.</i>',
@@ -2847,7 +2847,7 @@ const SearchTheStudio = new NPC('Search The Studio', [
 {requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 20), new QuestLineStepCompletedRequirement('Shadows in the Desert', 22, GameConstants.AchievementOption.less)])}
 );
 const EsCade2 = new NPC('Mayor Es Cade', [
-    'My, my. That certainly was a battle worth seeing. I must be honest with you. I never imaged that you would get this far.',
+    'My, my. That certainly was a battle worth seeing. I must be honest with you. I never imagined that you would get this far.',
     'Oh, dear me. Do you fail to understand still? You\'re such an innocent child. At times, I am the affable mayor of Phenac... And at others, I am the secret boss of the criminal syndicate Cipher!',
     'I am Evice, and I shall rule the world!',
     '<i>The Mayor changes before your eyes, taking on a much more sinister appearance.</i>',
@@ -2872,7 +2872,7 @@ const OldManPhenac = new NPC('Old Man', [
     'Those Pokémon would be better off in the hands of a loving trainer.',
 ]);
 const OrreRoamerNPC = new RoamerNPC('Fateen\'s Fortune Telling', [
-    'I sense the presence of rate Pokémon at the {ROUTE_NAME}! Hurry, before the fates intervene!',
+    'I sense the presence of rare Pokémon at the {ROUTE_NAME}! Hurry, before the fates intervene!',
 ], GameConstants.Region.hoenn, RoamingPokemonList.findGroup(GameConstants.Region.hoenn, GameConstants.HoennSubRegions.Orre), 'assets/images/npcs/Psychic (female).png');
 const AgateOldMan = new NPC('Old Man', [
     'This town is pretty quite. Most folks here are retired trainers.',


### PR DESCRIPTION
## Description
- Fixed typos
- Fixed characterization
- Condensed Cowyboy npc into Willie, made Phenac npc mention Catch Filters, added npc images

## Motivation and Context
Team Cipher were disrupting the beace and tranquility of the region.

## How Has This Been Tested?
The npcs have been interacted with and their text read

## Types of changes
- Grammar check
- Enhanced experience