### PR TITLE
Notification for full Flow at Purify Chamber

### DIFF
--- a/src/scripts/towns/PurifyChamber.ts
+++ b/src/scripts/towns/PurifyChamber.ts
@@ -29,6 +29,7 @@ class PurifyChamber implements Saveable {
     public selectedPokemon: KnockoutObservable<PartyPokemon>;
     public currentFlow: KnockoutObservable<number>;
     public flowNeeded: KnockoutComputed<number>;
+    private notified = false;
 
     constructor() {
         this.selectedPokemon = ko.observable(undefined);
@@ -61,6 +62,7 @@ class PurifyChamber implements Saveable {
         }
         this.selectedPokemon().shadow = GameConstants.ShadowStatus.Purified;
         this.currentFlow(0);
+        this.notified = false;
     }
 
     public gainFlow(exp: number) {
@@ -69,6 +71,16 @@ class PurifyChamber implements Saveable {
         }
         const newFlow = Math.round(this.currentFlow() + exp / 1000);
         this.currentFlow(Math.min(newFlow, this.flowNeeded()));
+
+        if (!this.notified && this.currentFlow() >= this.flowNeeded()) {
+            this.notified = true;
+            Notifier.notify({
+                title: 'Purify Chamber',
+                message: 'Maximum Flow has accumulated at the Purify Chamber!',
+                type: NotificationConstants.NotificationOption.primary,
+                timeout: 6e4,
+            });
+        }
     }
 
     saveKey = 'PurifyChamber';


### PR DESCRIPTION
## Description
Adds a notification for when Flow is capped at the Purify Chamber. It's set to stick around for 60 seconds.

## Motivation and Context
The only way to check progress towards the next purified pokemon is by going to the Purify Chamber and manually checking if you've reached the max flow.

## How Has This Been Tested?
Loaded the game and sat on a route until I reached maximum flow, notification appeared once.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/668d05d8-8764-4985-aef9-a054361ff270)

## Types of changes
- Notification
