### PR TITLE
Rainbow Rocket quest description change

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -2768,7 +2768,7 @@ class QuestLineHelper {
         // Multi-step #10
 
         const meltanCatch400Meltan = new CaptureSpecificPokemonQuest('Meltan','Catch 400 Meltan in Alola.', 400, false, 0, undefined);
-        const meltanRainbowRocket = new CustomQuest(1, 0, 'Defeat Team Rainbow Leader Giovanni.', () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Team Rainbow Leader Giovanni')]());
+        const meltanRainbowRocket = new CustomQuest(1, 0, 'Defeat Team Rainbow Rocket.', () => App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex('Team Rainbow Leader Giovanni')]());
 
         const meltanGetMelmetal = () => {
             App.game.party.gainPokemonByName('Melmetal');


### PR DESCRIPTION
## Motivation and Context
The quest currently tells the player to defeat Giovanni, which isn't possible until they progress in another quest, which can cause some confusion. This change makes it more clear that the goal is to complete the other questline

## How Has This Been Tested?
It has not been, but it's just a change for a line of text

## Types of changes
- Small
