### PR TITLE
Add pokemon location function for Gift NPC rewards

### DIFF
--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -19,7 +19,8 @@ enum PokemonLocationType {
     TempBattleReward,
     GymReward,
     DungeonReward,
-    Trade
+    Trade,
+    GiftNPC,
 }
 
 class PokemonHelper extends TmpPokemonHelper {
@@ -357,6 +358,28 @@ class PokemonHelper extends TmpPokemonHelper {
         return trades;
     }
 
+    public static getPokemonGifts(pokemonName: PokemonNameType, maxRegion: GameConstants.Region = GameConstants.Region.none): Array<object> {
+        const gifts = [];
+        Object.entries(TownList).forEach(([townName, town]) => {
+            // If we only want to check up to a maximum region
+            if (maxRegion != GameConstants.Region.none && town.region > maxRegion) {
+                return false;
+            }
+
+            const npcs = town.npcs?.filter(n => n instanceof GiftNPC);
+            npcs?.forEach(npc => {
+                if ((npc as GiftNPC).giftFunction?.toString().includes(`'${pokemonName}'`)) {
+                    gifts.push({
+                        town: townName,
+                        npc: npc.name,
+                        requirements: npc.options?.requirement?.hint(),
+                    });
+                }
+            });
+        });
+        return gifts;
+    }
+
     public static getPokemonLocations = (pokemonName: PokemonNameType, maxRegion: GameConstants.Region = GameConstants.MAX_AVAILABLE_REGION) => {
         const encounterTypes = {};
         // Routes
@@ -461,6 +484,12 @@ class PokemonHelper extends TmpPokemonHelper {
         const trades = PokemonHelper.getPokemonTrades(pokemonName);
         if (trades.length) {
             encounterTypes[PokemonLocationType.Trade] = trades;
+        }
+
+        // Gift NPC
+        const gifts = PokemonHelper.getPokemonGifts(pokemonName);
+        if (gifts.length) {
+            encounterTypes[PokemonLocationType.GiftNPC] = gifts;
         }
 
         // Return the list of items

--- a/src/scripts/towns/GiftNPC.ts
+++ b/src/scripts/towns/GiftNPC.ts
@@ -4,7 +4,7 @@ class GiftNPC extends NPC {
     constructor(
         public name: string,
         public dialog: string[],
-        private giftFunction: () => void,
+        public giftFunction: () => void,
         public giftImage?: string,
         options: NPCOptionalArgument = {}
     ) {


### PR DESCRIPTION
## Description
Adds a location function to `PokemonHelper` to check if the pokemon is gained through a Gift NPC.

Eternatus was moved from a temp battle reward to a NPC gift to make it optional. This resulted in it no longer having any valid locations thus it was being excluded from the friend safari rotation.

## How Has This Been Tested?
See screenshots below.

## Screenshots (optional):
before:
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/325798cc-3f7f-46f5-9271-4d3909e41c4e)

after:
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/9f2cdd9d-4da0-4653-ab1a-c497fc9f021b)
