### PR TITLE
Prevent interacting with resizable modules through modals

### DIFF
--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -823,6 +823,10 @@ button.btn-circle {
     resize: vertical;
     overflow: auto;
     min-height: 50px;
+
+    .modal-open & {
+        pointer-events: none;
+    }
 }
 
 .lazy-loader-container {


### PR DESCRIPTION
## Description
This seems to affect the client only, the resize handles for the pokeball selector and pokemon list could be interacted with through modals. See screen recording below.

## How Has This Been Tested?
Loaded the game, resized the pokeball selector, opened the underground modal, could no longer interact with the resize handle.

## Screenshots (optional):
https://github.com/pokeclicker/pokeclicker/assets/672420/c754618c-0bf5-413c-b1d5-f0eed051cf85

## Types of changes
- Bug fix