### PR TITLE
Added toLocaleString to more numbers

### DIFF
--- a/src/components/berryMasterModal.html
+++ b/src/components/berryMasterModal.html
@@ -33,9 +33,9 @@
                             <tbody data-bind='foreach: BerryDeal.getDeals(ShopHandler.shopObservable().location)'>
                                 <!-- ko foreach: berries -->
                                 <tr>
-                                    <td data-bind="text: App.game.farming.berryList[$data.berryType]()"></td>
+                                    <td data-bind="text: App.game.farming.berryList[$data.berryType]().toLocaleString('en-US')"></td>
                                     <td><img height="28px" data-bind="attr: {src: FarmController.getBerryImage($data.berryType) }, css: {'berryLocked': !App.game.farming.unlockedBerries[$data.berryType]() }"></img></td>
-                                    <td data-bind="text: amount + ' x ' + (App.game.farming.unlockedBerries[$data.berryType]() ? BerryType[$data.berryType] : '???')"></td>
+                                    <td data-bind="text: amount.toLocaleString('en-US') + ' x ' + (App.game.farming.unlockedBerries[$data.berryType]() ? BerryType[$data.berryType] : '???')"></td>
                                     <!-- ko if: $index() === 0 -->
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.berries.length }">→</td>
                                     <td class='vertical-middle' data-bind="attr: { rowspan: $parent.berries.length }">

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -165,7 +165,7 @@ class BreedingController {
             case 'stepsPerAttack': return `Steps/Att: ${(pokemon.getEggSteps() / (pokemon.getBreedingAttackBonus() * BreedingController.calculateRegionalMultiplier(pokemon))).toLocaleString('en-US', { maximumSignificantDigits: 2 })}`;
             case 'dexId': return `#${pokemon.id <= 0 ? '???' : Math.floor(pokemon.id).toString().padStart(3,'0')}`;
             case 'vitamins': return `Vitamins: ${pokemon.totalVitaminsUsed()}`;
-            case 'evs': return `EVs: ${pokemon.evs()}`;
+            case 'evs': return `EVs: ${pokemon.evs().toLocaleString('en-US')}`;
         }
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Added toLocaleString to EVs display in the Hatchery and the Berry Deals' berry numbers.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Most numbers have the thousand separator. It looks more legible.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I checked the relevant modals.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
EVs display in the Hatchery:
![EVs-localestring](https://github.com/pokeclicker/pokeclicker/assets/106291026/f5af9c87-5d2c-413c-b7a6-d0d008c14a6e)

Berry Deal:
![berries-tolocalestring](https://github.com/pokeclicker/pokeclicker/assets/106291026/16765073-8d53-415b-ad40-332487a837d2)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
