### PR TITLE
Add a "Disable Auto Save" feature

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -79,6 +79,7 @@
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('catchFilters.initialEnabled')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('useWebWorkerForGameTicks')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('disableOfflineProgress')}"></tr>
+                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('disableAutoSave')}"></tr>
                                 <tr data-bind="visible: player.highestRegion() > 0, with: Settings.getSetting('breedingQueueSizeSetting')">
                                     <td class="p-2" data-bind="text: `${$data.displayName}:`">setting name</td>
                                     <td class="p-0">

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -146,6 +146,7 @@ Settings.add(new CssVariableSetting('completed', 'Completed Location', [], '#fff
 Settings.add(new BooleanSetting('disableAutoDownloadBackupSaveOnUpdate', 'Disable automatic backup save downloading when game updates', false));
 Settings.add(new BooleanSetting('useWebWorkerForGameTicks', 'Make use of web workers for game ticks (more consistent game speed)', true));
 Settings.add(new BooleanSetting('disableOfflineProgress', 'Disable offline progress', false));
+Settings.add(new BooleanSetting('disableAutoSave', 'Disable Auto Saves', false));
 Settings.add(new Setting<string>('saveReminder', 'Save reminder interval (in game time)',
     [
         new SettingOption('Never', '0'),

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -517,7 +517,9 @@ class Game {
 
     save() {
         player._lastSeen = Date.now();
-        Save.store(player);
+        if (Settings.getSetting('disableAutoSave').value === false) {
+            Save.store(player);
+        }
     }
 
     // Knockout getters/setters


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Adds a "Disable Auto Save" setting that when toggled disables auto saves

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
SRing for specific mons in challenge runs is painful, so this aims to help by allowing auto saves to be disabled.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested the game with the setting on, and it doesn't automatically save. Manual save via Shift+S still possible
Tested the game with the setting off, and it does automatically save

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->

- New feature

