### PR TITLE
Improved underground item / daily deal trading

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -182,13 +182,21 @@
                                     <td class='vertical-middle'>
                                         <img class='mineInventoryItem' data-bind='attr: {src: item1.image }'>
                                     </td>
-                                    <td class='vertical-middle' data-bind='text: amount1 + " × " + item1.name'></td>
+                                    <td class="vertical-middle">
+                                        <span data-bind="text: amount1"></span>
+                                        <span data-bind="visible: App.game.underground.tradeAmount() > 1, text: ` (${(amount1 * App.game.underground.tradeAmount()).toLocaleString('en-US')})`"></span>
+                                        <span data-bind="text: ` × ${item1.name}`"></span>
+                                    </td>
                                     <td class='vertical-middle'>→</td>
                                     <td class='vertical-middle text-center' data-bind="text: player.getUndergroundItemAmount(item2.id).toLocaleString('en-US')"></td>
                                     <td class='vertical-middle'>
                                         <img class='mineInventoryItem' data-bind='attr: {src: item2.image }'>
                                     </td>
-                                    <td class='vertical-middle' data-bind='text: amount2 + " × " + item2.name'></td>
+                                    <td class="vertical-middle">
+                                        <span data-bind="text: amount2"></span>
+                                        <span data-bind="visible: App.game.underground.tradeAmount() > 1, text: ` (${(amount2 * App.game.underground.tradeAmount()).toLocaleString('en-US')})`"></span>
+                                        <span data-bind="text: ` × ${item2.name}`"></span>
+                                    </td>
                                     <td class='vertical-middle'>
                                         <div class="btn-group btn-block">
                                             <button class="btn btn-primary btn-block" data-bind="click: () => DailyDeal.use($index(), App.game.underground.tradeAmount()), css: { disabled: !DailyDeal.canUse($index()) }">
@@ -201,7 +209,7 @@
                                                 <div class="dropdown-divider m-0"></div>
                                                 <!-- ko foreach: [10, 25, 50, 75, 100] -->
                                                 <button class="dropdown-item small py-1" type="button" data-bind="text: `${$data}%`,
-                                                    click: () => { App.game.underground.tradeAmount(player.getUndergroundItemAmount($parent.item1.id) * ($data / 100)) }"></button>
+                                                    click: () => { App.game.underground.tradeAmount(Math.floor(player.getUndergroundItemAmount($parent.item1.id) * ($data / 100) / $parent.amount1)) }"></button>
                                                 <!-- /ko -->
                                             </div>
                                         </div>
@@ -223,7 +231,7 @@
                                     <button class="btn btn-warning btn-outline-dark smallButton smallFont"
                                         data-bind="click: () => App.game.underground.tradeAmount(1)">Reset</button>
                                 </div>
-                                <input type="number" class="outline-dark form-control form-control-number" data-bind="value: App.game.underground.tradeAmount" />
+                                <input type="number" class="outline-dark form-control form-control-number" data-bind="textInput: App.game.underground.tradeAmount" />
                                 <div class="input-group-append">
                                     <!-- ko if: Settings.getSetting('shopButtons').observableValue() == 'original' -->
                                     <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.increaseTradeAmount(10)">

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -233,6 +233,11 @@
                                 </div>
                                 <input type="number" class="outline-dark form-control form-control-number" data-bind="textInput: App.game.underground.tradeAmount" />
                                 <div class="input-group-append">
+                                    <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split rounded-0" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
+                                    <div class="dropdown-menu" data-bind="foreach: [10, 100, 1000]">
+                                        <button class="dropdown-item py-1" type="button" data-bind="text: $data.toLocaleString('en-US'),
+                                            click: () => App.game.underground.tradeAmount($data)"></button>
+                                    </div>
                                     <!-- ko if: Settings.getSetting('shopButtons').observableValue() == 'original' -->
                                     <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.increaseTradeAmount(10)">
                                         +10

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -175,7 +175,8 @@
                                     <th></th>
                                 </tr>
                             </thead>
-                            <tbody data-bind='foreach: DailyDeal.list'>
+                            <tbody>
+                                <!-- ko foreach: DailyDeal.list -->
                                 <tr>
                                     <td class='vertical-middle text-center' data-bind="text: player.getUndergroundItemAmount(item1.id).toLocaleString('en-US')"></td>
                                     <td class='vertical-middle'>
@@ -189,20 +190,68 @@
                                     </td>
                                     <td class='vertical-middle' data-bind='text: amount2 + " × " + item2.name'></td>
                                     <td class='vertical-middle'>
-                                        <div class="btn-group btn-block" data-bind="let: { tradeAmount: ko.observable(1) }">
-                                            <button class='btn btn-success btn-block' data-bind='click: function(){DailyDeal.use($index(), tradeAmount())}, css: { disabled: !DailyDeal.canUse($index()) }'>
+                                        <div class="btn-group btn-block">
+                                            <button class="btn btn-primary btn-block" data-bind="click: () => DailyDeal.use($index(), App.game.underground.tradeAmount()), css: { disabled: !DailyDeal.canUse($index()) }">
                                                 Trade
                                             </button>
