### PR TITLE
Fixed GameHelper date observables

### DIFF
--- a/src/modules/GameHelper.ts
+++ b/src/modules/GameHelper.ts
@@ -10,7 +10,7 @@ export default class GameHelper {
     public static currentTime: KnockoutObservable<Date> = ko.observable(new Date());
     public static today: KnockoutObservable<Date> = ko.observable(GameHelper.getToday());
     public static tomorrow: KnockoutComputed<Date> = ko.pureComputed<Date>(() => {
-        const tomorrow = GameHelper.today();
+        const tomorrow = new Date(GameHelper.today());
         tomorrow.setDate(tomorrow.getDate() + 1);
         return tomorrow;
     });


### PR DESCRIPTION
## Description
The computed `tomorrow` modifies the object of the observable it is bound to instead of a copy.

## Motivation and Context
[Max Raid Tempbattles had issues.](https://discord.com/channels/450412847017754644/1198943997368991794)

## How Has This Been Tested?
See screenshot.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/68825215/f91929de-13ae-481e-a00c-9dbe154b8671)

## Types of changes
- Bug fix
