### PR TITLE
[DEV] Throw when attempting to get unknown quest line

### DIFF
--- a/src/scripts/quests/Quests.ts
+++ b/src/scripts/quests/Quests.ts
@@ -74,7 +74,17 @@ class Quests implements Saveable {
      * @param name The quest line name
      */
     getQuestLine(name: string) {
-        return this.questLines().find(ql => ql.name.toLowerCase() == name.toLowerCase());
+        const questLine = this.questLines().find(ql => ql.name.toLowerCase() == name.toLowerCase());
+        if (!questLine && GameHelper.isDevelopmentBuild()) {
+            Notifier.notify({
+                title: '[DEV] FATAL ERROR',
+                message: `Unknown quest line "${name}". Is this a typo?`,
+                type: NotificationConstants.NotificationOption.danger,
+                timeout: 2 ** 31 - 1,
+            });
+            throw new Error(`Unknown quest line "${name}".`);
+        }
+        return questLine;
     }
 
     public beginQuest(index: number) {


### PR DESCRIPTION
IMPORTANT: Please check out #4973 for a compile-time solution.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
Throws an error and shows a notification whenever `Quests.getQuestLine(name)` is called with an unknown quest line name in a dev environment.



## Motivation and Context
A typo can be hard to spot and might make people waste a lot of time trying to troubleshoot their code.



## How Has This Been Tested?
Replaced the Charmander -> Charmeleon evolution with a `QuestlineLevelEvolution`.



## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/21047644/5b0a5bab-149d-4821-b965-a731d3f77152)




## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Dev improvement
