### PR TITLE
Orre Colosseum Requirements Tuning

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -976,6 +976,7 @@ export enum BulletinBoards {
     Hoenn,
     Sevii4567,
     Sinnoh,
+    Unova,
     Kalos,
     Alola,
     Hoppy,

--- a/src/modules/pokeballs/PokeballFilterOptions.ts
+++ b/src/modules/pokeballs/PokeballFilterOptions.ts
@@ -30,7 +30,7 @@ class PokeballFilterOption<T, M = T> {
     }
 }
 
-const tempShadowRequirement = new DevelopmentRequirement();
+const tempShadowRequirement = new QuestLineStepCompletedRequirement('Shadows in the Desert', 3);
 
 const encounterTypeRequirements: Partial<Record<EncounterType, Requirement>> = {
     [EncounterType.trainer]: tempShadowRequirement,

--- a/src/modules/pokeballs/PokeballFilterOptions.ts
+++ b/src/modules/pokeballs/PokeballFilterOptions.ts
@@ -4,7 +4,6 @@ import Setting from '../settings/Setting';
 import GameHelper from '../GameHelper';
 import SettingOption from '../settings/SettingOption';
 import KeyItemType from '../enums/KeyItemType';
-import DevelopmentRequirement from '../requirements/DevelopmentRequirement';
 import Requirement from '../requirements/Requirement';
 import CustomRequirement from '../requirements/CustomRequirement';
 import PokemonType from '../enums/PokemonType';

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -441,6 +441,7 @@ namespace GameConstants {
         Hoenn,
         Sevii4567,
         Sinnoh,
+        Unova,
         Kalos,
         Alola,
         Hoppy,

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1497,7 +1497,7 @@ class QuestLineHelper {
     }
     // XD Questline, available after Unova E4
     public static createOrreXDQuestLine() {
-        const orreXDQuestLine = new QuestLine('Gale of Darkness', 'Team Cipher has returned to Orre. Stop their new evil plan!', new DevelopmentRequirement(), GameConstants.BulletinBoards.Hoenn);
+        const orreXDQuestLine = new QuestLine('Gale of Darkness', 'Team Cipher has returned to Orre. Stop their new evil plan!', new MultiRequirement([new DevelopmentRequirement(), new QuestLineCompletedRequirement('Shadows in the Desert'), new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)]), GameConstants.BulletinBoards.Unova);
 
         const talkToWillie = new TalkToNPCQuest(Willie, 'This is a placeholder for locking content'); // TODO make the quest for real
         orreXDQuestLine.addQuest(talkToWillie);

--- a/src/scripts/towns/PurifyChamber.ts
+++ b/src/scripts/towns/PurifyChamber.ts
@@ -18,7 +18,7 @@ class PurifyChamberTownContent extends TownContent {
 }
 
 class PurifyChamber implements Saveable {
-    public static requirements = new DevelopmentRequirement(); //TODO: when should this unlock? Waiting for story
+    public static requirements = new QuestLineStepCompletedRequirement('Shadows in the Desert', 17);
 
     public selectedPokemon: KnockoutObservable<PartyPokemon>;
     public currentFlow: KnockoutObservable<number>;

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2804,6 +2804,7 @@ const Sack = new NPC('Check the sack', [
     'My name is Rui, by the way. I\'m a psychic of sorts, on a mission to save Pokémon who have had their souls corrupted by some evil folks in Orre.',
     'There\'s a few in this city that need help. Can you come with me though? I\'m worried more shady guys will show up.',
     'I can point out which Pokémon have been corrupted, or turned into "Shadow Pokémon", and you can confiscate them from evildoers using your Pokéballs.',
+    'You can adjust your Catch Filters to catch any Shadow Pokémon now too.',
 ], {image: 'assets/images/npcs/Rui.png',
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Shadows in the Desert', 2), new QuestLineStepCompletedRequirement('Shadows in the Desert', 4, GameConstants.AchievementOption.less)]),
 });
@@ -4791,7 +4792,7 @@ TownList['Aspertia City'] = new Town(
     'Aspertia City',
     GameConstants.Region.unova,
     GameConstants.UnovaSubRegions.Unova,
-    [],
+    [new BulletinBoard(GameConstants.BulletinBoards.Unova)],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion)],
         npcs: [],


### PR DESCRIPTION
## Description
Tuning the unlocks in Colosseum to get them  closer to release
1. Moves XD to Unova Bulletin Board and behind the correct requirements (plus dev req)
2. Moves Shadow Filters to unlock at the appropriate time, with NPC dialogue telling the player they are ready
3. Moves Purify Chamber to correct quest step unlock


## Motivation and Context
Knocking things out to get Colosseum closer to release, resolving comments from testing


## How Has This Been Tested?
Verified filters unlocked correctly andthe XD quest has moved to the correct location


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Orre polishing
