### PR TITLE
Add a Pinkan Wanderer

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -629,7 +629,9 @@ class Farming implements Feature {
             [
                 'This Berry endemic to Pinkan Island has an incredibly sweet taste.',
                 'It has a vibrant pink pigment, and it is found in such abundance on Pinkan Island that all Pokémon found there are colored Pink!',
-            ]
+            ],
+            undefined,
+            ['Pinkan Scyther']
         );
         //#endregion
 


### PR DESCRIPTION
## Description
Adds Pinkan Scyther as a wanderer for the Pinkan Berry


## Motivation and Context
The powers that be asked me to add a reasonable Pinkan wanderer from the pool of mons in the Pinkan berry shop. Since Scyther is a normal wanderer, Pinkan Scyther was a logical choice.


## How Has This Been Tested?
Ran to make sure it didn't crash


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
- Content
