### PR TITLE
Fix Silvally quest memories given multiple times

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2366,6 +2366,9 @@ class Update implements Saveable {
                     playerData._itemList[crystalName] = 1;
                 }
             });
+
+            // Fixing Silvally item amounts
+            Object.keys(playerData._itemList).filter(itemName => itemName.includes('Memory_Silvally')).forEach(itemName => playerData._itemList[itemName] = Math.min(1, playerData._itemList[itemName]));
         },
     };
 

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -2441,11 +2441,9 @@ class QuestLineHelper {
 
         const BugSilvallyBattle = new CustomQuest(
             1,
-            undefined,
+            () => ItemList.Bug_Memory_Silvally.gain(1),
             'Defeat Guzma to get the Memory back.',
-            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Guzma Bug Memory')](),
-            0,
-            () => ItemList.Bug_Memory_Silvally.gain(1)
+            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Guzma Bug Memory')]()
         );
         SilvallyTypesQuestLine.addQuest(BugSilvallyBattle);
 
@@ -2454,11 +2452,9 @@ class QuestLineHelper {
 
         const FlyingSilvallyBattle = new CustomQuest(
             1,
-            undefined,
+            () => ItemList.Flying_Memory_Silvally.gain(1),
             'Defeat Kahili to get the Memory back.',
-            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Kahili Flying Memory')](),
-            0,
-            () => ItemList.Flying_Memory_Silvally.gain(1)
+            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Kahili Flying Memory')]()
         );
         SilvallyTypesQuestLine.addQuest(FlyingSilvallyBattle);
 
@@ -2467,11 +2463,9 @@ class QuestLineHelper {
 
         const PoisonSilvallyBattle = new CustomQuest(
             1,
-            undefined,
+            () => ItemList.Poison_Memory_Silvally.gain(1),
             'Defeat Plumeria to get the Memory back.',
-            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Plumeria Poison Memory')](),
-            0,
-            () => ItemList.Poison_Memory_Silvally.gain(1)
+            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Plumeria Poison Memory')]()
         );
         SilvallyTypesQuestLine.addQuest(PoisonSilvallyBattle);
 
@@ -2480,11 +2474,9 @@ class QuestLineHelper {
 
         const GhostSilvallyBattle = new CustomQuest(
             1,
-            undefined,
+            () => ItemList.Ghost_Memory_Silvally.gain(1),
             'Defeat Captain Acerola to get the Memory back.',
-            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Acerola Ghost Memory')](),
-            0,
-            () => ItemList.Ghost_Memory_Silvally.gain(1)
+            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Acerola Ghost Memory')]()
         );
         SilvallyTypesQuestLine.addQuest(GhostSilvallyBattle);
 
@@ -2493,11 +2485,9 @@ class QuestLineHelper {
 
         const PsychicSilvallyBattle = new CustomQuest(
             1,
-            undefined,
+            () => ItemList.Psychic_Memory_Silvally.gain(1),
             'Defeat Aether Branch Chief Faba to get the Memory back.',
-            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Faba Psychic Memory')](),
-            0,
-            () => ItemList.Psychic_Memory_Silvally.gain(1)
+            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Faba Psychic Memory')]()
         );
         SilvallyTypesQuestLine.addQuest(PsychicSilvallyBattle);
 
@@ -2506,11 +2496,9 @@ class QuestLineHelper {
 
         const SteelSilvallyBattle = new CustomQuest(
             1,
-            undefined,
+            () => ItemList.Steel_Memory_Silvally.gain(1),
             'Defeat Molayne to get the Memory back.',
-            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Molayne Steel Memory')](),
-            0,
-            () => ItemList.Steel_Memory_Silvally.gain(1)
+            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Molayne Steel Memory')]()
         );
         SilvallyTypesQuestLine.addQuest(SteelSilvallyBattle);
 
@@ -2519,11 +2507,9 @@ class QuestLineHelper {
 
         const DragonSilvallyBattle = new CustomQuest(
             1,
-            undefined,
+            () => ItemList.Dragon_Memory_Silvally.gain(1),
             'Defeat Ryuki to get the Memory back.',
-            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Ryuki Dragon Memory')](),
-            0,
-            () => ItemList.Dragon_Memory_Silvally.gain(1)
+            () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Ryuki Dragon Memory')]()
         );
         SilvallyTypesQuestLine.addQuest(DragonSilvallyBattle);
 


### PR DESCRIPTION
## Description
On some steps, the memory was given in the `onLoad` function instead of in the reward function, causing the players to stack some memories up from reloading the game.
Made those functions reward functions.
Added code to update function in order to reduce the amounts of memories to 1 when higher.

## Motivation and Context
[Discord bug report](https://discord.com/channels/450412847017754644/1131967969967222917).

## How Has This Been Tested?
Loaded a file, started the quest and run through with no issue, checking the memories were correctly given in due time.
Loaded an affected file and verified the amount were correctly reduced to 1 when required.

## Types of changes
- Bug fix
