### PR TITLE
Fix tutorial pokeball selector prompt

### DIFF
--- a/src/components/pokeballSelector.html
+++ b/src/components/pokeballSelector.html
@@ -26,7 +26,7 @@
                         </tr>
                     </thead>
                     <tbody id="pokeballFilters" data-bind="foreach: App.game.pokeballFilters.displayList">
-                        <tr data-bind="css: { 'pokeballFilterDisabled': !$data.enabled() }">
+                        <tr data-bind="css: { 'pokeballFilterDisabled': !$data.enabled() }, attr: { 'data-name': $data.name }">
                             <td><span data-bind="
                                 text: $data.name,
                                 tooltip: {

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -43,7 +43,7 @@ class QuestLineHelper {
                     exitOnEsc: false,
                     showButtons: false,
                 });
-                const caughtSelector: HTMLElement = document.querySelector('.pokeball-small.clickable.pokeball-selected');
+                const caughtSelector: HTMLElement = document.querySelector('tr[data-name="Caught"] img.pokeball-small.clickable.pokeball-selected');
                 caughtSelector.addEventListener('click', () => {
                     Information.hide();
                     $('#pokeballSelectorModal').one('shown.bs.modal', null, () => {


### PR DESCRIPTION
## Description
During the tutorial the player would be prompted to select the "Caught" pokeball filter and choose a pokeball. When #4990 was merged the default order for new files changed from bottom-to-top, with Caught at the top, to top-to-bottom, with Caught at the bottom. This changed cause the prompt to continue when the player selected the 'New Shiny' ball rather than the 'Caught' ball.

## How Has This Been Tested?
Started a new game and progressed in the tutorial

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/316fa183-aca5-4d6d-8509-c2a231b4734f)

## Types of changes
- Bug fix
