### PR TITLE
Slightly improve applyRouteBindings() performance

### DIFF
--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -3,7 +3,7 @@
  */
 class GameController {
     static applyRouteBindings() {
-        $('path, rect').hover(function () {
+        $('path, rect', $('#map')).hover(function () {
             let tooltipText = $(this).attr('data-town');
             const route = $(this).attr('data-route');
             if (route) {

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -3,7 +3,7 @@
  */
 class GameController {
     static applyRouteBindings() {
-        $('path, rect', $('#map')).hover(function () {
+        $('#map path, #map rect').hover(function () {
             let tooltipText = $(this).attr('data-town');
             const route = $(this).attr('data-route');
             if (route) {


### PR DESCRIPTION
Change GameController.applyRouteBindings() to only look for tooltip bindings inside the town map element, which should be slightly faster.
