### PR TITLE
ExternalHelper fix - PokemonLevelRequirement missing from temporaryWindowInjection

### DIFF
--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -112,6 +112,7 @@ import MaxLevelOakItemRequirement from './requirements/MaxLevelOakItemRequiremen
 import MaxRegionRequirement from './requirements/MaxRegionRequirement';
 import ObtainedPokemonRequirement from './requirements/ObtainedPokemonRequirement';
 import PokeballRequirement from './requirements/PokeballRequirement';
+import PokemonLevelRequirement from './requirements/PokemonLevelRequirement';
 import PokerusStatusRequirement from './requirements/PokerusStatusRequirement';
 import VitaminObtainRequirement from './requirements/VitaminObtainRequirement';
 import QuestRequirement from './requirements/QuestRequirement';
@@ -313,6 +314,7 @@ Object.assign(<any>window, {
     MaxRegionRequirement,
     ObtainedPokemonRequirement,
     PokeballRequirement,
+    PokemonLevelRequirement,
     PokerusStatusRequirement,
     VitaminObtainRequirement,
     QuestRequirement,


### PR DESCRIPTION
## Description
As the title says, sometimes `ExternalHelper.isInLiveVersion()` would error because `PokemonLevelRequirement` was not included in temporaryWindowInjection.

## How Has This Been Tested?
See screenshots below.

## Screenshots (optional):
before:
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/a43911d4-1102-4bd9-9cf9-ca27f78d700c)

after:
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/28164fce-524f-4e0f-a0f8-5ff3ddd7e51d)

## Types of changes
- Bug fix
