### PR TITLE
XD Shard Shop

### DIFF
--- a/src/modules/underground/ShardDeal.ts
+++ b/src/modules/underground/ShardDeal.ts
@@ -478,6 +478,103 @@ export class ShardDeal {
                     1),
             ],
         );
+        ShardDeal.list[ShardTraderLocations['Pokemon HQ Lab']] = ko.observableArray(
+            [
+                new ShardDeal(
+                    [{ shardTypeString: 'Blue Shard', amount: 40 }],
+                    ItemList.Water_stone,
+                    1),
+                new ShardDeal(
+                    [{ shardTypeString: 'Red Shard', amount: 40 }],
+                    ItemList.Fire_stone,
+                    1),
+                new ShardDeal(
+                    [{ shardTypeString: 'Green Shard', amount: 40 }],
+                    ItemList.Leaf_stone,
+                    1),
+                new ShardDeal(
+                    [{ shardTypeString: 'Yellow Shard', amount: 40 }],
+                    ItemList.Thunder_stone,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Blue Shard', amount: 20 },
+                        { shardTypeString: 'Grey Shard', amount: 30 },
+                    ],
+                    ItemList.Kings_rock,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Green Shard', amount: 20 },
+                        { shardTypeString: 'Grey Shard', amount: 30 },
+                    ],
+                    ItemList.Soothe_bell,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Yellow Shard', amount: 20 },
+                        { shardTypeString: 'Grey Shard', amount: 30 },
+                    ],
+                    ItemList.Metal_coat,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Green Shard', amount: 20 },
+                        { shardTypeString: 'Blue Shard', amount: 20 },
+                    ],
+                    ItemList.Moon_stone,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Red Shard', amount: 20 },
+                        { shardTypeString: 'Grey Shard', amount: 30 },
+                    ],
+                    ItemList.Sun_stone,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Red Shard', amount: 20 },
+                        { shardTypeString: 'Yellow Shard', amount: 20 },
+                    ],
+                    ItemList.Linking_cord,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Yellow Shard', amount: 20 },
+                        { shardTypeString: 'Purple Shard', amount: 30 },
+                    ],
+                    ItemList.Upgrade,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Blue Shard', amount: 20 },
+                        { shardTypeString: 'Purple Shard', amount: 30 },
+                    ],
+                    ItemList.Dragon_scale,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Blue Shard', amount: 20 },
+                        { shardTypeString: 'Ochre Shard', amount: 30 },
+                    ],
+                    ItemList.Prism_scale,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Red Shard', amount: 20 },
+                        { shardTypeString: 'Ochre Shard', amount: 30 },
+                    ],
+                    ItemList.Deepsea_tooth,
+                    1),
+                new ShardDeal(
+                    [
+                        { shardTypeString: 'Green Shard', amount: 20 },
+                        { shardTypeString: 'Ochre Shard', amount: 30 },
+                    ],
+                    ItemList.Deepsea_scale,
+                    1),
+            ],
+        );
     }
 
     public static generateSinnohDeals() {

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3230,7 +3230,7 @@ TownList['Pokemon HQ Lab'] = new Town(
     'Pokemon HQ Lab',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [TemporaryBattleList['Cipher Peon Naps']],
+    [new ShardTraderShop(GameConstants.ShardTraderLocations['Pokemon HQ Lab']), TemporaryBattleList['Cipher Peon Naps']],
     {
         requirements: [new QuestLineCompletedRequirement('Gale of Darkness')],
         npcs: [],


### PR DESCRIPTION
## Description
Adds a shard shop to the Pokemon HQ Lab

## Motivation and Context
Adds a shard shop with all Gen1 - Gen 3 evolution items in it to represent that research is happening in that area.

Adds flavor and convenience to XD content.

## How Has This Been Tested?
Opened the game, force-completed quest steps to unlock the area, checked the shop. stuff is in there as expected.

## Screenshots (optional):


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->

- New feature

