### PR TITLE
Fix: Safari active environment variable not resetting

### DIFF
--- a/src/scripts/safari/Safari.ts
+++ b/src/scripts/safari/Safari.ts
@@ -65,6 +65,7 @@ class Safari {
         Safari.playerXY.x = 0;
         Safari.playerXY.y = 0;
         Safari.lastDirection = 'up';
+        Safari.activeEnvironment(SafariEnvironments.Grass);
         Safari.inBattle(false);
         Safari.inProgress(true);
         Safari.balls(this.calculateStartPokeballs());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
`Safari.activeEnvironment()` doesn't reset when the Safari loads so if you finish the run on water and start a new run, the `Safari.activeEnvironment()` variable is set to water until you walk on land, this makes the player sprite changes to the surfing one while on land.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Fix


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
* Finish Safari run on water and start a new one
* Walk 1 step and see the sprite changing is fixed



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
