### PR TITLE
Fix undefined loot caused by loot weight and get loot filter difference

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -277,21 +277,24 @@ class Dungeon {
         return this.mimicList.filter(p => App.game.party.alreadyCaughtPokemonByName(p));
     }
 
-    public getRandomLootTier(clears: number, debuffed = false): LootTier {
-        const tierWeights = this.getLootTierWeights(clears, debuffed);
+    public getRandomLootTier(clears: number, debuffed = false, onlyDebuffable = false): LootTier {
+        const tierWeights = this.getLootTierWeights(clears, debuffed, onlyDebuffable);
         return Rand.fromWeightedArray(Object.keys(tierWeights), Object.values(tierWeights)) as LootTier;
     }
 
+    private lootFilter = (loot: Loot, onlyDebuffable: boolean) => ((!loot.requirement || loot.requirement.isCompleted()) && (!ItemList[loot.loot] || (ItemList[loot.loot].isAvailable() && !ItemList[loot.loot].isSoldOut()))) && !(onlyDebuffable && loot.ignoreDebuff);
+
     public getRandomLoot(tier: LootTier, onlyDebuffable = false): Loot {
-        const lootTable = this.lootTable[tier].filter((loot) => ((!loot.requirement || loot.requirement.isCompleted()) && (!ItemList[loot.loot] || (ItemList[loot.loot].isAvailable() && !ItemList[loot.loot].isSoldOut()))) && !(onlyDebuffable && loot.ignoreDebuff));
+        const lootTable = this.lootTable[tier].filter((loot) => this.lootFilter(loot, onlyDebuffable));
         return Rand.fromWeightedArray(lootTable, lootTable.map((loot) => loot.weight ?? 1));
     }
 
-    public getLootTierWeights(clears: number, debuffed : boolean): Record<LootTier, number> {
+    public getLootTierWeights(clears: number, debuffed : boolean, onlyDebuffable = false): Record<LootTier, number> {
         if (debuffed) {
             return Object.entries(nerfedLootTierChance).reduce((chances, [tier, chance]) => {
                 if (tier in this.lootTable &&
-                    this.lootTable[tier].some((loot) => !loot.requirement || loot.requirement.isCompleted())) {
+                    this.lootTable[tier].some((loot: Loot) => this.lootFilter(loot, onlyDebuffable))
+                ) {
                     chances[tier] = chance;
                 }
                 return chances;

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -19,7 +19,7 @@ class DungeonRunner {
     public static fightingLootEnemy: boolean;
     public static continuousInteractionInput = false;
 
-    public static initializeDungeon(dungeon) {
+    public static initializeDungeon(dungeon: Dungeon) {
         if (!dungeon.isUnlocked()) {
             return false;
         }
@@ -53,7 +53,7 @@ class DungeonRunner {
             let tier = dungeon.getRandomLootTier(clears);
             let loot = dungeon.getRandomLoot(tier);
             if (!loot.ignoreDebuff && debuffed) {
-                tier = dungeon.getRandomLootTier(clears, debuffed);
+                tier = dungeon.getRandomLootTier(clears, debuffed, true);
                 loot = dungeon.getRandomLoot(tier, true);
             }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
The getRandomLoot filter was different from the getLootTierWeights filter, so a tier could be selected with no valid loots
```ts
-> dungeonList['Under Colosseum'].getRandomLoot('legendary', true)
<< undefined 
```
If Orre Under Colloseum was debuffed, your first item roll is debuffed, and you hadn't got enough clears for the Lum, you can roll Legendary (because the scent is "valid" as far as get weights is concerned), but then when asking for a legendary item, both get filtered out (Lum not met requirement, Scent filtered out because onlyDebuffable)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Fix bug


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Lum requirement not met:
```ts
App.game.statistics.dungeonsCleared[72](0)
dungeonList['Under Colosseum'].getLootTierWeights(0, true, true) 
```
```ts
Object { common: 0.75, rare: 0.24, epic: 0.009 }
```

Lum requirement met:
```ts
App.game.statistics.dungeonsCleared[72](200)
dungeonList['Under Colosseum'].getLootTierWeights(200, true, true) 
```
```ts
Object { common: 0.75, rare: 0.24, epic: 0.009, legendary: 0.00099, mythic: 0.00001 }
```

Legendary and Mythic no longer possible `onlyDebuffable = true` tiers until Lum requirement met. 


`ignoreDebuffable` items (ie, Scents) are still valid for the first loot roll, as we don't pass onlyDebuffable for that roll.
```ts
App.game.statistics.dungeonsCleared[72](0)

dungeonList['Under Colosseum'].getLootTierWeights(0)
Object { common: 0.7497, rare: 0.200099, epic: 0.04012, legendary: 0.00996, mythic: 0.000121 }

dungeonList['Under Colosseum'].getRandomLoot('legendary')
Object { loot: "Excite_Scent", ignoreDebuff: true }
```

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix

