### PR TITLE
Fix gym error during tutorial

### DIFF
--- a/src/components/gymView.html
+++ b/src/components/gymView.html
@@ -60,7 +60,7 @@
                   <knockout data-bind="text: GymBattle.gym.leaderName.replace(/\d/g,'')"></knockout>
                 </td>
                 <td width="50%">
-                  <knockout data-bind="text: `${GymRunner.gymObservable().clears().toLocaleString('en-US')} Clears`"></knockout>
+                  <knockout data-bind="text: `${(GymRunner.gymObservable()?.clears() ?? 0).toLocaleString('en-US')} Clears`"></knockout>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
## Description
After the change in #4500 upon battling Brock during the tutorial an error would occur (see screenshot below).

## How Has This Been Tested?
Error did not occur after defeating Brock and completing the tutorial.

## Screenshots (optional):
Error:
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/bffee875-c81f-4640-b9e5-7118b3c07571)


## Types of changes
- Bug fix
