### PR TITLE
Add shadow sprite toggle in Pokédex entry.

### DIFF
--- a/src/components/pokemonStatisticsModal.html
+++ b/src/components/pokemonStatisticsModal.html
@@ -9,6 +9,11 @@
         <h5 class="modal-title text-light ml-1" data-bind="if: App.game.party.getPokemon(pokemonMap[$data].id)">
           <img width="18px" src=""
             data-bind="attr: { src: `assets/images/pokeball/Pokeball${App.game.party.alreadyCaughtPokemon(pokemonMap[$data].id, true) && PokedexHelper.toggleStatisticShiny() ? '-shiny' : ''}.svg`}, click: () => PokedexHelper.toggleStatisticShiny(!PokedexHelper.toggleStatisticShiny())" />
+          
+            <!-- ko if: App.game.party.getPokemon($data)?.shadow > GameConstants.ShadowStatus.None -->
+              <img width="18px" src=""
+                data-bind="attr: { src: `assets/images/status/${PokedexHelper.toggleStatisticShadow() ? 'shadow' : 'purified'}.svg`}, click: () => PokedexHelper.toggleStatisticShadow(!PokedexHelper.toggleStatisticShadow())" />
+            <!-- /ko -->
         </h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
@@ -17,7 +22,7 @@
       <div class="modal-body p-0 pb-1">
         <div class="row m-0 mt-1">
           <div class="col">
-            <img data-bind="attr:{ src: PokemonHelper.getImage(pokemonMap[$data].id, App.game.party.alreadyCaughtPokemon(pokemonMap[$data].id, true) && PokedexHelper.toggleStatisticShiny(), App.game.party.alreadyCaughtPokemon(pokemonMap[$data].id) && App.game.party.getPokemon(pokemonMap[$data].id).defaultFemaleSprite()) }" src=""/>
+            <img data-bind="attr:{ src: PokemonHelper.getImage(pokemonMap[$data].id, App.game.party.alreadyCaughtPokemon(pokemonMap[$data].id, true) && PokedexHelper.toggleStatisticShiny(), App.game.party.alreadyCaughtPokemon(pokemonMap[$data].id) && App.game.party.getPokemon(pokemonMap[$data].id).defaultFemaleSprite(), (App.game.party.getPokemon($data)?.shadow > GameConstants.ShadowStatus.None && PokedexHelper.toggleStatisticShadow()) ? GameConstants.ShadowStatus.Shadow : GameConstants.ShadowStatus.None) }" src=""/>
             <div class="position-absolute" style="top: 0px; right: 15px;"
               data-bind="if: App.game.party.getPokemon(pokemonMap[$data].id)?.pokerus">
               <img width="40px" src=""

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -2,6 +2,7 @@ import TypeColor = GameConstants.TypeColor;
 
 class PokedexHelper {
     public static toggleStatisticShiny = ko.observable(true);
+    public static toggleStatisticShadow = ko.observable(false);
     public static hideShinyImages = ko.observable(false);
 
     public static getBackgroundColors(name: PokemonNameType): string {
@@ -224,5 +225,6 @@ class PokedexHelper {
 $(document).ready(() => {
     $('#pokemonStatisticsModal').on('hidden.bs.modal', () => {
         PokedexHelper.toggleStatisticShiny(true);
+        PokedexHelper.toggleStatisticShadow(false);
     });
 });


### PR DESCRIPTION
## Description
I've added a toggle to the Pokédex entry modal that will allow users to view the shadow form of a relevant shadow Pokémon independently of their party default setting, akin to the shiny sprite toggle.

## Motivation and Context
As the code currently stands, when a user changes the default setting for the shadow form of a Pokémon, it also changes the sprite as viewed in the Pokédex entry modal. This is a deviation from the setting for the shiny form, which only changes the form in the list view *(and elsewhere)* while leaving the sprite in the entry modal as-is. This is a small update that seeks to unify the behavior of the setting and add a similar toggle specific to the entry modal for the sake of consistency.

## How Has This Been Tested?
I have validated the following scenarios:
* Toggling the shiny sprite view on and off while the shadow sprite view is on
* Toggling the shiny sprite view on and off while the shadow sprite view is off
* Toggling the shadow setting on and off while the shadow sprite view is on
* Toggling the shadow setting on and off while the shadow sprite view is off

## Other Notes
I noticed during the testing of these changes that the shiny setting doesn't have any impact on the sprite that appears on the little Pokédex cards while querying the Pokédex. I assume this is due to the `Hide shiny images` setting within the Pokédex modal, but it seems like an oversight to have the shiny setting for a given Pokémon ignored for these results. This also creates a behavior discrepancy between the shadow setting and the shiny setting. It would be easy enough to remedy this, but I figured I would bring it up first to discuss whether this is intended or not before making any modifications in that department.

## Screenshots
![image](https://github.com/pokeclicker/pokeclicker/assets/10764837/2eb218d6-f1b3-41d0-bce6-7aaf24c4699f)
![image](https://github.com/pokeclicker/pokeclicker/assets/10764837/ee6ed445-9c32-4f02-b49c-da9dd9296ecd)
![image](https://github.com/pokeclicker/pokeclicker/assets/10764837/de997343-0d1b-4fdf-8f95-751ba10cf1eb)

## Types of Changes
UI improvement