### PR TITLE
Added dummyEvolutions for the gmax that didnt have them

### DIFF
--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -14304,7 +14304,7 @@ export const pokemonList = createPokemonArray(
         'catchRate': 50,
         'evolutions': [
             StoneEvolution('Munchlax', 'Snorlax', StoneType.Soothe_bell),
-            DummyEvolution('Munchlax', 'Gigantamax Snorlax')
+            DummyEvolution('Munchlax', 'Gigantamax Snorlax'),
         ],
         'baby': true,
         'base': {
@@ -28063,7 +28063,7 @@ export const pokemonList = createPokemonArray(
             DummyEvolution('Kubfu', 'Urshifu (Single Strike)'),
             DummyEvolution('Kubfu', 'Urshifu (Rapid Strike)'),
             DummyEvolution('Kubfu', 'Gigantamax Urshifu (Single Strike)'),
-            DummyEvolution('Kubfu', 'Gigantamax Urshifu (Rapid Strike)')
+            DummyEvolution('Kubfu', 'Gigantamax Urshifu (Rapid Strike)'),
         ],
         'catchRate': 3,
         'eggCycles': 120,

--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -14302,7 +14302,10 @@ export const pokemonList = createPokemonArray(
         'levelType': LevelType.slow,
         'exp': 78,
         'catchRate': 50,
-        'evolutions': [StoneEvolution('Munchlax', 'Snorlax', StoneType.Soothe_bell)],
+        'evolutions': [
+            StoneEvolution('Munchlax', 'Snorlax', StoneType.Soothe_bell),
+            DummyEvolution('Munchlax', 'Gigantamax Snorlax')
+        ],
         'baby': true,
         'base': {
             'hitpoints': 135,
@@ -28056,6 +28059,12 @@ export const pokemonList = createPokemonArray(
             'specialDefense': 50,
             'speed': 72,
         },
+        'evolutions': [
+            DummyEvolution('Kubfu', 'Urshifu (Single Strike)'),
+            DummyEvolution('Kubfu', 'Urshifu (Rapid Strike)'),
+            DummyEvolution('Kubfu', 'Gigantamax Urshifu (Single Strike)'),
+            DummyEvolution('Kubfu', 'Gigantamax Urshifu (Rapid Strike)')
+        ],
         'catchRate': 3,
         'eggCycles': 120,
         'levelType': LevelType.slow,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Added evolution data for gmax snorlax and all 4 forms of urshifu


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
The data should be consistent even if it has no effect on the actual game


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Went into game and saw that the mons still had the same amount of egg steps


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- idk? data i guess
