### PR TITLE
Fix broken Knockout extenders (and hatchery filters)

### DIFF
--- a/src/modules/DataStore/StatisticStore/getRouteKillsProxy.ts
+++ b/src/modules/DataStore/StatisticStore/getRouteKillsProxy.ts
@@ -1,4 +1,5 @@
-import { Observable } from 'knockout';
+import type { Observable } from 'knockout';
+import '../../koExtenders';
 import * as GameConstants from '../../GameConstants';
 
 const failedSetValue = () => 0;

--- a/src/modules/DataStore/StatisticStore/index.ts
+++ b/src/modules/DataStore/StatisticStore/index.ts
@@ -1,4 +1,4 @@
-import { Observable as KnockoutObservable } from 'knockout';
+import type { Observable as KnockoutObservable } from 'knockout';
 import getRouteKillsProxy from './getRouteKillsProxy';
 import { Saveable } from '../common/Saveable';
 import '../../koExtenders';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -4,5 +4,8 @@ import './polyfill';
 // Ensure that the Knockout Extenders are injected
 import './koExtenders';
 
+// Inject the Knockout bindingHandlers (may load other local modules due to imports)
+import './koBindingHandlers';
+
 // Load everything else
 import './temporaryWindowInjection';

--- a/src/modules/items/ConsumableController.ts
+++ b/src/modules/items/ConsumableController.ts
@@ -1,3 +1,4 @@
+import '../koExtenders';
 import { ConsumableType } from '../GameConstants';
 
 export default class ConsumableController {

--- a/src/modules/items/VitaminController.ts
+++ b/src/modules/items/VitaminController.ts
@@ -1,3 +1,4 @@
+import '../koExtenders';
 import { VitaminType } from '../GameConstants';
 
 export default class VitaminController {

--- a/src/modules/koBindingHandlers.d.ts
+++ b/src/modules/koBindingHandlers.d.ts
@@ -1,0 +1,8 @@
+export declare module 'knockout' {
+    export interface BindingHandlers {
+        contentEditable;
+        playerSpriteMove;
+        sortable;
+        resizable;
+    }
+}

--- a/src/modules/koBindingHandlers.ts
+++ b/src/modules/koBindingHandlers.ts
@@ -3,7 +3,7 @@
 import Sortable from 'sortablejs';
 import Settings from './settings/Settings';
 
-ko.bindingHandlers.contentEditable = {
+const contentEditableHandler = {
     init: (element: HTMLElement, valueAccessor) => {
         const value = valueAccessor();
 
@@ -45,7 +45,7 @@ function handleVisibleElement(element) {
     }
 }
 
-ko.bindingHandlers.playerSpriteMove = {
+const playerSpriteMoveHandler = {
     init: function (element) {
         const observer = new MutationObserver((mutationsList) => {
             for (const mutation of mutationsList) {
@@ -75,7 +75,7 @@ ko.bindingHandlers.playerSpriteMove = {
 //TODO END
 
 const sortableControllers = new WeakMap();
-ko.bindingHandlers.sortable = {
+const sortableHandler = {
     init: function (element, valueAccessor, allBindings, viewModel) {
         sortableControllers.set(element, null);
         const value = valueAccessor();
@@ -143,7 +143,7 @@ const moduleResizeObserver = new ResizeObserver((entries) => {
     });
 });
 
-ko.bindingHandlers.resizable = {
+const resizableHandler = {
     init: function (element, valueAccessor) {
         const value = valueAccessor();
         element.classList.add('resizable-container');
@@ -152,3 +152,10 @@ ko.bindingHandlers.resizable = {
         moduleResizeObserver.observe(element);
     },
 };
+
+Object.assign(ko.bindingHandlers, {
+    contentEditable: contentEditableHandler,
+    playerSpriteMove: playerSpriteMoveHandler,
+    sortable: sortableHandler,
+    resizable: resizableHandler,
+});

--- a/src/modules/koBindingHandlers.ts
+++ b/src/modules/koBindingHandlers.ts
@@ -1,0 +1,154 @@
+/// <reference path="./koBindingHandlers.d.ts" />
+
+import Sortable from 'sortablejs';
+import Settings from './settings/Settings';
+
+ko.bindingHandlers.contentEditable = {
+    init: (element: HTMLElement, valueAccessor) => {
+        const value = valueAccessor();
+
+        function onBlur() {
+            if (ko.isWriteableObservable(value)) {
+                value(this.textContent);
+            }
+        }
+
+        element.textContent = value();
+        element.contentEditable = 'true';
+        element.addEventListener('blur', onBlur);
+    },
+};
+
+//Fixes the PlayerSVG rendering beneath other SVGs by rerendering the current PlayerSVG in the forefront. #4306
+//TODO: Replace with logic that maintains a singular PlayerSpriteSVG (Might be performance costly over a simple observer)
+function handleVisibleElement(element) {
+    if (element.classList.contains('iconLocation')) {
+        if (element.classList.contains('iconLocation')) {
+            var targetElement = document.getElementById('playerSprite');
+            var imageElement = element.cloneNode(true);
+            imageElement.classList.remove('hide');
+
+            targetElement.innerHTML = '';
+            targetElement.appendChild(imageElement);
+
+            //Get required variables to replicate the rotate on parent group as well
+            var rotate = imageElement.getAttribute('rotate');
+            var x = imageElement.getAttribute('localx');
+            var y = imageElement.getAttribute('localy');
+
+            if (rotate) {
+                targetElement.setAttribute('transform', 'rotate(90,' + x + ', ' + y + ')');
+            } else {
+                targetElement.setAttribute('transform', '');
+            }
+        }
+    }
+}
+
+ko.bindingHandlers.playerSpriteMove = {
+    init: function (element) {
+        const observer = new MutationObserver((mutationsList) => {
+            for (const mutation of mutationsList) {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+                    const target = mutation.target as HTMLElement;
+                    const displayStyle = window.getComputedStyle(target).getPropertyValue('display');
+
+                    const isVisible = displayStyle !== 'none';
+                    if (isVisible) {
+                        handleVisibleElement(element);
+                    }
+                }
+            }
+        });
+
+        // Observe changes to the 'style' attribute of the target element
+        observer.observe(element, { attributes: true });
+
+        // Trigger initial visibility check on load
+        const displayStyle = window.getComputedStyle(element).getPropertyValue('display');
+        const isVisible = displayStyle !== 'none';
+        if (isVisible) {
+            handleVisibleElement(element);
+        }
+    },
+};
+//TODO END
+
+const sortableControllers = new WeakMap();
+ko.bindingHandlers.sortable = {
+    init: function (element, valueAccessor, allBindings, viewModel) {
+        sortableControllers.set(element, null);
+        const value = valueAccessor();
+        ko.applyBindingsToNode(element, {
+            template: {
+                ...value,
+                afterRender(nodes, el) {
+                    nodes.forEach((n) => {
+                        if (n.dataset) {
+                            n.dataset.sortableId = value.options.getId(el);
+                        }
+                    });
+                },
+                beforeRemove(node: HTMLElement, idx, el) {
+                    // Sortable may have cloned the node, so we need to get the real one
+                    const found = element.querySelector(`[data-sortable-id="${value.options.getId(el)}"]`);
+                    (found ?? node)?.remove();
+                },
+            },
+        }, viewModel);
+        return { controlsDescendantBindings: true };
+    },
+    update: function (element, valueAccessor) {
+        const value = ko.unwrap(valueAccessor());
+        const options = {
+            // defaults
+            animation: 100,
+            sort: true,
+            delay: 500,
+            delayOnTouchOnly: true,
+            touchStartThreshold: 20,
+
+            // override with options passed through knockout binding
+            ...(value.options ?? {}),
+            dataIdAttr: 'data-sortable-id',
+
+            // handle updating underlying knockout array when moving items
+            onEnd: (evt, originalEvt) => {
+                value.options?.onEnd?.(evt, originalEvt);
+
+                const { oldIndex, newIndex } = evt;
+                const list = [...value.foreach()];
+                const movedItem = list.splice(oldIndex, 1)[0];
+
+                const newList = [
+                    ...list.slice(0, newIndex),
+                    movedItem,
+                    ...list.slice(newIndex),
+                ];
+                value.foreach(newList);
+            },
+        };
+
+        sortableControllers.set(element, Sortable.create(element, options));
+    },
+};
+
+const moduleResizeObserver = new ResizeObserver((entries) => {
+    entries.forEach((entry) => {
+        const height = entry.target.getBoundingClientRect().height;
+        if (height > 0) {
+            const resizeId = (entry.target as HTMLElement).dataset.resizeId;
+            Settings.setSettingByName(`moduleHeight.${resizeId}`, height);
+        }
+    });
+});
+
+ko.bindingHandlers.resizable = {
+    init: function (element, valueAccessor) {
+        const value = valueAccessor();
+        element.classList.add('resizable-container');
+        element.style.height = `${Settings.getSetting(`moduleHeight.${value.setting}`).value}px`;
+        element.dataset.resizeId = value.setting;
+        moduleResizeObserver.observe(element);
+    },
+};

--- a/src/modules/koExtenders.d.ts
+++ b/src/modules/koExtenders.d.ts
@@ -1,3 +1,5 @@
+import { Subscribable } from 'knockout';
+
 export declare module 'knockout' {
     export interface ExtendersOptions {
         numeric: number;
@@ -8,7 +10,9 @@ export declare module 'knockout' {
 }
 
 declare global {
-    interface SkippableRateLimit {
+    interface SkippableRateLimit extends Subscribable<unknown> {
         evaluateEarly: () => void;
     }
 }
+
+export { };

--- a/src/modules/koExtenders.d.ts
+++ b/src/modules/koExtenders.d.ts
@@ -5,10 +5,6 @@ export declare module 'knockout' {
         arrayEquals: true;
         skippableRateLimit: number;
     }
-
-    export interface BindingHandlers {
-        contentEditable;
-    }
 }
 
 declare global {

--- a/src/modules/koExtenders.ts
+++ b/src/modules/koExtenders.ts
@@ -1,4 +1,3 @@
-// /* eslint-disable no-param-reassign */
 /// <reference path="./koExtenders.d.ts" />
 
 import type { Subscribable, Observable, Computed } from 'knockout';
@@ -15,7 +14,7 @@ import type { Subscribable, Observable, Computed } from 'knockout';
 */
 
 // Only numeric values allowed - usage: ko.observable(0).extend({ numeric: 0 });
-ko.extenders.numeric = (target: Subscribable, precision: number) => {
+const numericExtender = (target: Subscribable, precision: number) => {
     // create a writable computed observable to intercept writes to our observable
     const result = ko.pureComputed<number>({
         read: target, // always return the original observable's value
@@ -45,7 +44,7 @@ ko.extenders.numeric = (target: Subscribable, precision: number) => {
     return result;
 };
 
-ko.extenders.boolean = (target: Subscribable) => {
+const booleanExtender = (target: Subscribable) => {
     // create a writable computed observable to intercept writes to our observable
     const result = ko.pureComputed<boolean>({
         read: target, // always return the original observable's value
@@ -63,7 +62,7 @@ ko.extenders.boolean = (target: Subscribable) => {
 
 // Don't treat shallowly-equal arrays as new values, i.e. don't notify subscribers
 // Usage: ko.observable([]).extend({ arrayEquals: true });
-ko.extenders.arrayEquals = (target: Observable<any[]> | Computed<any[]>) => {
+const arrayEqualsExtender = (target: Observable<any[]> | Computed<any[]>) => {
     const defaultComparer = target.equalityComparer;
     target.equalityComparer = function (a, b) {
         if (Array.isArray(a) && Array.isArray(b)) {
@@ -79,7 +78,7 @@ ko.extenders.arrayEquals = (target: Observable<any[]> | Computed<any[]>) => {
 // A modified version of the rateLimit extender that can be forced to evaluate early
 // Usage: const example = ko.pureComputed(() => { whatever }).extend({ skippableRateLimit: GameConstants.WEEK });
 //        example.evaluateEarly();
-ko.extenders.skippableRateLimit = (target: Subscribable, delay: number) => {
+const skippableRateLimitExtender = (target: Subscribable, delay: number): typeof target & SkippableRateLimit => {
     // Custom rate limiter function, see https://knockoutjs.com/documentation/rateLimit-observable.html#custom-rate-limit-methods
     const skippableLimiter = (callback, timeout) => {
         var timeoutInstance = null;
@@ -118,3 +117,10 @@ ko.extenders.skippableRateLimit = (target: Subscribable, delay: number) => {
     };
     return target.extend({ rateLimit: { timeout: delay, method: skippableLimiter } }) as typeof target & SkippableRateLimit;
 };
+
+Object.assign(ko.extenders, {
+    numeric: numericExtender,
+    boolean: booleanExtender,
+    arrayEquals: arrayEqualsExtender,
+    skippableRateLimit: skippableRateLimitExtender,
+});

--- a/src/modules/logbook/LogBook.ts
+++ b/src/modules/logbook/LogBook.ts
@@ -1,5 +1,6 @@
 /* eslint-disable class-methods-use-this */
-import { Observable, ObservableArray, PureComputed } from 'knockout';
+import type { Observable, ObservableArray, PureComputed } from 'knockout';
+import '../koExtenders';
 import { Feature } from '../DataStore/common/Feature';
 import { LogContent } from './helpers';
 import LogBookLog from './LogBookLog';

--- a/src/modules/oakItems/OakItemLoadouts.ts
+++ b/src/modules/oakItems/OakItemLoadouts.ts
@@ -1,7 +1,8 @@
-import {
+import type {
     Observable as KnockoutObservable,
     Computed as KnockoutComputed,
 } from 'knockout';
+import '../koExtenders';
 import { Saveable } from '../DataStore/common/Saveable';
 import OakItemType from '../enums/OakItemType';
 import OakItemLoadout from './OakItemLoadout';

--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -1,4 +1,5 @@
-import {
+import '../koExtenders';
+import type {
     Observable as KnockoutObservable,
 } from 'knockout';
 import { Saveable } from '../DataStore/common/Saveable';

--- a/src/modules/saveReminder/SaveReminder.ts
+++ b/src/modules/saveReminder/SaveReminder.ts
@@ -1,6 +1,7 @@
-import {
+import type {
     Observable as KnockoutObservable,
 } from 'knockout';
+import '../koExtenders';
 import { Saveable } from '../DataStore/common/Saveable';
 import * as GameConstants from '../GameConstants';
 import Notifier from '../notifications/Notifier';

--- a/src/modules/settings/BreedingFilters.ts
+++ b/src/modules/settings/BreedingFilters.ts
@@ -1,3 +1,4 @@
+import '../koExtenders';
 import PokemonType from '../enums/PokemonType';
 import { Pokerus } from '../GameConstants';
 import SettingOption from './SettingOption';

--- a/src/modules/settings/PokedexFilters.ts
+++ b/src/modules/settings/PokedexFilters.ts
@@ -1,3 +1,4 @@
+import '../koExtenders';
 import PokemonType from '../enums/PokemonType';
 import { Pokerus, Region } from '../GameConstants';
 import SettingOption from './SettingOption';

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -1,4 +1,5 @@
 import type { Observable, Computed } from 'knockout';
+import '../koExtenders';
 import { Feature } from '../DataStore/common/Feature';
 import { Currency, EnergyRestoreSize, EnergyRestoreEffect, PLATE_VALUE } from '../GameConstants';
 import GameHelper from '../GameHelper';

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -100,7 +100,7 @@ class BreedingController {
         hatcherySettingObervables.forEach((setting) => {
             setting.subscribe(() => {
                 BreedingController.viewResetWaiting(true);
-                (BreedingController.hatcherySortedFilteredList as unknown as SkippableRateLimit).evaluateEarly();
+                BreedingController.hatcherySortedFilteredList.evaluateEarly();
             });
         });
 
@@ -229,7 +229,7 @@ class BreedingController {
     }).extend({ arrayEquals: true }); // Only notify subscribers when the array contents change, i.e. not on every "has sort order changed" check
 
     // Sorted list of pokemon that match hatchery filters
-    private static hatcherySortedFilteredList: KnockoutComputed<PartyPokemon[]> = ko.pureComputed(() => {
+    private static hatcherySortedFilteredList = ko.pureComputed(() => {
         const hatcheryList = Array.from(BreedingController.hatcheryFilteredList());
         // Don't adjust attack based on region if debuff is disabled
         const region = App.game.challenges.list.regionalAttackDebuff.active() ? BreedingController.regionalAttackDebuff() : -1;
@@ -240,7 +240,7 @@ class BreedingController {
             BreedingController.viewResetReady = true;
         }
         return hatcheryList;
-    }).extend({ skippableRateLimit: 500 });  // Lets us rerender immediately after filter changes
+    }).extend({ skippableRateLimit: 500 }) as KnockoutComputed<PartyPokemon[]> & SkippableRateLimit;  // Lets us rerender immediately after filter changes
 
     // Filters for pokemon that match hatchery filters
     private static hatcheryFilteredList: KnockoutComputed<PartyPokemon[]> = ko.pureComputed(() => {


### PR DESCRIPTION
Fixed hatchery filters initially not working after loading the game. As it turns out, this wasn't related to the hatchery improvements at all! The custom extenders the filters use had broken completely.

The culprit was the new bindingHandlers added in #4894. The handlers work as intended, but importing from Settings inadvertently loaded most of the game's modules before the custom extenders got created. And for some stupid reason Knockout doesn't throw any errors if you try to use an extender that doesn't exist (yet).

Fixes #5043.

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

I moved all the bindingHandlers to their own separate file, so they can use imports without interfering with the top-priority extenders. I also imported `koExtenders.ts` in all the modules that currently use custom extenders; this way the dependencies are visible if we ever want to add a build step that rejects circular dependencies.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Checked the new dependency tree, confirmed the game loads, confirmed the BreedingFilter extenders are now present and the filters operating correctly. 