### PR TITLE
Allow filtering shiny duplicate log messages

### DIFF
--- a/src/modules/logbook/LogBookTypes.ts
+++ b/src/modules/logbook/LogBookTypes.ts
@@ -12,6 +12,10 @@ export const LogBookTypes: Record<string, LogBookType> = {
         display: 'warning',
         label: 'SHINY',
     },
+    SHINY_DUPLICATE: {
+        display: 'warning',
+        label: 'SHINY_DUPLICATE',
+    },
     CAUGHT: {
         display: 'success',
         label: 'CAUGHT',

--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -116,18 +116,23 @@ class Battle {
         PokemonHelper.incrementPokemonStatistics(enemyPokemon.id, GameConstants.PokemonStatisticsType.Encountered, enemyPokemon.shiny, enemyPokemon.gender, enemyPokemon.shadow);
         // Shiny
         if (enemyPokemon.shiny) {
-            App.game.logbook.newLog(
-                LogBookTypes.SHINY,
-                App.game.party.alreadyCaughtPokemon(enemyPokemon.id, true)
-                    ? createLogContent.encounterShinyDupe({
+            if (App.game.party.alreadyCaughtPokemon(enemyPokemon.id, true)) {
+                App.game.logbook.newLog(
+                    LogBookTypes.SHINY_DUPLICATE,
+                    createLogContent.encounterShinyDupe({
                         location: Routes.getRoute(player.region, player.route()).routeName,
                         pokemon: enemyPokemon.name,
                     })
-                    : createLogContent.encounterShiny({
+                );
+            } else {
+                App.game.logbook.newLog(
+                    LogBookTypes.SHINY,
+                    createLogContent.encounterShiny({
                         location: Routes.getRoute(player.region, player.route()).routeName,
                         pokemon: enemyPokemon.name,
                     })
-            );
+                );
+            }
         } else if (!App.game.party.alreadyCaughtPokemon(enemyPokemon.id) && enemyPokemon.health()) {
             App.game.logbook.newLog(
                 LogBookTypes.NEW,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Adds new logbook type called SHINY_DUPLICATE and tweaks log entries of regular route battles accordingly, so that duplicate shiny log messages can be filtered out by users as desired


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
work in progress at closing #4003 


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
making new save with modified shiny chances and examining the log setting functionality, look and feel of the log entries, etc.
Requires translation tweaks when testing ( https://github.com/pokeclicker/pokeclicker-translations/pull/97 ) or else the game soft locks once a SHINY_DUPLICATE log entry would appear

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://github.com/pokeclicker/pokeclicker/assets/142755288/be1f3755-94f4-4e6f-ae73-16d489a88b48)
![image](https://github.com/pokeclicker/pokeclicker/assets/142755288/cca6e81f-6a77-4423-ad46-efecda3282b5)



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement

## TODO
- [ ] Determine why the log entries say type.SHINY_DUPLICATE instead of SHINY_DUPLICATE and fix that
- [ ] add SHINY_DUPLICATE logic to escaping pokemon (Battle.ts)
- [ ] add SHINY_DUPLICATE logic to wandering farm pokemon (Plot.ts)
- [ ] add SHINY_DUPLICATE logic to dungeon pokemon encounters (DungeonBattle.ts)
- [ ] add SHINY_DUPLICATE logic to dungeon loot pokemon encounters (DungeonBattle.ts)
- [ ] add SHINY_DUPLICATE logic to dungeon boss pokemon encounters (DungeonBattle.ts)
- [ ] add SHINY_DUPLICATE logic to evolutions (EvolutionHandler.ts)
- [ ] add SHINY_DUPLICATE logic to hatching (Egg.ts)
- [ ] add SHINY_DUPLICATE logic to shop pokemon (PokemonItem.ts)
- [ ] add SHINY_DUPLICATE logic to catching pokemon (Party.ts)