### PR TITLE
Replacing multiple notifications when removing all Vitamins with just one notification

### DIFF
--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -91,11 +91,21 @@ class PartyController {
             }
         }
 
+        let arePokemonInHatchery = false;
         App.game.party.caughtPokemon.forEach((p) => {
-            if (p.vitaminsUsed[vitamin]() > 0) {
+            if (p.vitaminsUsed[vitamin]() > 0 && !p.breeding) {
                 p.removeVitamin(vitamin, amount);
             }
+            if (p.breeding && !arePokemonInHatchery) {
+                arePokemonInHatchery = true;
+            }
         });
+        if (arePokemonInHatchery) {
+            Notifier.notify({
+                message: `${GameConstants.VitaminType[vitamin]} couldn\'t be modified for Pokémon in Hatchery or Queue.`,
+                type: NotificationConstants.NotificationOption.warning,
+            });
+        }
     }
 
     public static async removeAllVitaminsFromParty(shouldConfirm = true) {
@@ -111,13 +121,23 @@ class PartyController {
         }
 
         const vitamins = GameHelper.enumNumbers(GameConstants.VitaminType);
+        let arePokemonInHatchery = false;
         App.game.party.caughtPokemon.forEach((p) => {
             vitamins.forEach((v) => {
-                if (p.vitaminsUsed[v]() > 0) {
+                if (p.vitaminsUsed[v]() > 0 && !p.breeding) {
                     p.removeVitamin(v, Infinity);
+                }
+                if (p.breeding && !arePokemonInHatchery) {
+                    arePokemonInHatchery = true;
                 }
             });
         });
+        if (arePokemonInHatchery) {
+            Notifier.notify({
+                message: 'Vitamins couldn\'t be modified for Pokémon in Hatchery or Queue.',
+                type: NotificationConstants.NotificationOption.warning,
+            });
+        }
     }
 
     public static getMaxLevelPokemonList(): Array<PartyPokemon> {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
When you remove all vitamins (or all of a kind of vitamin), you'll get up to 3 notifications per each Pokémon in the Hatchery/Queue, this PR changes that so it only shows a single notification if a Pokémon's vitamins couldn't be modified.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
There is no point for multiple notifications with the same message, plus you won't be able to see them all if you have several Pokémon in the Hatchery.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
In the "All Vitamins" modal, I clicked every "Removed All" button.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
Before:
![image](https://github.com/pokeclicker/pokeclicker/assets/104547700/c004a884-cc25-4fb1-a7db-65ea9e2a52b7)
After:
![image](https://github.com/pokeclicker/pokeclicker/assets/104547700/e2fccfca-ae26-4d22-85e9-688b2811e654)



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
