### PR TITLE
Changed Printed name of Rare Candy

### DIFF
--- a/src/scripts/towns/DreamOrbController.ts
+++ b/src/scripts/towns/DreamOrbController.ts
@@ -54,7 +54,7 @@ class DreamOrbController implements Saveable {
             new DreamOrbLoot({type: ItemType.item, id: 'Protein'}, 0.091),
             new DreamOrbLoot({type: ItemType.item, id: 'Calcium'}, 0.092),
             new DreamOrbLoot({type: ItemType.item, id: 'Carbos'}, 0.092),
-            new DreamOrbLoot({type: ItemType.item, id: 'Rare_Candy'}, 0.15),
+            new DreamOrbLoot({type: ItemType.item, id: 'Rare Candy'}, 0.15),
         ]),
         new DreamOrb('Blue', new MultiRequirement([new ObtainedPokemonRequirement('Landorus (Therian)'), new ObtainedPokemonRequirement('Enamorus')]), [
             new DreamOrbLoot({type: ItemType.item, id: 'Igglybuff'}, 0.2),


### PR DESCRIPTION
Fixed issue with Rare Candy name having an underscore instead of a space

<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->
Changed the printed name when you get a Rare Candy from the dream orbs
## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

It's all in the summary it is super basic


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

To fix a bug in the game.
Previous Issue that was opened by me: https://github.com/pokeclicker/pokeclicker/issues/4898
Fixes #4898 
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

this is untested but so little has changed that no testing should be required

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
