### PR TITLE
Made Pinkan less Sweet

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -621,7 +621,7 @@ class Farming implements Feature {
             0.1,
             2500,
             15,
-            [0, 0, 50, 0, 0],
+            [0, 0, 35, 0, 0],
             30,
             BerryColor.Pink,
             3.5,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Made Pinkan be 35 Sweet (down from 50) to keep it more in line with the other berries as normally gen 3 are at max 30 and gen 5 are 40, so it's still a bit sweeter than other gen 3 due to the requirements attached to getting it.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Pinkan at 50 was a bit excessive when nothing else came close to it, not even berries hard to get like Petaya. So 35 is a good compromise as it's a bit higher than usual gen 3 (like Belue at 30 Sour) but lower than the max flavor gen 5 (like Custap at 40 Sweet).


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I opened the Berry Dex and checked that it showed the right flavor.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Balance