-                                            <button type="button" data-bind="text: tradeAmount() + '&nbsp;', css: { disabled: !DailyDeal.canUse($index()) }" class="btn btn-success dropdown-toggle dropdown-toggle-split active" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            </button>
-                                            <div class="dropdown-menu" data-bind="foreach: [1, 10, 100, 1000, Infinity]">
-                                                <button class="dropdown-item" type="button" data-bind="click: function(){tradeAmount($data)}, text: $data.toLocaleString('en-US')"></button>
+                                            <button type="button" data-bind="css: { disabled: !DailyDeal.canUse($index()) }"
+                                                class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
+                                            <div class="dropdown-menu text-center p-0">
+                                                <p class="small py-2 m-0">Set Trade Amount</p>
+                                                <div class="dropdown-divider m-0"></div>
+                                                <!-- ko foreach: [10, 25, 50, 75, 100] -->
+                                                <button class="dropdown-item small py-1" type="button" data-bind="text: `${$data}%`,
+                                                    click: () => { App.game.underground.tradeAmount(player.getUndergroundItemAmount($parent.item1.id) * ($data / 100)) }"></button>
+                                                <!-- /ko -->
                                             </div>
                                         </div>
                                     </td>
                                 </tr>
+                                <!-- /ko -->
+                                <!-- ko ifnot: App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Daily_Deals_Max).isMaxLevel() -->
+                                <tr>
+                                    <td colspan="8" class="text-center text-muted p-2">Upgrade the Underground to unlock additional deals!</td>
+                                </tr>
+                                <!-- /ko -->
                             </tbody>
                         </table>
+                    </div>
+                    <div class="modal-footer d-flex justify-content-center p-2">
+                        <div class="col-12 col-lg-6">
+                            <div class="input-group">
+                                <div class="input-group-prepend">
+                                    <button class="btn btn-warning btn-outline-dark smallButton smallFont"
+                                        data-bind="click: () => App.game.underground.tradeAmount(1)">Reset</button>
+                                </div>
+                                <input type="number" class="outline-dark form-control form-control-number" data-bind="value: App.game.underground.tradeAmount" />
+                                <div class="input-group-append">
+                                    <!-- ko if: Settings.getSetting('shopButtons').observableValue() == 'original' -->
+                                    <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.increaseTradeAmount(10)">
+                                        +10
+                                    </button>
+                                    <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.increaseTradeAmount(100)">
+                                        +100
+                                    </button>
+                                    <!-- /ko -->
+                                    <!-- ko if: Settings.getSetting('shopButtons').observableValue() == 'multiplication' -->
+                                    <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.multiplyTradeAmount(10)">
+                                        &times;10
+                                    </button>
+                                    <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.multiplyTradeAmount(0.1)">
+                                        &div;10
+                                    </button>
+                                    <!-- /ko -->
+                                    <!-- ko if: Settings.getSetting('shopButtons').observableValue() == 'bigplus' -->
+                                    <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.increaseTradeAmount(100)">
+                                        +100
+                                    </button>
+                                    <button class="btn btn-secondary smallButton smallFont" type="button" onclick="App.game.underground.increaseTradeAmount(1000)">
+                                        +1,000
+                                    </button>
+                                    <!-- /ko -->
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -69,8 +69,15 @@ export class Underground implements Feature {
         return `<u>Owned:</u><br>Mine items: ${nMineItems.toLocaleString('en-US')}<br>Fossils: ${nFossils.toLocaleString('en-US')}<br>Plates: ${nPlates.toLocaleString('en-US')}<br>Shards: ${nShards.toLocaleString('en-US')}`;
     });
 
+    public tradeAmount: Observable<number> = ko.observable(1).extend({ numeric: 0 });
+
     constructor() {
         this.upgradeList = [];
+        this.tradeAmount.subscribe((value) => {
+            if (value < 1) {
+                this.tradeAmount(1);
+            }
+        });
     }
 
     initialize() {
@@ -482,6 +489,14 @@ export class Underground implements Feature {
     calculateItemEffect(item: EnergyRestoreSize) {
         const effect: number = EnergyRestoreEffect[EnergyRestoreSize[item]];
         return effect * this.getMaxEnergy();
+    }
+
+    public increaseTradeAmount(amount: number) {
+        this.tradeAmount(this.tradeAmount() + amount);
+    }
+
+    public multiplyTradeAmount(amount: number) {
+        this.tradeAmount(this.tradeAmount() * amount);
     }
 
     fromJSON(json: Record<string, any>): void {


### PR DESCRIPTION
## Description
Improves the daily deal trading experience by adding an input to enter custom amounts, ability to set the amount to a percentage of an item, and other UI & QoL tweaks.

## Motivation and Context
Trading large or specific amounts of items can be troublesome or take a while. This gives the player more control over how many items they are trading as well displays trade amounts more clearly.

## How Has This Been Tested?
Performed lots of trades, changed the number, used the dropdowns.

## Screenshots (optional):

normal view w/ 1 as the amount
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/867913f1-645d-4d99-945a-633ef52ffc9b)

when any number besides 1 is entered the total amount of items to be traded or received will display in parenthesis
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/09dfab48-b1c2-4051-a679-f1897aec88b4)

percentage options to quickly set the input to a percent of what the player has of the item
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/1973133e-8d7f-47dc-8ccd-cede81892e06)

## Types of changes
- UI improvement
