### PR TITLE
Adds PKRS and Caught status to all ShardShop and GemMaster modals

### DIFF
--- a/src/components/gemMasterModal.html
+++ b/src/components/gemMasterModal.html
@@ -59,6 +59,13 @@
                                                             'evs': App.game.party.getPokemonByName($parent.item.itemType.type)?.evs() }}">
                                                     </span>
                                                 </knockout>
+                                                <knockout data-bind="if: ($parent.item.itemType instanceof EvolutionStone)">
+                                                    <span style="position: relative; top: -1px;"
+                                                          data-bind="template: { name: 'pokerusStatusTemplate', data: {
+                                                            'pokerus': $parent.item.itemType.getPokerusStatus(), 'width': '32px',
+                                                            'evsProgress': $parent.item.itemType.getPokerusProgress() }}">
+                                                    </span>
+                                               </knockout>
                                             </span>
                                         </td>
                                         <td class='vertical-middle' data-bind="attr: { rowspan: $parent.gems.length }">

--- a/src/components/shardTraderModal.html
+++ b/src/components/shardTraderModal.html
@@ -49,7 +49,28 @@
                                                 src: $parent.item.itemType.image
                                             }">
                                         </td>
-                                        <td class='vertical-middle' data-bind='attr: { rowspan: $parent.shards.length }, text: $parent.item.amount + " × " + $parent.item.itemType.displayName'></td>
+                                        <td class='vertical-middle' data-bind='attr: { rowspan: $parent.shards.length }'>
+                                            <span data-bind='text: $parent.item.amount + " × " + $parent.item.itemType.displayName'></span>
+                                            <span style="float: right; margin-right: 5px">
+                                                <knockout data-bind="if: ($parent.item.itemType instanceof CaughtIndicatingItem)">
+                                                    <span data-bind="template: { name: 'caughtStatusTemplate', data: {'status': $parent.item.itemType.getCaughtStatus()}}"></span>
+                                                </knockout>
+                                                <knockout data-bind="if: ($parent.item.itemType instanceof PokemonItem)">
+                                                    <span style="position: relative; top: -1px;"
+                                                          data-bind="template: { name: 'pokerusStatusTemplate', data: {
+                                                            'pokerus': $parent.item.itemType.getPokerusStatus(), 'width': '32px',
+                                                            'evs': App.game.party.getPokemonByName($parent.item.itemType.type)?.evs() }}">
+                                                    </span>
+                                                </knockout>
+                                                <knockout data-bind="if: ($parent.item.itemType instanceof EvolutionStone)">
+                                                    <span style="position: relative; top: -1px;"
+                                                          data-bind="template: { name: 'pokerusStatusTemplate', data: {
+                                                            'pokerus': $parent.item.itemType.getPokerusStatus(), 'width': '32px',
+                                                            'evsProgress': $parent.item.itemType.getPokerusProgress() }}">
+                                                    </span>
+                                               </knockout>
+                                            </span>
+                                        </td>
                                         <td class='vertical-middle' data-bind="attr: { rowspan: $parent.shards.length, hidden: ShopHandler.shopObservable().hidePlayerInventory }, text: player.itemList[$parent.item.itemType.name]().toLocaleString('en-US')"></td>
                                         <td class='vertical-middle' data-bind="attr: { rowspan: $parent.shards.length }">
                                             <div class="btn-group btn-block" data-bind="let: { tradeAmount: ko.observable(1) }">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
- Added a **_Pokerus_** and a **_caught_** indicator to all Shard shops (similar as in Gem Masters and other Shops)
- This will apply to all ShopMon, Evolution Stones and Eggs. It will also impact the Fossil Master (as it is coded as a Shard Shop).

- Also preventively added the PKRS indicator for EvolutionStone in GemMaster (even if there is no such use case for now)



## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
I was annoyed that there is a difference between the Shard Trader and Gem Trader in Parfum Palace in Kalos.
So I unified the Modals to both have the indicators. This gives a clear view on which Pokémon are already caught and resisted.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I checked different Shard Shops, Fossil Master, and verified that the indicators are correctly set.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
### Before :
<img src="https://github.com/pokeclicker/pokeclicker/assets/5937559/a623babf-4724-4f69-b05d-213288f18973" width="600">

### After :
<img src="https://github.com/pokeclicker/pokeclicker/assets/5937559/ce8f4cab-9995-4f5a-866e-0baa3f302670" width="600">

### Before :
<img src="https://github.com/pokeclicker/pokeclicker/assets/5937559/db1af581-ae33-46d4-93f8-f08f60d2d260" width="600">

### After :
<img src="https://github.com/pokeclicker/pokeclicker/assets/5937559/c1772a16-2d87-455f-bc1e-3d10c68f3d2c" width="600">


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
