### PR TITLE
ClickAttack multipliers correctly displayed in statistic modal

### DIFF
--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -535,6 +535,7 @@ class AchievementHandler {
         multiplier.addBonus('exp', () => 1 + this.achievementBonus(), multiplierSource);
         multiplier.addBonus('money', () => 1 + this.achievementBonus(), multiplierSource);
         multiplier.addBonus('dungeonToken', () => 1 + this.achievementBonus(), multiplierSource);
+        multiplier.addBonus('clickAttack', () => 1 + this.achievementBonus(), multiplierSource);
     }
 
     static load() {

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -295,7 +295,7 @@ class Party implements Feature {
         const caught = caughtPokemon.length;
         const shiny = caughtPokemon.filter(p => p.shiny).length;
         const resistant = caughtPokemon.filter(p => p.pokerus >= GameConstants.Pokerus.Resistant).length;
-        const clickAttack = Math.pow(caught + shiny + resistant + 1, 1.4) * (1 + AchievementHandler.achievementBonus());
+        const clickAttack = Math.pow(caught + shiny + resistant + 1, 1.4);
 
         const bonus = this.multiplier.getBonus('clickAttack', useItem);
 


### PR DESCRIPTION
## Description
I made click attack calculation make use of the addition of the achievement bonus in the multipliers. It was forgotten thus making the statistic display wrong.

## Motivation and Context
Closes #4565.

## How Has This Been Tested?
Loaded a file and verified click attack worked as expected and the multiplier was correct.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/68825215/ee57f618-9fc3-4de8-9056-1c4598ae3428)

## Types of changes
- Bug fix
