### PR TITLE
Fix Red sometimes not challenging you on update day

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2454,6 +2454,9 @@ class Update implements Saveable {
             saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 52);
             saveData.badgeCase = Update.moveIndex(saveData.badgeCase, 53);
 
+            // Reset Red temp battle
+            saveData.statistics.temporaryBattleDefeated[31] = 0;
+
         },
     };
 


### PR DESCRIPTION
## Description
The update function now resets the tempbattle as well.

## Motivation and Context
Some players might not be able to encounter Red if they happen to play then update their game in the same day.

## How Has This Been Tested?
Loaded an affected save before and after me changing the update function. Looked for Red not appearing on first save, appearing on fixed save.

## Types of changes
- Bug fix
