### PR TITLE
Mega Mewtwo Quest: Catch Fighting types fix

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -2407,7 +2407,7 @@ class QuestLineHelper {
         const defeatUnrivaledFighting = new CustomQuest(750, 0, 'Defeat 750 Fighting-type Pokémon.', () => {
             return pokemonMap.filter(p => p.type.includes(PokemonType.Fighting)).map(p => App.game.statistics.pokemonDefeated[p.id]()).reduce((a,b) => a + b, 0);
         });
-        const catchUnrivaledFighting = new CapturePokemonTypesQuest(600, undefined, PokemonType.Fighting);
+        const catchUnrivaledFighting = new CapturePokemonTypesQuest(300, undefined, PokemonType.Fighting);
         unrivaledPowerQuestLine.addQuest(new MultipleQuestsQuest([
             defeatUnrivaledPsychic,
             catchUnrivaledPsychic,


### PR DESCRIPTION
## Description
changes required fighting type catches from 600 to 300

## Motivation and Context
Fixing a copy/paste mistake

## How Has This Been Tested?
It hasn't. But it's also just a number

## Types of changes
- Bug fix
