### PR TITLE
Fix : eggsteps

### DIFF
--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -31155,7 +31155,9 @@ pokemonList.forEach((p) => {
         // Calculate evolutions egg steps to be higher than the base forms
         (p as PokemonListData).evolutions?.forEach((evo) => {
             const poke = pokemonList.find((_p) => _p.name === evo.evolvedPokemon);
-            poke.eggCycles = Math.min(maxEggCycles, Math.round(poke.eggCycles * (evo.ignoreECChange ? 1 : 1.5)));
+            if (!evo.ignoreECChange) {
+                poke.eggCycles = Math.min(maxEggCycles, Math.round(p.eggCycles * 1.5));
+            }
 
         });
     }


### PR DESCRIPTION
## Description
Proper implementation.

## Motivation and Context
Eggsteps were weirdly increased on few Pokémon due to a change in the computation.



## How Has This Been Tested?
Loaded the game, went to see that Santa Snorlax, Magnezone, Leafeon, Probopass and Burmy eggsteps were as they should be.


## Types of changes
- Bug fix
