### PR TITLE
Roamer NPC - Use roamer group name

### DIFF
--- a/src/scripts/towns/RoamerNPC.ts
+++ b/src/scripts/towns/RoamerNPC.ts
@@ -17,7 +17,9 @@ class RoamerNPC extends NPC {
 
         // If no roaming Pokemon yet
         if (!roamers.length) {
-            return `There hasn't been any reports of roaming Pokémon around ${GameConstants.camelCaseToString(GameConstants.Region[this.region])} lately.`;
+            const regionName = RoamingPokemonList.roamerGroups[this.region]?.[this.subRegionRoamerGroup]?.name
+                ?? GameConstants.camelCaseToString(GameConstants.Region[this.region]);
+            return `There hasn't been any reports of roaming Pokémon around ${regionName} lately.`;
         }
 
         roamers.forEach((roamer) => {

--- a/src/scripts/towns/RoamerNPC.ts
+++ b/src/scripts/towns/RoamerNPC.ts
@@ -19,7 +19,7 @@ class RoamerNPC extends NPC {
         if (!roamers.length) {
             const regionName = RoamingPokemonList.roamerGroups[this.region]?.[this.subRegionRoamerGroup]?.name
                 ?? GameConstants.camelCaseToString(GameConstants.Region[this.region]);
-            return `There hasn't been any reports of roaming Pokémon around ${regionName} lately.`;
+            return `There haven't been any reports of roaming Pokémon around ${regionName} lately.`;
         }
 
         roamers.forEach((roamer) => {


### PR DESCRIPTION
## Description
Changes the Roamer NPC to use the roamer group name rather than region name when there are currently no roamers. This allows it display the correct area name in subregions, such as 'Orre' instead of 'Hoenn' and 'Alola - Magikarp Jump' instead of 'Alola'.

## Motivation and Context
Accurancy

## How Has This Been Tested?
Talked to the roamer NPC in Orre and saw it said Orre instead of Hoenn.

## Screenshots
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/4166c653-af59-457c-8686-e52f84ad3252)

## Types of changes
- Text
