### PR TITLE
Indicate dungeon loot debuff in next region dialogue

### DIFF
--- a/src/components/nextRegionModal.html
+++ b/src/components/nextRegionModal.html
@@ -13,9 +13,12 @@
                    You can now travel on to <span data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() + 1])"></span>!<br/>
                    <br/>
                    <strong>There are a few things you should know before you depart:</strong><br/>
-                   You will gain <strong data-bind="text: App.game.breeding.queueSlotsGainedFromRegion(player.highestRegion())"></strong> queue slots in the Hatchery.<br/>
+                   You will gain <strong data-bind="text: App.game.breeding.queueSlotsGainedFromRegion(player.highestRegion())"></strong> queue slots in the Hatchery.<br/><br/>
                    <!-- ko if: App.game.challenges.list.regionalAttackDebuff.active() -->
-                   When Pokémon are in a Region they're not native to, they will only retain <strong data-bind="text: App.game.party.getRegionAttackMultiplier(player.highestRegion() + 1).toLocaleString(undefined,{style: 'percent'})"></strong> of their total attack.<br/>
+                   When Pokémon are in a Region they're not native to, they will only retain <strong data-bind="text: App.game.party.getRegionAttackMultiplier(player.highestRegion() + 1).toLocaleString(undefined,{style: 'percent'})"></strong> of their total attack.<br/><br/>
+                   <!-- /ko -->
+                   <!-- ko if: player.highestRegion() - 2 >= 0 -->
+                   Dungeons in the <strong data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() - 2])"></strong> Region will be significantly less likely to have Epic, Legendary, and Mythic loot.<br /><br/>
                    <!-- /ko -->
                    You will also have to progress to the Dock in <span data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() + 1])"></span> before you are able to travel between regions again.
                </p>

--- a/src/components/nextRegionModal.html
+++ b/src/components/nextRegionModal.html
@@ -17,8 +17,8 @@
                    <!-- ko if: App.game.challenges.list.regionalAttackDebuff.active() -->
                    When Pokémon are in a Region they're not native to, they will only retain <strong data-bind="text: App.game.party.getRegionAttackMultiplier(player.highestRegion() + 1).toLocaleString(undefined,{style: 'percent'})"></strong> of their total attack.<br/><br/>
                    <!-- /ko -->
-                   <!-- ko if: player.highestRegion() - 2 >= 0 -->
-                   Dungeons in the <strong data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() - 2])"></strong> Region will be significantly less likely to have Epic, Legendary, and Mythic loot.<br /><br/>
+                   <!-- ko if: player.highestRegion() - 2 >= GameConstants.Region.kanto -->
+                   Dungeons in the <strong data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() - 2])"></strong> Region will be significantly less likely to drop Epic, Legendary, and Mythic loot.<br /><br/>
                    <!-- /ko -->
                    You will also have to progress to the Dock in <span data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[player.highestRegion() + 1])"></span> before you are able to travel between regions again.
                </p>


### PR DESCRIPTION
## Description
Adds text to the next region dialogue indicating dungeon loot in [region] will be debuffed (when applicable). Maybe adding something to the dungeon start view to indicate it's debuffed would also be good, but I'm not sure what.

## Motivation and Context
A lot of players don't know about the loot debuff and I don't think it's mentioned anywhere else in game?

## How Has This Been Tested?
Checked the dialogue when traveling from various regions. (thanks Pant for the test files)

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/8ce339c9-fb82-4756-bfaa-4ae0e107fade)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/83bc851c-3540-4cc5-9734-f1cd36b7ea25)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/723bd4ef-d4ca-46ab-9925-5a174a821764)

## Types of changes
- Text
