### PR TITLE
Pokérus Indicator in Pokémon List

### DIFF
--- a/src/components/pokemonListContainer.html
+++ b/src/components/pokemonListContainer.html
@@ -71,6 +71,7 @@
                                 <sup data-bind="visible: App.game.party.alreadyCaughtPokemon($data.id, true)">✨</sup>
                                 <img class="shadow-icon" src="assets/images/status/shadow.svg" data-bind="visible: $data.shadow == GameConstants.ShadowStatus.Shadow"/>
                                 <img class="shadow-icon" src="assets/images/status/purified.svg" data-bind="visible: $data.shadow == GameConstants.ShadowStatus.Purified"/>
+                                <img width="32px" height="11px" data-bind="attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[App.game.party.getPokemon($data.id)?.pokerus]}.png`}, visible: App.game.party.getPokemon($data.id)?.pokerus >= GameConstants.Pokerus.Contagious"/>
                                 <!-- ko foreach: PokemonHelper.getMegaStones($data.name).filter(s => player.hasMegaStone(s.megaStone)) -->
                                 <img width="20px" data-bind="attr: { src: $data.image },
                                     tooltip: {


### PR DESCRIPTION
## Description
Added a new <img> to the  Pokémon list that only shows up when the mon is at least contagious and displays the current pokerus status next to it's name.


## Motivation and Context
This change gives a quicker overview as to which pokemon are at which stage of pokérus.

closes #4679

## How Has This Been Tested?
- Loaded a save without many contangious / resitant pokémon to see if there are no visual issues on mons with no indicator.
- Loaded a save with many contangious / resitant pokémon to see if they all show up correctly.
- Cought a new pokémon and infected it to see if it properly updates.
- Went to Orre cought a shadow pokémon to see if any overlap occures.


## Screenshots:
![image](https://github.com/pokeclicker/pokeclicker/assets/26049815/5285d7a4-3845-4033-bf0f-9666a6dd256f)


## Types of changes
- UI improvement
