### PR TITLE
The Red fight now resets daily

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -607,7 +607,7 @@ TemporaryBattleList.Red = new TemporaryBattle(
     ],
     '...',
     [new GymBadgeRequirement(BadgeEnums.Elite_JohtoChampion), new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Mt. Silver'))],
-    [new NullRequirement],
+    undefined,
     {
         rewardFunction: () => {
             BagHandler.gainItem({type: ItemType.item, id: 'Light_Ball'}, 1);
@@ -617,6 +617,7 @@ TemporaryBattleList.Red = new TemporaryBattle(
                 setting: NotificationConstants.NotificationSetting.Items.dropped_item,
             });
         },
+        resetDaily: true,
     }
 );
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Using some of the code i made for #4538, you can now only fight Red once a day.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
When all the pikachus in the game, and the coschus coming up, it feels a bit easy to be able to get +30% attack to what feels like 10% of your team, in such a free way. This prevents this, at least for new players.
Might also be a way to test out some of the Gigantamax code, before it's released


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Opened the game, defeated Red, saw he went away. Timetravled and saw i could beat him again.



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Rebalance
