### PR TITLE
Update Surprise Togepi quest line to use requirements

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -496,6 +496,17 @@ dungeonList['Viridian Forest'] = new Dungeon('Viridian Forest',
         new DungeonTrainer('Bug Catcher',
             [new GymPokemon('Weedle', 510, 9)],
             { weight: 1 }, 'Sammy'),
+        new DungeonTrainer('Egg Hunter',
+            [new GymPokemon('Surprise Togepi', 300000, 100)],
+            {
+                hide: true,
+                weight: 1,
+                requirement: new MultiRequirement([
+                    new QuestLineStartedRequirement('Togepi Egg Hunt'),
+                    new QuestLineStepCompletedRequirement('Togepi Egg Hunt', 0, GameConstants.AchievementOption.less),
+                    new GymBadgeRequirement(BadgeEnums.Elite_KantoChampion),
+                ]),
+            }),
     ],
     50, 1);
 
@@ -2110,6 +2121,17 @@ dungeonList['Ilex Forest'] = new Dungeon('Ilex Forest',
                 new GymBadgeRequirement(BadgeEnums.Elite_JohtoChampion),
                 new SpecialEventRequirement('Merry Christmas!'),
             ])}),
+        new DungeonTrainer('Egg Hunter',
+            [new GymPokemon('Surprise Togepi', 900000, 100)],
+            {
+                hide: true,
+                weight: 1,
+                requirement: new MultiRequirement([
+                    new QuestLineStepCompletedRequirement('Togepi Egg Hunt', 0),
+                    new QuestLineStepCompletedRequirement('Togepi Egg Hunt', 1, GameConstants.AchievementOption.less),
+                    new GymBadgeRequirement(BadgeEnums.Elite_JohtoChampion),
+                ]),
+            }),
     ],
     4000, 34);
 
