### PR TITLE
Lint Fix on Custap Aura

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1046,8 +1046,8 @@ class Farming implements Feature {
                 'The flesh underneath the Custap Berry\'s tough skin is sweet and creamy soft.',
                 'This inspires Pokémon to train harder.',
             ],
-            new Aura(AuraType.Xp, [1.005, 1.01, 1.015])
-                ['Burmy (No Coat)']
+            new Aura(AuraType.Xp, [1.005, 1.01, 1.015]),
+            ['Burmy (No Coat)']
         );
 
         this.berryData[BerryType.Jaboca] = new Berry(


### PR DESCRIPTION
## Description
eslint didn't catch a formatting error in my last Berry PR, but Cypher (Timespazm) did


## Motivation and Context
Makes the custap wanderer work correctly


## How Has This Been Tested?
Launched the game, no crashes or hangs


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
