### PR TITLE
Fixed Anomaly Mewtwo tempbattle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "description": "PokéClicker repository",
   "main": "index.js",
   "scripts": {

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2531,6 +2531,12 @@ class Update implements Saveable {
             // Fix Hopo berry visible in berrydex when not available
             saveData.farming.mutations[71] = false;
         },
+        '0.10.17': ({ saveData }) => {
+            // Fix Anomaly Mewtwo 5 if the quest is not completed.
+            if (saveData.quests.questLines.find(ql => ql.name === 'An Unrivaled Power')?.state < 2) {
+                saveData.statistics.temporaryBattleDefeated[223] = 0;
+            }
+        },
     };
 
     constructor() {


### PR DESCRIPTION
## Description
The 0.10.17 update resets the Tempbattle.

## Motivation and Context
Anomaly Mewtwo 5 got mixed up with Hau 1.
Wild Electrike Horde tempbattle left as is because it does not matter much.

## How Has This Been Tested?
Loaded a bugged save.

## Screenshots (optional):
No screenshot but enjoy shiny Psyduck.
![54](https://github.com/pokeclicker/pokeclicker/assets/68825215/0dd02109-5cab-4283-8ecf-4e407dff0136)

## Types of changes
- Bug fix
