### PR TITLE
Add visuals to Relic Stone Sage NPC

### DIFF
--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2882,7 +2882,8 @@ const RelicSage = new NPC('Relic Stone Sage', [
     'This stone has the power to cleanse and purify the spirits of Pokémon.',
     'If you train with your Pokémon, you will gain spiritual energy, or "Flow". You can use this Flow to purify your Pokémon.',
     'Purification will take more flow with each Pokémon you purify.',
-]);
+    '<img src="./assets/images/status/shadow.svg" height="60px"/> <img src="./assets/images/arrow.svg" height="30px"/> <img src="./assets/images/status/purified.svg" height="60px"/>',
+], {image: 'assets/images/npcs/Sage.png'});
 //Hoenn Towns
 TownList['Littleroot Town'] = new Town(
     'Littleroot Town',


### PR DESCRIPTION
## Description
Added an npc image and to the relic stone sage.
Added the shadow svg with an arrow going to the purified svg at the end of his dialogue. Hopefully this makes the purpose of the stone clearer now.

## Motivation and Context
I forgot to add an npc image for the sage.
There is no Help tab in the Relic Stone, so I added some visual aids to the npc.

## How Has This Been Tested?
See below:

## Screenshots:
![relic stone sage](https://github.com/pokeclicker/pokeclicker/assets/114451054/66d68c9f-1988-4fe6-9d1b-f1177ed8a8e9)

## Types of changes
- UI improvement
