### PR TITLE
Made Overcast Green

### DIFF
--- a/src/modules/weather/Weather.ts
+++ b/src/modules/weather/Weather.ts
@@ -34,7 +34,7 @@ export default class Weather {
         [WeatherType.Clear]:
             new WeatherCondition(WeatherType.Clear, '#ffe57a', 'The weather is clear and pleasant.', 30),
         [WeatherType.Overcast]:
-            new WeatherCondition(WeatherType.Overcast, '#bed8ff', 'Clouds fill the skies.', 15,
+            new WeatherCondition(WeatherType.Overcast, '#a7db8d', 'Clouds fill the skies.', 15,
                 [{ type: PokemonType.Normal, multiplier: 1.1 }, { type: PokemonType.Fighting, multiplier: 1.1 }, { type: PokemonType.Poison, multiplier: 1.1 }]),
         [WeatherType.Rain]:
             new WeatherCondition(WeatherType.Rain, '#9db7f5', 'It\'s rainy and humid.', 10,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Made Overcast weather green to better reflect canon. 


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
In Sword / Shield Overcast weather is green (https://bulbapedia.bulbagarden.net/wiki/Weather#Galar).


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
With my eyes.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![green-overcast](https://github.com/pokeclicker/pokeclicker/assets/106291026/9215c192-7d3a-4d0b-8956-edb71fce017f)


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Green
