### PR TITLE
Some minor QoL improvements

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -87,6 +87,7 @@
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('confirmLeaveDungeon')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('confirmBeformeMulchingAllPlots')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('breedingQueueClearConfirmation')}"></tr>
+                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('confirmChangeHeldItem')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('disableRightClickMenu')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('catchFilters.initialEnabled')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('catchFilters.invertPriorityOrder')}"></tr>

--- a/src/components/templates/currencyContainerCurrencyTemplate.html
+++ b/src/components/templates/currencyContainerCurrencyTemplate.html
@@ -7,6 +7,14 @@
                 trigger: 'hover',
                 placement: 'top'
             }">
-        <div class="" data-bind="text: App.game.wallet.amountText($data.currency), attr: { id: `animateCurrency-${Currency[$data.currency]}` }">0</div>
+        <div class="" data-bind="text: App.game.wallet.amountText($data.currency),
+            attr: { id: `animateCurrency-${Currency[$data.currency]}` },
+            tooltip: {
+                title: Settings.getSetting('currencyMainDisplayReduced').observableValue()
+                    ? App.game.wallet.currencies[$data.currency]().toLocaleString('en-US')
+                    : '',
+                trigger: 'hover',
+                placement: 'bottom'
+            }">0</div>
     </div>
 </script>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -69,7 +69,6 @@ Settings.add(new Setting<string>('breedingDisplay', 'Breeding progress display',
         new SettingOption('Step count', 'stepCount'),
     ],
     'stepCount'));
-Settings.add(new BooleanSetting('breedingQueueClearConfirmation', 'Confirm before clearing the hatchery queue', true));
 Settings.add(new Setting<string>('shopButtons', 'Shop amount buttons',
     [
         new SettingOption('+10, +100', 'original'),
@@ -127,6 +126,8 @@ Settings.add(new BooleanSetting('currencyMainDisplayReduced', 'Shorten currency 
 Settings.add(new BooleanSetting('currencyMainDisplayExtended', 'Show Diamonds, Farm Points, Battle Points, and Contest Tokens on main screen', false));
 Settings.add(new BooleanSetting('confirmLeaveDungeon', 'Confirm before leaving dungeons', false));
 Settings.add(new BooleanSetting('confirmBeformeMulchingAllPlots', 'Confirm before mulching all plots', false));
+Settings.add(new BooleanSetting('breedingQueueClearConfirmation', 'Confirm before clearing the hatchery queue', true));
+Settings.add(new BooleanSetting('confirmChangeHeldItem', 'Confirm before removing or replacing a Held Item', true));
 Settings.add(new BooleanSetting('showGymGoAnimation', 'Show Gym GO animation', true));
 Settings.add(new Setting<string>('gameDisplayStyle', 'Game display style',
     [

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -90,7 +90,8 @@ class FarmHand {
 
         this.tooltip = ko.pureComputed(() => `<strong>${this.name}</strong><br/>
             Energy: ${this.energy()}/${this.maxEnergy}<br/>
-            Work Cycle: ${GameConstants.formatTimeFullLetters((this.workTick - this.workTicks()) / 1000)}`
+            Work Cycle: ${GameConstants.formatTimeFullLetters((this.workTick - this.workTicks()) / GameConstants.SECOND)}<br/>
+            Next Payment: ${GameConstants.formatTimeFullLetters((this.costTick - this.costTicks()) / GameConstants.SECOND)}`
         );
     }
 

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -492,7 +492,7 @@ class PartyPokemon implements Saveable {
             }
         }
 
-        if (this.heldItem()) {
+        if (this.heldItem() && Settings.getSetting('confirmChangeHeldItem').value) {
             Notifier.confirm({
                 title: 'Remove held item',
                 message: 'Held items are one time use only.\nRemoved items will be lost.\nAre you sure you want to remove it?',


### PR DESCRIPTION
## Description
Three minor changes:
- Show full currency amount in tooltip when the shorten currency setting is enabled and hovering on the shortened amount
- Setting to disable the confirmation before removing or replacing a held item
- Show time until next payment in the hired farm hand tooltip

## How Has This Been Tested?
Loaded the game and verified all changes were working as expected

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/520b6f56-ddf4-404a-aa07-2424773095a3)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/793403f5-8621-426e-8521-37833fdbf323)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/790a4b2e-3f4c-497f-8f0a-3bf3e431618e)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/9e66ba60-7760-459d-94bd-ba45205ed4a6)
