### PR TITLE
Custap is now an XP aura berry

### DIFF
--- a/src/modules/enums/AuraType.ts
+++ b/src/modules/enums/AuraType.ts
@@ -12,6 +12,7 @@ enum AuraType {
     Ev,
     Repel,
     Decay,
+    Xp,
 }
 
 export default AuraType;

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -51,6 +51,7 @@ class Farming implements Feature {
         this.externalAuras[AuraType.Shiny] = ko.pureComputed<number>(() => this.multiplyPlotAuras(AuraType.Shiny));
         this.externalAuras[AuraType.Roaming] = ko.pureComputed<number>(() => this.multiplyPlotAuras(AuraType.Roaming));
         this.externalAuras[AuraType.Ev] = ko.pureComputed<number>(() => this.multiplyPlotAuras(AuraType.Ev));
+        this.externalAuras[AuraType.Xp] = ko.pureComputed<number>(() => this.multiplyPlotAuras(AuraType.Xp));
         this.externalAuras[AuraType.Repel] = ko.pureComputed<number>(() => this.addPlotAuras(AuraType.Repel));
 
         const multiplierSource = 'Farm Aura';
@@ -58,6 +59,7 @@ class Farming implements Feature {
         this.multiplier.addBonus('eggStep', () => this.externalAuras[AuraType.Egg](), multiplierSource);
         this.multiplier.addBonus('roaming', () => this.externalAuras[AuraType.Roaming](), multiplierSource);
         this.multiplier.addBonus('ev', () => this.externalAuras[AuraType.Ev](), multiplierSource);
+        this.multiplier.addBonus('exp', () => this.externalAuras[AuraType.Xp](), multiplierSource);
 
         this.highestUnlockedBerry = ko.pureComputed(() => {
             for (let i = GameHelper.enumLength(BerryType) - 2; i >= 0; i--) {
@@ -1021,7 +1023,11 @@ class Farming implements Feature {
             BerryColor.Red,
             26.7,
             BerryFirmness.Super_Hard,
-            ['The flesh underneath the Custap Berry\'s tough skin is sweet and creamy soft.']
+            [
+                'The flesh underneath the Custap Berry\'s tough skin is sweet and creamy soft.',
+                'This inspires Pokémon to train harder.',
+            ],
+            new Aura(AuraType.Xp, [1.005, 1.01, 1.015]),
         );
 
         this.berryData[BerryType.Jaboca] = new Berry(

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1027,7 +1027,7 @@ class Farming implements Feature {
                 'The flesh underneath the Custap Berry\'s tough skin is sweet and creamy soft.',
                 'This inspires Pokémon to train harder.',
             ],
-            new Aura(AuraType.Xp, [1.005, 1.01, 1.015]),
+            new Aura(AuraType.Xp, [1.005, 1.01, 1.015])
         );
 
         this.berryData[BerryType.Jaboca] = new Berry(


### PR DESCRIPTION
## Description
Adds in an XP aura for Custap, similar to Rowap.

Max of x2.43 with all the Lums in the right places

## Motivation and Context
More berries should have auras, and faster XP makes mechanical sense. Values are based on triage from a few months ago.

Custap is the same gen as Rowap and Micle for weird but useful auras

## How Has This Been Tested?
I did an initial test with a field of Rowaps and clicking through gyms and it seems to give XP faster.

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes

- New feature
