### PR TITLE
Dungeon indicator for uncaught shadow pokemon

### DIFF
--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -134,6 +134,12 @@
             }">
           </li>
           <!-- /ko -->
+          <!-- ko if: player.town().dungeon.allAvailableShadowPokemon().some(p => App.game.party.getPokemonByName(p)?.shadow < GameConstants.ShadowStatus.Shadow) -->
+          <li class="list-inline-item">
+            <img class="boss" src="assets/images/status/shadow.svg"/>
+            <img class="dungeon-pokemon-preview dungeon-pokemon-locked" src="assets/images/npcs/specialNPCs/Mysterious Trainer.png"/>
+          </li>
+          <!-- /ko -->
         </ul>
       </div>
     </knockout>


### PR DESCRIPTION
## Description
As requested, adds an indicator to the end of the encounter list when an uncaught shadow pokemon remains in a dungeon.

## How Has This Been Tested?
Indicator is visible while viewing a dungeon that has uncaught shadow pokemon. After capturing these shadows (with magic) the indicator is no longer visible.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/ee03bcea-ff1c-4ef1-84a2-440c1aa1872e)

## Types of changes
- UI improvement
