### PR TITLE
Updating Flavor-Style association to match Pokeblocks

### DIFF
--- a/src/scripts/towns/PokemonContest.ts
+++ b/src/scripts/towns/PokemonContest.ts
@@ -105,7 +105,7 @@ class ContestEntry {
         switch (PokemonContestController.contestStyle()) {
             case ContestStyle.Cool:
                 stylePoints = baseStats.attack + baseStats.specialDefense;
-                flavorType = FlavorType.Bitter;
+                flavorType = FlavorType.Spicy;
                 break;
             case ContestStyle.Beautiful:
                 stylePoints = baseStats.specialAttack + baseStats.defense;
@@ -117,11 +117,11 @@ class ContestEntry {
                 break;
             case ContestStyle.Clever:
                 stylePoints = baseStats.specialAttack + baseStats.speed;
-                flavorType = FlavorType.Sour;
+                flavorType = FlavorType.Bitter;
                 break;
             case ContestStyle.Tough:
                 stylePoints = baseStats.hitpoints + baseStats.defense;
-                flavorType = FlavorType.Spicy;
+                flavorType = FlavorType.Sour;
                 break;
         }
 


### PR DESCRIPTION
## Description
Makes the contest style-flavor association match pokeblock coloring for better color match.

## Motivation and Context
Been meaning to fix this, just got around to it now (Thanks jostav for pointing it out)

## How Has This Been Tested?
It has not, but it's a small change


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- New feature

