### PR TITLE
Remove Scent held item on purify

### DIFF
--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -22,6 +22,7 @@ class PartyPokemon implements Saveable {
     public exp = 0;
     public evs: KnockoutComputed<number>;
     _attack: KnockoutComputed<number>;
+    private _canUseHeldItem: KnockoutComputed<boolean>;
 
     defaults = {
         attackBonusPercent: 0,
@@ -109,6 +110,12 @@ class PartyPokemon implements Saveable {
         this._displayName = ko.pureComputed(() => this._nickname() ? this._nickname() : this._translatedName());
         this._shadow = ko.observable(shadow);
         this._showShadowImage = ko.observable(false);
+        this._canUseHeldItem = ko.pureComputed(() => this.heldItem()?.canUse(this));
+        this._canUseHeldItem.subscribe((canUse) => {
+            if (!canUse && this.heldItem()) {
+                this.addOrRemoveHeldItem(this.heldItem());
+            }
+        });
     }
 
     public calculateAttack(ignoreLevel = false): number {

--- a/src/scripts/towns/PurifyChamber.ts
+++ b/src/scripts/towns/PurifyChamber.ts
@@ -55,6 +55,10 @@ class PurifyChamber implements Saveable {
         }
         this.selectedPokemon().shadow = GameConstants.ShadowStatus.Purified;
         this.currentFlow(0);
+        const heldItem = this.selectedPokemon().heldItem();
+        if (heldItem && !heldItem.canUse(this.selectedPokemon())) {
+            this.selectedPokemon().heldItem(undefined);
+        }
     }
 
     public gainFlow(exp: number) {

--- a/src/scripts/towns/PurifyChamber.ts
+++ b/src/scripts/towns/PurifyChamber.ts
@@ -55,10 +55,6 @@ class PurifyChamber implements Saveable {
         }
         this.selectedPokemon().shadow = GameConstants.ShadowStatus.Purified;
         this.currentFlow(0);
-        const heldItem = this.selectedPokemon().heldItem();
-        if (heldItem && !heldItem.canUse(this.selectedPokemon())) {
-            this.selectedPokemon().heldItem(undefined);
-        }
     }
 
     public gainFlow(exp: number) {


### PR DESCRIPTION
## Description
Scent held items can only be used by shadow pokemon. This will remove the scent upon being purified if one is equipped.

## Motivation and Context
Bug

## How Has This Been Tested?
Purified a pokemon with no held item.
Purified a pokemon with a power brace - it was not removed.
Purified a pokemon with a joy scent - it was removed.

## Types of changes
- Bug fix
