### PR TITLE
Opening Orre for the Pokemon Colosseum Quest and Content

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1042,7 +1042,7 @@ class QuestLineHelper {
 
     // Orre Questlines - Available post-Hoenn-E4
     public static createOrreColosseumQuestLine() {
-        const orreColosseumQuestLine = new QuestLine('Shadows in the Desert', 'Explore Orre and uncover the origin of Shadow Pokémon.', new MultiRequirement([new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion), new DevelopmentRequirement()]), GameConstants.BulletinBoards.Hoenn);
+        const orreColosseumQuestLine = new QuestLine('Shadows in the Desert', 'Explore Orre and uncover the origin of Shadow Pokémon.', new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion), GameConstants.BulletinBoards.Hoenn);
 
         const exploreStand = new TalkToNPCQuest(ExploreStand, 'Travel to Orre and explore the Outskirt Stand.');
         orreColosseumQuestLine.addQuest(exploreStand);


### PR DESCRIPTION
## Description
Removes Dev Requirement from Orre Part 1: Pokemon Colosseum


## Motivation and Context
Gotten open it some time.

Keeping this in draft until:

- [ ] Level Cap issue caused by flow calculation is resolved
- [x] #4656 is merged
- [x] #4657 is merged (for the dock content in Gateon)


## How Has This Been Tested?
Checked the Hoenn Bulletin Board, the quest came up


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
- New feature