@@ -2709,6 +2731,17 @@ dungeonList['Petalburg Woods'] = new Dungeon('Petalburg Woods',
         new DungeonTrainer('Team Aqua Grunt',
             [new GymPokemon('Poochyena', 860000, 9)],
             { weight: 1 }, undefined, '(male)'),
+        new DungeonTrainer('Egg Hunter',
+            [new GymPokemon('Surprise Togepi', 2700000, 100)],
+            {
+                hide: true,
+                weight: 1,
+                requirement: new MultiRequirement([
+                    new QuestLineStepCompletedRequirement('Togepi Egg Hunt', 1),
+                    new QuestLineStepCompletedRequirement('Togepi Egg Hunt', 2, GameConstants.AchievementOption.less),
+                    new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion),
+                ]),
+            }),
     ],
     12000, 101);
 

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -3585,9 +3585,6 @@ class QuestLineHelper {
     public static createFindSurpriseTogepiForEasterQuestLine() {
         const findSurpriseTogepiForEasterQuestLine = new QuestLine('Togepi Egg Hunt', 'A strange Togepi has been spotted, but cannot be found!', new SpecialEventRequirement('Easter'), GameConstants.BulletinBoards.All);
 
-        const togepiInKantoSetup = () => {
-            dungeonList['Viridian Forest'].bossList.push(new DungeonTrainer('Egg Hunter', [new GymPokemon('Surprise Togepi', 300000, 100)], { weight: 1, requirement: new GymBadgeRequirement(BadgeEnums.Elite_KantoChampion) }));
-        };
         const afterDefeatingTogepiInKanto = () => {
             Notifier.notify({
                 title: findSurpriseTogepiForEasterQuestLine.name,
@@ -3596,15 +3593,10 @@ class QuestLineHelper {
                 type: NotificationConstants.NotificationOption.info,
                 timeout: 3e4,
             });
-
-            dungeonList['Viridian Forest'].bossList = dungeonList['Viridian Forest'].bossList.filter(boss => boss.name != 'Egg Hunter');
         };
-        const defeatTogepiInKanto = new DefeatDungeonBossQuest('Viridian Forest', 'Egg Hunter', afterDefeatingTogepiInKanto, 'A strange Togepi has been seen around Kanto. Go look for it! Maybe Erika knows more.', togepiInKantoSetup);
+        const defeatTogepiInKanto = new DefeatDungeonBossQuest('Viridian Forest', 'Egg Hunter', afterDefeatingTogepiInKanto, 'A strange Togepi has been seen around Kanto. Go look for it! Maybe Erika knows more.');
         findSurpriseTogepiForEasterQuestLine.addQuest(defeatTogepiInKanto);
 
-        const togepiInJohtoSetup = () => {
-            dungeonList['Ilex Forest'].bossList.push(new DungeonTrainer('Egg Hunter', [new GymPokemon('Surprise Togepi', 900000, 100)], { weight: 1, requirement: new GymBadgeRequirement(BadgeEnums.Elite_JohtoChampion) }));
-        };
         const afterDefeatingTogepiInJohto = () => {
             Notifier.notify({
                 title: findSurpriseTogepiForEasterQuestLine.name,
@@ -3613,14 +3605,10 @@ class QuestLineHelper {
                 type: NotificationConstants.NotificationOption.info,
                 timeout: 3e4,
             });
-            dungeonList['Ilex Forest'].bossList = dungeonList['Ilex Forest'].bossList.filter(boss => boss.name != 'Egg Hunter');
         };
-        const encounterSurpriseTogepiInJohto = new DefeatDungeonBossQuest('Ilex Forest', 'Egg Hunter', afterDefeatingTogepiInJohto, 'Another report just came in, there have been sightings of a strange egg in a forest in Johto!', togepiInJohtoSetup);
+        const encounterSurpriseTogepiInJohto = new DefeatDungeonBossQuest('Ilex Forest', 'Egg Hunter', afterDefeatingTogepiInJohto, 'Another report just came in, there have been sightings of a strange egg in a forest in Johto!');
         findSurpriseTogepiForEasterQuestLine.addQuest(encounterSurpriseTogepiInJohto);
 
-        const togepiInHoennSetup = () => {
-            dungeonList['Petalburg Woods'].bossList.push(new DungeonTrainer('Egg Hunter', [new GymPokemon('Surprise Togepi', 2700000, 100)], { weight: 1, requirement: new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion) }));
-        };
         const afterDefeatingTogepiInHoenn = () => {
             App.game.party.gainPokemonByName('Surprise Togepi');
             Notifier.notify({
@@ -3629,9 +3617,8 @@ class QuestLineHelper {
                 type: NotificationConstants.NotificationOption.success,
                 timeout: 3e4,
             });
-            dungeonList['Petalburg Woods'].bossList = dungeonList['Petalburg Woods'].bossList.filter(boss => boss.name != 'Egg Hunter');
         };
-        const encounterTogepiInHoenn = new DefeatDungeonBossQuest('Petalburg Woods', 'Egg Hunter', afterDefeatingTogepiInHoenn, 'There is a big Egg Hunt going on in the woods south of Rustboro in Hoenn; maybe you should take a look?', togepiInHoennSetup);
+        const encounterTogepiInHoenn = new DefeatDungeonBossQuest('Petalburg Woods', 'Egg Hunter', afterDefeatingTogepiInHoenn, 'There is a big Egg Hunt going on in the woods south of Rustboro in Hoenn; maybe you should take a look?');
         findSurpriseTogepiForEasterQuestLine.addQuest(encounterTogepiInHoenn);
 
         App.game.quests.questLines().push(findSurpriseTogepiForEasterQuestLine);


### PR DESCRIPTION
## Description
Updates the Surprise Togepi easter event quest line to use requirements rather than pushing to the dungeon boss list.

## Motivation and Context
It's better. And works properly with quest pausing.

## How Has This Been Tested?
Played through the quest line and verified everything appeared and disappeared at the correct stages.

## Types of changes
- Quest Line
