### PR TITLE
Changed Thunderstorm Weight from 5 to 10

### DIFF
--- a/src/modules/weather/Weather.ts
+++ b/src/modules/weather/Weather.ts
@@ -40,7 +40,7 @@ export default class Weather {
             new WeatherCondition(WeatherType.Rain, '#9db7f5', 'It\'s rainy and humid.', 10,
                 [{ type: PokemonType.Water, multiplier: 1.1 }, { type: PokemonType.Bug, multiplier: 1.1 }]),
         [WeatherType.Thunderstorm]:
-            new WeatherCondition(WeatherType.Thunderstorm, '#a19288', 'It\'s currently raining heavily with thunder.', 5,
+            new WeatherCondition(WeatherType.Thunderstorm, '#a19288', 'It\'s currently raining heavily with thunder.', 10,
                 [{ type: PokemonType.Electric, multiplier: 1.1 }, { type: PokemonType.Water, multiplier: 1.1 }, { type: PokemonType.Fire, multiplier: 0.9 }]),
         [WeatherType.Snow]:
             new WeatherCondition(WeatherType.Snow, '#bbe6e6', 'It\'s cold and snowing.', 5,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Changed Thunderstorm Weight from 5 to 10 so it's more in line with the other weather types. 


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Thunderstorm being weight 5 was odd and it also caused issues with a quest line in Hoenn where, sometimes, people had to wait more than a week to complete it.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Checked the Weather Institute Forecast to see the changes.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
Before:
![thunderstorm-2](https://github.com/pokeclicker/pokeclicker/assets/106291026/2d0dd031-9677-4e9e-acc0-e43d83368b03)

With weight 10:
![thunderstorm-1](https://github.com/pokeclicker/pokeclicker/assets/106291026/baae0334-708c-4ad5-aa8f-9741f8cbd7f7)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- I dunno, weather.
