### PR TITLE
Fixes catching shiny shadow pokemons

### DIFF
--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -72,7 +72,7 @@ class Party implements Feature {
                 // Already caught (non shadow) we need to update the party pokemon directly
                 if (this.alreadyCaughtPokemon(pokemon.id, false, false)) {
                     this.getPokemon(pokemon.id).shadow = GameConstants.ShadowStatus.Shadow;
-                    if (!pokemon.shiny && pokemon.shiny) { // Will almost never happen, so don't want to have a log message, that we need to keep track of
+                    if (pokemon.shiny) { // Will almost never happen, so don't want to have a log message, that we need to keep track of
                         this.getPokemon(pokemon.id).shiny = true;
                     }
                     return;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Fixes an issue where catching a shiny shadow pokemon would not gain the shiny status when it was non shiny non shadow before catching


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
If you have a regular non-shiny, non-shadow pokemon and you catch a shiny-shadow it does not apply the the shiny status because of the `if (!pokemon.shiny && pokemon.shiny)` check.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Loaded a game where I had a non-shiny, non shadow pokemon. Forced every pokemon to be shiny and attempted to catch it. It applied both shiny and shadow correctly now.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
