### PR TITLE
Fix: Use setInterval instead of setTimeout for game loop.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokeclicker",
-  "version": "0.10.14",
+  "version": "0.10.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pokeclicker",
-      "version": "0.10.14",
+      "version": "0.10.17",
       "license": "ISC",
       "dependencies": {
         "bootstrap": "^4.5.3",

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -273,13 +273,13 @@ class Game {
         // requestAnimationFrame (consistent if page visible)
         let lastFrameTime = 0;
         let ticks = 0;
-        const tick = (currentFrameTime) => {
+        this.frameRequest = setInterval(() => {
             // Don't process while page hidden
             if (pageHidden) {
-                this.frameRequest = requestAnimationFrame(tick);
                 return;
             }
 
+            const currentFrameTime = Date.now();
             const delta = currentFrameTime - lastFrameTime;
             ticks += delta;
             lastFrameTime = currentFrameTime;
@@ -292,9 +292,7 @@ class Game {
                 }
                 this.gameTick();
             }
-            this.frameRequest = requestAnimationFrame(tick);
-        };
-        this.frameRequest = requestAnimationFrame(tick);
+        }, 1000 / 60);
 
         // Try start our webworker so we can process stuff while the page isn't focused
         try {
@@ -352,7 +350,7 @@ class Game {
     }
 
     stop() {
-        cancelAnimationFrame(this.frameRequest);
+        clearInterval(this.frameRequest);
         window.onbeforeunload = () => {};
     }
 


### PR DESCRIPTION
Prevents the callstack from overflowing over time.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
I've changes the main `tick()` loop to use setInterval instead of a self-referencial setTimeout to prevent long-term lag.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
I've noticed that the game can lag if played for too long. (Mobile/Browser). While I was messing around in the code I noticed that when break in the `tick` function the callstack becomes endlessly large. This is essentially a memory leak.
Using `setInterval` instead of `setTimeout` that the `requestAnimationFrame` uses prevents that issue and is functionally the same.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
After starting up a file in my brower, I ran `App.game.stop()` to stop the current implementation.
I then ran the following code to emulate what this new code will do:
```javascript
{
    let lastFrameTime = 0;
    let ticks = 0;
    App.game.frameRequest = setInterval(() => {
        if (document.hidden) { return; }
        const currentFrameTime = Date.now();
        const delta = currentFrameTime - lastFrameTime;
        ticks += delta;
        lastFrameTime = currentFrameTime;
        if (ticks >= GameConstants.TICK_TIME) {
            if (ticks >= GameConstants.TICK_TIME * 2) { ticks = 0; }
            else { ticks -= GameConstants.TICK_TIME; }
            App.game.gameTick();
        }
    }, 1000 / 60);
    console.log('test');
}
``` 
I checked various parts of the game and they still ran as expected.
Using the log to set a breakpoint, I could verify that the callstack remained constant and that the game ticks were properly set to 0 if the loop ran too slow. (e.g. if the game was paused or lagged in some other way)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
