### PR TITLE
Fix shop egg pokerus infection bug

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2599,8 +2599,9 @@ class Update implements Saveable {
 
             // Fix pokerus status for party members infected via shop eggs
             saveData.party.caughtPokemon.forEach(pokemon => {
-                if (pokemon[PartyPokemonSaveKeys.pokerus] === GameConstants.Pokerus.Infected && !pokemon[PartyPokemonSaveKeys.breeding]) {
-                    pokemon[PartyPokemonSaveKeys.pokerus] = GameConstants.Pokerus.Contagious;
+                // PartyPokemonSaveKeys.pokerus and .breeding
+                if (pokemon[8] === GameConstants.Pokerus.Infected && !pokemon[4]) {
+                    pokemon[8] = GameConstants.Pokerus.Contagious;
                 }
             });
         },

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2596,6 +2596,13 @@ class Update implements Saveable {
                     helper.sortOption = 5;
                 }
             });
+
+            // Fix pokerus status for party members infected via shop eggs
+            saveData.party.caughtPokemon.forEach(pokemon => {
+                if (pokemon[PartyPokemonSaveKeys.pokerus] === GameConstants.Pokerus.Infected && !pokemon[PartyPokemonSaveKeys.breeding]) {
+                    pokemon[PartyPokemonSaveKeys.pokerus] = GameConstants.Pokerus.Contagious;
+                }
+            });
         },
     };
 

--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -149,9 +149,6 @@ class Egg implements Saveable {
             if (partyPokemon.pokerus == GameConstants.Pokerus.Infected) {
                 partyPokemon.pokerus = GameConstants.Pokerus.Contagious;
             }
-            if (partyPokemon.evs() >= 50 && partyPokemon.pokerus == GameConstants.Pokerus.Contagious) {
-                partyPokemon.pokerus = GameConstants.Pokerus.Resistant;
-            }
         }
 
         if (shiny) {

--- a/src/scripts/breeding/Egg.ts
+++ b/src/scripts/breeding/Egg.ts
@@ -143,12 +143,14 @@ class Egg implements Saveable {
                 partyPokemon.level = 1;
                 partyPokemon.breeding = false;
                 partyPokemon.level = partyPokemon.calculateLevelFromExp();
-                if (partyPokemon.pokerus == GameConstants.Pokerus.Infected) {
-                    partyPokemon.pokerus = GameConstants.Pokerus.Contagious;
-                }
-                if (partyPokemon.evs() >= 50 && partyPokemon.pokerus == GameConstants.Pokerus.Contagious) {
-                    partyPokemon.pokerus = GameConstants.Pokerus.Resistant;
-                }
+            }
+
+            // Update pokerus status
+            if (partyPokemon.pokerus == GameConstants.Pokerus.Infected) {
+                partyPokemon.pokerus = GameConstants.Pokerus.Contagious;
+            }
+            if (partyPokemon.evs() >= 50 && partyPokemon.pokerus == GameConstants.Pokerus.Contagious) {
+                partyPokemon.pokerus = GameConstants.Pokerus.Resistant;
             }
         }
 


### PR DESCRIPTION
Pokemon bred through shop eggs could become infected with pokerus, but would not be set to contagious upon hatching. Fixed this bug and added an update check to set any incorrectly "infected" pokemon to contagious.

## How Has This Been Tested?

Bred various pokemon via shop eggs, updated a save with currently-infected pokemon.
