### PR TITLE
Fix friend safari rotation seeding

### DIFF
--- a/src/scripts/safari/SafariPokemonList.ts
+++ b/src/scripts/safari/SafariPokemonList.ts
@@ -159,15 +159,16 @@ class SafariPokemonList {
     }
 
     public static generateKalosSafariList() {
-        SeededRand.seed(+player.trainerId);
-
         // Obtain the list of non-EVable pokemon and shuffle it
         // There may not be an evenly divisible number of pokemon so repeat list 5 times
-        const shuffledPokemon = new Array(GameConstants.FRIEND_SAFARI_POKEMON).fill(
-            SeededRand.shuffleArray(
-                pokemonList.filter((p) => PokemonHelper.isObtainableAndNotEvable(p.name)
-                    && PokemonHelper.calcNativeRegion(p.name) <= GameConstants.MAX_AVAILABLE_REGION).map((p) => p.name))
-        ).flat();
+        const friendSafariPokemon = pokemonList
+            .filter((p) => PokemonHelper.isObtainableAndNotEvable(p.name)
+                && PokemonHelper.calcNativeRegion(p.name) <= GameConstants.MAX_AVAILABLE_REGION)
+            .map((p) => p.name);
+
+        SeededRand.seed(+player.trainerId);
+        const shuffledPokemon = new Array(GameConstants.FRIEND_SAFARI_POKEMON)
+            .fill(SeededRand.shuffleArray(friendSafariPokemon)).flat();
 
         // Rotation is fixed, use the current date to determine where in the list to select the 5 pokemon
         const batchCount = Math.ceil(shuffledPokemon.length / GameConstants.FRIEND_SAFARI_POKEMON);


### PR DESCRIPTION
## Description
During load the friend safari pokemon list shuffling would result in an unexpected order, it appears something was causing the rand seed to change. Moving a couple things around in the generation has corrected the issue.

## Motivation and Context
Bug

## How Has This Been Tested?
Loaded a save that was encountering the issue on live and checked that the rotation was now correct. Also had several other players who reported the issue test.

## Types of changes
- Bug fix
