### PR TITLE
Cap Evolution Egg Steps to 4800 (120 cycles)

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -157,6 +157,7 @@ export const PLATE_VALUE = 100;
 
 // Breeding
 export const EGG_CYCLE_MULTIPLIER = 40;
+export const MAX_EGG_CYCLES = 120;
 export const BREEDING_ATTACK_BONUS = 25;
 export const BREEDING_SHINY_ATTACK_MULTIPLIER = 5;
 

--- a/src/modules/changelog/ChangelogItems.ts
+++ b/src/modules/changelog/ChangelogItems.ts
@@ -14,7 +14,7 @@ const ChangelogItems = [
     new ChangelogUpdate('v0.10.18', new Date(2024, 0, 21)),
     new Changelog(changelogType.NEW, 'New Pokémon'),
     new Changelog(changelogType.NEW, 'Alternate Berrydex viewing mode (enabled in Display settings)'),
-    new Changelog(changelogType.NEW, 'Audio queue when Max Flow has been gathered'),
+    new Changelog(changelogType.NEW, 'Audio cue when Max Flow has been gathered'),
     new Changelog(changelogType.NEW, 'Farm button to invert locked plots'),
     new Changelog(changelogType.CHANGE, 'Hatchery, battle, and clicking performance optimizations'),
     new Changelog(changelogType.CHANGE, 'Pink Bow replaced with Fairy Feather'),

--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -23,7 +23,7 @@ import BerryType from '../enums/BerryType';
 import ItemType from '../enums/ItemType';
 import PokemonType from '../enums/PokemonType';
 import {
-    Region, StoneType, Genders, MaxIDPerRegion, MegaStoneType,
+    Region, StoneType, Genders, MaxIDPerRegion, MegaStoneType, MAX_EGG_CYCLES,
 } from '../GameConstants';
 import BagItem from '../interfaces/BagItem';
 import {
@@ -31435,7 +31435,6 @@ export const pokemonList = createPokemonArray(
 export type PokemonList = typeof pokemonList;
 
 const pokemonNameIndex = {};
-const maxEggCycles = Math.max(...pokemonList.map((p) => p.eggCycles));
 
 // This needs to be initiallised before pokemonMap as some other things rely on it for data
 // Specifically Roamers not sure what else.
@@ -31466,7 +31465,7 @@ pokemonList.forEach((p) => {
             if (evo.ignoreECChange) {
                 poke.eggCycles = Math.max(poke.eggCycles, p.eggCycles);
             } else {
-                poke.eggCycles = Math.min(maxEggCycles, Math.round(p.eggCycles * 1.5));
+                poke.eggCycles = Math.min(MAX_EGG_CYCLES, Math.round(p.eggCycles * 1.5));
             }
 
         });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Maximum egg cycles is currently defined reactively based on the highest known egg cycle Pokémon in the list. This means that adding a new highest-ever egg cycle Pokémon retroactively nerfs all those who would have gone over the previous cap.
In the last update (#5007), placeholder Pokémon were added with 404 egg cycles, triggering this issue to occur.

Also, snuck in a wording fix for the changelog


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Egg Steps for evolutions are effectively uncapped right now. While the change could be to just put the 404s down to 120, this change protects against legitimate >120 egg cycle Pokémon coming from the games


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Exported a `name: eggcycle` list from v10.18 with this fix, and v10.17, and confirmed the only changes were the Mega Pokémon that were changed in #4949

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
