### PR TITLE
Anomaly Mewtwo trainer from Mega Mewtwo questline does not show up anymore

### DIFF
--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -18,7 +18,7 @@
             </knockout>
 
             <knockout class="left">
-                <!-- ko if: DungeonBattle.trainer() -->
+                <!-- ko if: DungeonBattle.trainer() && !DungeonBattle.trainer().options?.hideTrainer -->
                 <knockout data-bind="text: DungeonBattle.trainer().name">Trainer name</knockout>
                 <!-- /ko -->
             </knockout>
@@ -50,7 +50,7 @@
 
         <!-- ko if: (DungeonRunner.fighting() || DungeonBattle.catching)  -->
         <div data-bind="if: DungeonBattle.enemyPokemon">
-            <div class="trainer" data-bind="if: DungeonBattle.trainer()">
+            <div class="trainer" data-bind="if: DungeonBattle.trainer() && !DungeonBattle.trainer().options?.hideTrainer">
                 <img data-bind="attr:{ src: DungeonBattle.trainer().image }" onerror="this.src='assets/images/npcs/specialNPCs/Mysterious Trainer.png';"/>
             </div>
             <div class="dungeon-enemy">

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -15,6 +15,7 @@ interface EnemyOptions {
     requirement?: MultiRequirement | OneFromManyRequirement | Requirement,
     reward?: Amount,
     hide?: boolean,
+    hideTrainer?: boolean,
 }
 
 interface DetailedPokemon {
@@ -10149,13 +10150,13 @@ dungeonList['Pokémon Village'] = new Dungeon('Pokémon Village',
             ])}),
         new DungeonTrainer('Anomaly Mewtwo',
             [new GymPokemon('Mega Mewtwo X', 120000000, 70)],
-            { hide: true, requirement: new QuestLineCompletedRequirement('An Unrivaled Power')}, undefined, 'X'),
+            { hide: true, requirement: new QuestLineCompletedRequirement('An Unrivaled Power'), hideTrainer: true}, undefined, 'X'),
         new DungeonTrainer('Anomaly Mewtwo',
             [new GymPokemon('Mega Mewtwo Y', 120000000, 70)],
             { hide: true, requirement: new MultiRequirement([
                 new QuestLineStepCompletedRequirement('An Unrivaled Power', 16),
                 new QuestLineCompletedRequirement('An Unrivaled Power', GameConstants.AchievementOption.less),
-            ])}, undefined, 'Y'),
+            ]), hideTrainer: true}, undefined, 'Y'),
     ],
     725000, 20);
 


### PR DESCRIPTION
## Description
Provided support for technically trainers whose we do not want to show names and sprites in dungeon, and applied it to the two Anomaly Mewtwo in Pokémon Village.

## Motivation and Context
In that dungeon, Mewtwo was showing twice on the screen, as a trainer and as its own pokémon.

## How Has This Been Tested?
I verified only one Mewtwo was showing there. I also checked an actual trainer was still showing as expected.

## Types of changes
- Bug fix
- New feature
- UI improvement
