### PR TITLE
Add XD Gyms to Orre Colosseum

### DIFF
--- a/src/components/HoennSVG.html
+++ b/src/components/HoennSVG.html
@@ -1381,7 +1381,31 @@
             })
         %>
 
+        <!--Orre Colosseum-->
+        <%- include('templates/mapTown',
+            { name: "Orre Colosseum"
+            , x: 20, y: 36
+            , width: 7, height: 5
+            })
+        %>
 
+        <!--Orre Colosseum extension-->
+        <%- include('templates/mapTown',
+            { name: "Orre Colosseum"
+            , x: 21, y: 41
+            , width: 5, height: 2
+            , isExtension: true
+            })
+        %>
+
+        <!--Orre Colosseum extension-->
+        <%- include('templates/mapTown',
+            { name: "Orre Colosseum"
+            , x: 22, y: 34
+            , width: 5, height: 2
+            , isExtension: true
+            })
+        %>
 
         <!-- -------- -->
         <!-- DUNGEONS -->
@@ -1531,32 +1555,6 @@
 			, invisible: true
 			})
 		%>
-
-        <!--Orre Colosseum-->
-        <%- include('templates/mapDungeon',
-            { name: "Orre Colosseum"
-            , x: 20, y: 36
-            , width: 7, height: 5
-            })
-        %>
-
-        <!--Orre Colosseum extension-->
-        <%- include('templates/mapDungeon',
-            { name: "Orre Colosseum"
-            , x: 21, y: 41
-            , width: 5, height: 2
-            , isExtension: true
-            })
-        %>
-
-        <!--Orre Colosseum extension-->
-        <%- include('templates/mapDungeon',
-            { name: "Orre Colosseum"
-            , x: 22, y: 34
-            , width: 5, height: 2
-            , isExtension: true
-            })
-        %>
 
 		<!--Gateon Port Battles-->
 		<%- include('templates/mapDungeon',

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -779,7 +779,7 @@ export const Environments: Record<string, EnvironmentData> = {
     Mansion: {
         [Region.kanto]: new Set(['Silph Co.', 'Pokémon Mansion']),
         [Region.johto]: new Set(['Olivine City', 'Sprout Tower', 'Burned Tower']),
-        [Region.hoenn]: new Set(['Petalburg City', 'Phenac City Battles', 'Pyrite Town Battles', 'Pyrite Building', 'Snagem Hideout', 'Phenac Stadium', 'Orre Colosseum', 'Citadark Isle Dome']),
+        [Region.hoenn]: new Set(['Petalburg City', 'Phenac City Battles', 'Pyrite Town Battles', 'Pyrite Building', 'Snagem Hideout', 'Phenac Stadium', 'Citadark Isle Dome', 'Orre Colosseum']),
         [Region.sinnoh]: new Set(['Veilstone City', 'Canalave City', 'Snowpoint Temple']),
         [Region.unova]: new Set(['Castelia City', 'Mistralton City', 'Opelucid City', 'Liberty Garden', 'Dragonspiral Tower', 'Dreamyard']),
         [Region.kalos]: new Set(['Parfum Palace', 'Lost Hotel']),
@@ -1295,6 +1295,11 @@ export const OrreGyms = [
     'Cipher Admin Miror B.',
     'Cipher Admin Dakim',
     'Cipher Admin Venus',
+    'Cipher Admin Lovrina',
+    'Cipher Admin Snattle',
+    'Cipher Admin Gorigan',
+    'Cipher Admin Ardos',
+    'Cipher Admin Eldes',
 ];
 
 export const MagikarpJumpGyms = [
@@ -1415,11 +1420,10 @@ export const HoennDungeons = [
     'Deep Colosseum',
     'Phenac Stadium',
     'Under Colosseum',
-    'Orre Colosseum',
     'Gateon Port Battles',
     'Cipher Key Lair',
     'Citadark Isle',
-    'Citadark Isle Dome', // 77
+    'Citadark Isle Dome', // 76
     // These aren't implemented anywhere yet
     /*
     "Island Cave",
@@ -1448,7 +1452,7 @@ export const HoennDungeons = [
 ];
 
 export const SinnohDungeons = [
-    'Oreburgh Gate', // 78
+    'Oreburgh Gate', // 77
     'Valley Windworks',
     'Eterna Forest',
     'Old Chateau',
@@ -1471,11 +1475,11 @@ export const SinnohDungeons = [
     'Flower Paradise',
     'Snowpoint Temple',
     'Stark Mountain',
-    'Hall of Origin', // 101
+    'Hall of Origin', // 100
 ];
 
 export const UnovaDungeons = [
-    'Floccesy Ranch', // 102
+    'Floccesy Ranch', // 101
     'Liberty Garden',
     'Castelia Sewers',
     'Relic Passage',
@@ -1497,11 +1501,11 @@ export const UnovaDungeons = [
     'Pledge Grove',
     'Pinwheel Forest',
     'Dreamyard',
-    'P2 Laboratory', // 124
+    'P2 Laboratory', // 123
 ];
 
 export const KalosDungeons = [
-    'Santalune Forest', // 125
+    'Santalune Forest', // 124
     'Connecting Cave',
     'Glittering Cave',
     'Reflection Cave',
@@ -1514,12 +1518,12 @@ export const KalosDungeons = [
     'Team Flare Secret HQ',
     'Terminus Cave',
     'Pokémon Village',
-    'Victory Road Kalos', // 137
+    'Victory Road Kalos', // 136
     // 'Unknown Dungeon',
 ];
 
 export const AlolaDungeons = [
-    'Trainers\' School', // 138
+    'Trainers\' School', // 137
     'Hau\'oli Cemetery',
     'Verdant Cavern',
     'Melemele Meadow',
@@ -1548,11 +1552,11 @@ export const AlolaDungeons = [
     'Ruins of Abundance',
     'Ruins of Hope',
     'Poni Meadow',
-    'Resolution Cave', // 167
+    'Resolution Cave', // 166
 ];
 
 export const GalarDungeons = [
-    'Slumbering Weald Shrine', // 168
+    'Slumbering Weald Shrine', // 167
     'Galar Mine',
     'Galar Mine No. 2',
     'Glimwood Tangle',
@@ -1572,11 +1576,11 @@ export const GalarDungeons = [
     'Lakeside Cave',
     'Dyna Tree Hill',
     'Tunnel to the Top',
-    'Crown Shrine', // 188
+    'Crown Shrine', // 187
 ];
 
 export const HisuiDungeons = [
-    'Floaro Gardens', // 189
+    'Floaro Gardens', // 188
     'Oreburrow Tunnel',
     'Heartwood',
     'Ancient Solaceon Ruins',
@@ -1598,18 +1602,18 @@ export const HisuiDungeons = [
     'Ancient Lake Valor',
     'Ancient Lake Acuity',
     'Temple of Sinnoh',
-    'Turnback Cave', // 211
+    'Turnback Cave', // 210
 ];
 
 export const PaldeaDungeons = [
-    'Inlet Grotto', // 212
+    'Inlet Grotto', // 211
     'Glaseado Mountain',
     'Grasswither Shrine',
     'Icerend Shrine',
     'Groundblight Shrine',
     'Firescourge Shrine',
     'Area Zero',
-    'Area Zero Depths', // 219
+    'Area Zero Depths', // 218
 ];
 
 export const RegionDungeons = [

--- a/src/modules/enums/Badges.ts
+++ b/src/modules/enums/Badges.ts
@@ -53,6 +53,11 @@ enum BadgeEnums {
     'Elite_L_Disk',
     'Elite_R_Disk',
     'Elite_U_Disk',
+    'Elite_ColosseumLovrina',
+    'Elite_ColosseumSnattle',
+    'Elite_ColosseumGorigan',
+    'Elite_ColosseumArdos',
+    'Elite_ColosseumEldes',
     // Sinnoh
     'Coal',
     'Forest',

--- a/src/modules/modules.test.ts
+++ b/src/modules/modules.test.ts
@@ -91,7 +91,7 @@ describe('Test GameConstants', () => {
         expect(expRandomElement([1, 2, 3, 4], 2)).toEqual(1);
     });
     it('return the gyms total index', () => {
-        expect(getGymIndex('Aspertia City')).toEqual(57);
+        expect(getGymIndex('Aspertia City')).toEqual(52);
         expect(getGymIndex('Not a real gym')).toEqual(-1);
     });
     it('return the region a gym is in', () => {

--- a/src/modules/modules.test.ts
+++ b/src/modules/modules.test.ts
@@ -91,7 +91,7 @@ describe('Test GameConstants', () => {
         expect(expRandomElement([1, 2, 3, 4], 2)).toEqual(1);
     });
     it('return the gyms total index', () => {
-        expect(getGymIndex('Aspertia City')).toEqual(52);
+        expect(getGymIndex('Aspertia City')).toEqual(57);
         expect(getGymIndex('Not a real gym')).toEqual(-1);
     });
     it('return the region a gym is in', () => {
@@ -99,7 +99,7 @@ describe('Test GameConstants', () => {
         expect(getGymRegion('Not a real gym')).toEqual(-1);
     });
     it('return the dungeons total index', () => {
-        expect(getDungeonIndex('Abundant Shrine')).toEqual(116);
+        expect(getDungeonIndex('Abundant Shrine')).toEqual(115);
         expect(getDungeonIndex('Not a real dungeon')).toEqual(-1);
     });
     it('return the region a dungeon is in', () => {

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2437,6 +2437,17 @@ class Update implements Saveable {
             saveData.statistics.gymsDefeated = Update.moveIndex(saveData.statistics.gymsDefeated, 146);
             saveData.statistics.gymsDefeated = Update.moveIndex(saveData.statistics.gymsDefeated, 147);
             saveData.statistics.gymsDefeated = Update.moveIndex(saveData.statistics.gymsDefeated, 148);
+
+            // Remove Orre Colosseum Dungeon
+            saveData.statistics.dungeonsCleared.splice(73, 1);
+
+            // Adding Orre XD badges
+            saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 49);
+            saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 50);
+            saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 51);
+            saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 52);
+            saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 53);
+
         },
     };
 

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -5687,13 +5687,6 @@ dungeonList['Under Colosseum'] = new Dungeon('Under Colosseum',
     ],
     91500, 134);
 
-dungeonList['Orre Colosseum'] = new Dungeon('Orre Colosseum', //Difficulty comperable to P2 Laboratory
-    [],
-    {},
-    5403000,
-    [],
-    396500, 134);
-
 dungeonList['Gateon Port Battles'] = new Dungeon('Gateon Port Battles',
     [
         new DungeonTrainer('Chaser',

--- a/src/scripts/gym/GymList.ts
+++ b/src/scripts/gym/GymList.ts
@@ -768,6 +768,91 @@ GymList['Cipher Admin Venus'] = new Gym (
     [new QuestLineCompletedRequirement('Shadows in the Desert')],
     undefined, undefined, { displayName: 'Challenge Venus' }
 );
+GymList['Cipher Admin Lovrina'] = new Gym ( //Kalos E4 difficulty, plus 10% per Orre Colosseum boss
+    'Cipher Admin Lovrina',
+    'Cipher Admin Lovrina',
+    [
+        new GymPokemon('Shuckle', 30994948, 100),
+        new GymPokemon('Milotic', 30994948, 100),
+        new GymPokemon('Wobbuffet', 30994948, 100),
+        new GymPokemon('Blissey', 30994948, 100),
+        new GymPokemon('Misdreavus', 30994948, 100),
+        new GymPokemon('Meganium', 30994948, 100),
+    ],
+    BadgeEnums.Elite_ColosseumLovrina,
+    100000,
+    'I was so impressed by your toughness! Because you are so tough, I\'ll let you be the first member in my fan club! Doesn\'t that so make your day?',
+    [new QuestLineCompletedRequirement('Gale of Darkness')],
+    undefined, undefined, { displayName: 'Challenge Lovrina' }
+);
+GymList['Cipher Admin Snattle'] = new Gym (
+    'Cipher Admin Snattle',
+    'Cipher Admin Snattle',
+    [
+        new GymPokemon('Electrode', 34094443, 100),
+        new GymPokemon('Gengar', 34094443, 100),
+        new GymPokemon('Muk', 34094443, 100),
+        new GymPokemon('Glalie', 34094443, 100),
+        new GymPokemon('Regirock', 34094443, 100),
+        new GymPokemon('Regice', 34094443, 100),
+    ],
+    BadgeEnums.Elite_ColosseumSnattle,
+    100000,
+    'In the near future, when I become the Governor of Orre, I shall appoint you as my official secretary. Let that be a motivation for you to constantly better your skills!',
+    [new GymBadgeRequirement(BadgeEnums.Elite_ColosseumLovrina)],
+    undefined, undefined, { displayName: 'Challenge Snattle' }
+);
+GymList['Cipher Admin Gorigan'] = new Gym (
+    'Cipher Admin Gorigan',
+    'Cipher Admin Gorigan',
+    [
+        new GymPokemon('Salamence', 37503887, 100),
+        new GymPokemon('Granbull', 37503887, 100),
+        new GymPokemon('Arcanine', 37503887, 100),
+        new GymPokemon('Tauros', 37503887, 100),
+        new GymPokemon('Hitmontop', 37503887, 100),
+        new GymPokemon('Gyarados', 37503887, 100),
+    ],
+    BadgeEnums.Elite_ColosseumGorigan,
+    100000,
+    'You\'re some kind of special! You\'re worthy of sharing my camaraderie as a friend.',
+    [new GymBadgeRequirement(BadgeEnums.Elite_ColosseumSnattle)],
+    undefined, undefined, { displayName: 'Challenge Gorigan' }
+);
+GymList['Cipher Admin Ardos'] = new Gym (
+    'Cipher Admin Ardos',
+    'Cipher Admin Ardos',
+    [
+        new GymPokemon('Sceptile', 41254276, 100),
+        new GymPokemon('Charizard', 41254276, 100),
+        new GymPokemon('Gengar', 41254276, 100),
+        new GymPokemon('Aerodactyl', 41254276, 100),
+        new GymPokemon('Tauros', 41254276, 100),
+        new GymPokemon('Starmie', 41254276, 100),
+    ],
+    BadgeEnums.Elite_ColosseumArdos,
+    120000,
+    'In all of Orre, I\'ve never seen a Pokémon Trainer of your caliber. You appear to be the biggest threat to Cipher. To make sure my underlings watch you with caution, I give you the title “Cipher\'s Biggest Enemy.”',
+    [new GymBadgeRequirement(BadgeEnums.Elite_ColosseumGorigan)],
+    undefined, undefined, { displayName: 'Challenge Ardos' }
+);
+GymList['Cipher Admin Eldes'] = new Gym (
+    'Cipher Admin Eldes',
+    'Cipher Admin Eldes',
+    [
+        new GymPokemon('Latios', 45379704, 100),
+        new GymPokemon('Latias', 45379704, 100),
+        new GymPokemon('Gengar', 45379704, 100),
+        new GymPokemon('Metagross', 45379704, 100),
+        new GymPokemon('Snorlax', 45379704, 100),
+        new GymPokemon('Tauros', 45379704, 100),
+    ],
+    BadgeEnums.Elite_ColosseumEldes,
+    150000,
+    'I\'m satisfied that I was able to battle to my heart\'s content. I would like to confer on you the title “Eldes\'s Top Rival.”',
+    [new GymBadgeRequirement(BadgeEnums.Elite_ColosseumArdos)],
+    undefined, undefined, { displayName: 'Challenge Eldes' }
+);
 //Sinnoh Gyms
 GymList['Oreburgh City'] = new Gym(
     'Roark',

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3056,7 +3056,9 @@ const ProfKrane = new NPC('Professor Krane', [
 const DrKaminko = new NPC('Dr. Kaminko', [
     'Leave me alone! I\'m WORKING!']
 );
-
+const OrreColosseumSpectator = new NPC('Colosseum Spectator', [
+    'Only the toughest trainers in Orre are allowed to fight here! I\'m just watching until I get stronger.']
+);
 //Hoenn Towns
 TownList['Littleroot Town'] = new Town(
     'Littleroot Town',
@@ -3371,7 +3373,7 @@ TownList['Gateon Port'] = new Town(
     'Gateon Port',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [GateonPortShop, new MoveToDungeon(dungeonList['Gateon Port Battles'])],
+    [GateonPortShop, new MoveToDungeon(dungeonList['Gateon Port Battles']), new DockTownContent()],
     {
         requirements: [new QuestLineStartedRequirement('Shadows in the Desert')],
         npcs: [GateonSailor, Verich],
@@ -3410,7 +3412,16 @@ TownList['S. S. Libra'] = new Town(
         npcs: [SearchLibra],
     }
 );
-
+TownList['Orre Colosseum'] = new Town(
+    'Orre Colosseum',
+    GameConstants.Region.hoenn,
+    GameConstants.HoennSubRegions.Orre,
+    [GymList['Cipher Admin Lovrina'], GymList['Cipher Admin Snattle'], GymList['Cipher Admin Gorigan'], GymList['Cipher Admin Ardos'], GymList['Cipher Admin Eldes']],
+    {
+        requirements: [new QuestLineCompletedRequirement('Gale of Darkness')],
+        npcs: [OrreColosseumSpectator],
+    }
+);
 //Hoenn Dungeons
 TownList['Petalburg Woods'] = new DungeonTown(
     'Petalburg Woods',
@@ -3748,14 +3759,6 @@ TownList['Under Colosseum'] = new DungeonTown(
     GameConstants.HoennSubRegions.Orre,
     [
         new QuestLineCompletedRequirement('Shadows in the Desert'),
-    ]
-);
-TownList['Orre Colosseum'] = new DungeonTown(
-    'Orre Colosseum',
-    GameConstants.Region.hoenn,
-    GameConstants.HoennSubRegions.Orre,
-    [
-        new DevelopmentRequirement, //TODO Populate this
     ]
 );
 TownList['Gateon Port Battles'] = new DungeonTown(


### PR DESCRIPTION
## Description
Adds the Cipher Admins as Gym battles in the Orre Colosseum. Their difficulty starts at Kalos E4 and crosses over to slightly harder than Diantha

Removed Orre Colosseum as a dungeon because there's no shadowmons there, so it would just be an extra dungeons no one needed

Adds dock content to Gateon Port while I'm in there.

## Motivation and Context
XD content needed gyms. Orre Colosseum needed a reason to be on the map. This makes the two issues resolved.


## How Has This Been Tested?
Checked that all gym battles work, increment on defeats, have hte desired mons, and show the correct messages
Checked dungeons and Gyms in Hoenn and Sinnoh versus a test file to makes sure the update function changed the index correctly.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
- New feature

