### PR TITLE
Protect player.gainItem and player.loseItem

### DIFF
--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -191,11 +191,11 @@ class Player {
     }
 
     public gainItem(itemName: string, amount: number) {
-        this._itemList[itemName](this._itemList[itemName]() + amount);
+        this._itemList[itemName](Math.min(this._itemList[itemName]() + amount, ItemList[itemName].maxAmount));
     }
 
     public loseItem(itemName: string, amount: number) {
-        this._itemList[itemName](this._itemList[itemName]() - amount);
+        this._itemList[itemName](Math.max(this._itemList[itemName]() - amount, 0));
     }
 
     public lowerItemMultipliers(multiplierDecreaser: MultiplierDecreaser, amount = 1) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
I'll start by stating that I am in no way proficient in this codebase, and would like others to verify that changing behaviour in this location does not break anything else.

Player.gainItem didn't perform any checks related to the maxAmount that was set for items in ItemList. This change makes it impossible for item count to go over the maxAmount set, or impossible to go below 0.

Edit:
Things to note:
* Already owning items with an item count above the limit will reset it to the limit next time you gain or lose some amount of this item.
* This also does not remove the option to gain/buy extra items, this will only prevent them from being added to your account.
* Once you have more than MAX_SAFE_INTEGER of an underground item, daily trades also become infinite, as you can trade smaller amounts which are insignificant, and thus just creating the second item while not losing any of the first.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
This protects items from going over their maxAmount limit, which by default is set to MAX_SAFE_INTEGER. The ability to go over this number affects Evolution stones in a way that you now have the option to have infinite evolution stones available, as subtracting 1 does not decrease the item count.
Downside (if this can be considered one??) would be that daily trades will also be capped at this number. 


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1. Boot up the game
2. Open Evolution items tab
3. Open console
4. Run `ItemList['Fire_stone'].gain(1e20)` and verify it's capped at MAX_SAFE_INTEGER 9,007,199,254,740,991


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
