### PR TITLE
Pokédex Shadow filters

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -233,8 +233,8 @@ aria-labelledby="pokedexModalLabel">
                                                     data-bind="attr: { src: $data.image }, style: { right: `${1 + 17 * $index()}px` }"/>
                                             </knockout>
                                             <!-- /ko -->
-                                            <img style="position: absolute; top: 20px; right: 0px;" class="shadow-icon" src="assets/images/status/shadow.svg" data-bind="visible: App.game.party.getPokemon($data.id).shadow == GameConstants.ShadowStatus.Shadow"/>
-                                            <img style="position: absolute; top: 20px; right: 0px;" class="shadow-icon" src="assets/images/status/purified.svg" data-bind="visible: App.game.party.getPokemon($data.id).shadow == GameConstants.ShadowStatus.Purified"/>
+                                            <img style="position: absolute; top: 24px; right: 0px;" class="shadow-icon" src="assets/images/status/shadow.svg" data-bind="visible: App.game.party.getPokemon($data.id).shadow == GameConstants.ShadowStatus.Shadow"/>
+                                            <img style="position: absolute; top: 24px; right: 0px;" class="shadow-icon" src="assets/images/status/purified.svg" data-bind="visible: App.game.party.getPokemon($data.id).shadow == GameConstants.ShadowStatus.Purified"/>
 
                                             <!-- /ko -->
                                             <img src="" width="80px" data-bind="css: { 'pokemon-not-seen': !PokedexHelper.pokemonSeen($data.id)(), 'pokemon-seen-but-not-caught': !App.game.party.alreadyCaughtPokemonByName(name) && PokedexHelper.pokemonSeen($data.id)() }, attr:{ src: PokemonHelper.getImage($data.id, App.game.party.alreadyCaughtPokemon($data.id, true) && !PokedexHelper.hideShinyImages())}">

--- a/src/modules/settings/PokedexFilters.ts
+++ b/src/modules/settings/PokedexFilters.ts
@@ -59,6 +59,9 @@ const PokedexFilters: Record<string, FilterOption> = {
             new SettingOption('Caught', 'caught'),
             new SettingOption('Caught Not Shiny', 'caught-not-shiny'),
             new SettingOption('Caught Shiny', 'caught-shiny'),
+            new SettingOption('Caught Not Shadow', 'caught-not-shadow'),
+            new SettingOption('Caught Shadow', 'caught-shadow'),
+            new SettingOption('Caught Purified', 'caught-purified'),
         ],
     ),
     statusPokerus: new FilterOption<number>(

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -272,13 +272,14 @@ class Party implements Feature {
         return this.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(name).id, shiny);
     }
 
-    alreadyCaughtPokemon(id: number, shiny = false, shadow = false) {
+    alreadyCaughtPokemon(id: number, shiny = false, shadow = false, purified = false) {
         const pokemon = this.getPokemon(id);
 
         if (pokemon) {
             const shinyOkay = (!shiny || pokemon.shiny);
             const shadowOkay = (!shadow || (pokemon.shadow > GameConstants.ShadowStatus.None));
-            return shinyOkay && shadowOkay;
+            const purifiedOkay = (!purified || (pokemon.shadow == GameConstants.ShadowStatus.Purified));
+            return shinyOkay && shadowOkay && purifiedOkay;
         }
         return false;
     }

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -65,6 +65,8 @@ class PokedexHelper {
             // Checks based on caught/shiny status
             const alreadyCaught = App.game.party.alreadyCaughtPokemon(pokemon.id);
             const alreadyCaughtShiny = App.game.party.alreadyCaughtPokemon(pokemon.id, true);
+            const alreadyCaughtShadow = App.game.party.alreadyCaughtPokemon(pokemon.id, false, true);
+            const alreadyCaughtPurified = App.game.party.alreadyCaughtPokemon(pokemon.id, false, true, true);
 
             // If the Pokemon shouldn't be unlocked yet
             const nativeRegion = PokemonHelper.calcNativeRegion(pokemon.name);
@@ -126,6 +128,7 @@ class PokedexHelper {
             }
 
             const caughtShiny = PokedexFilters.caughtShiny.value();
+
             // Only uncaught
             if (caughtShiny == 'uncaught' && alreadyCaught) {
                 return false;
@@ -143,6 +146,21 @@ class PokedexHelper {
 
             // Only caught shiny
             if (caughtShiny == 'caught-shiny' && !alreadyCaughtShiny) {
+                return false;
+            }
+
+            // Only caught not shadow
+            if (caughtShiny == 'caught-not-shadow' && (!alreadyCaught || alreadyCaughtShadow)) {
+                return false;
+            }
+
+            // Only caught shadow
+            if (caughtShiny == 'caught-shadow' && (!alreadyCaughtShadow || alreadyCaughtPurified)) {
+                return false;
+            }
+
+            // Only caught purified
+            if (caughtShiny == 'caught-purified' && !alreadyCaughtPurified) {
                 return false;
             }
 


### PR DESCRIPTION
Added `Caught Not Shadow`, `Caught Shadow`, and `Caught Purified` as Pokédex filters. Also adjusted the Shadow and Purified SVG locations on the Pokédex entries to be slightly lower so there's not an overlap with the mega stone icons.