### PR TITLE
Update The Legend Awakened (Genesect) quest step description

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1472,7 +1472,7 @@ class QuestLineHelper {
         const watchGenesectFight = new TalkToNPCQuest(GenesectFight, 'Witness the battle between the Red Genesect and another powerful Pokémon in Castelia City.');
         genesectQuestLine.addQuest(watchGenesectFight);
 
-        const digP2 = new MineLayersQuest(5, 0).withDescription('The Red Genesect has crashed into the P2 Lab, leaving a pile of rubble in its wake. Dig through the rubble to learn more.');
+        const digP2 = new MineLayersQuest(5, 0).withDescription('The Red Genesect has crashed into the P2 Lab and escaped underground. Start digging to learn more.');
         genesectQuestLine.addQuest(digP2);
 
         const battleRedGenesect2 = new DefeatTemporaryBattleQuest('Red Genesect 2', 'The Red Genesect is trying to escape the Castelia Sewers, stop it!');


### PR DESCRIPTION
## Description
Changes the description of the digging quest step from
`The Red Genesect has crashed into the P2 Lab, leaving a pile of rubble in its wake. Dig through the rubble to learn more.`
to
`The Red Genesect has crashed into the P2 Lab and escaped underground. Start digging to learn more.`

## Motivation and Context
During testing the consensus was the current description was confusing, this change clarifies what needs to be done.

## Types of changes
- Text
