### PR TITLE
Made Battle Frontier use Clear Weather

### DIFF
--- a/src/components/battleFrontierInfo.html
+++ b/src/components/battleFrontierInfo.html
@@ -9,6 +9,7 @@
         <h5>Welcome to the Battle Frontier!</h5>
         <p>
             Here you will be battling through many stages to earn Battle Points.<br/>
+            There is no damage debuff and no weather bonus.<br/>
             You can leave early and return to your checkpoint later on.<br/>
             You'll get special items if you reach special milestone stages.<br/>
             When you are ready, click Start!<br/>

--- a/src/components/battleFrontierInfo.html
+++ b/src/components/battleFrontierInfo.html
@@ -9,7 +9,7 @@
         <h5>Welcome to the Battle Frontier!</h5>
         <p>
             Here you will be battling through many stages to earn Battle Points.<br/>
-            There is no damage debuff and no weather bonus.<br/>
+            There is no damage debuff and the weather has no effect.<br/>
             You can leave early and return to your checkpoint later on.<br/>
             You'll get special items if you reach special milestone stages.<br/>
             When you are ready, click Start!<br/>

--- a/src/components/battleFrontierInfo.html
+++ b/src/components/battleFrontierInfo.html
@@ -9,7 +9,7 @@
         <h5>Welcome to the Battle Frontier!</h5>
         <p>
             Here you will be battling through many stages to earn Battle Points.<br/>
-            There is no damage debuff and the weather has no effect.<br/>
+            There is no regional attack debuff or weather effects.<br/>
             You can leave early and return to your checkpoint later on.<br/>
             You'll get special items if you reach special milestone stages.<br/>
             When you are ready, click Start!<br/>

--- a/src/components/battleFrontierView.html
+++ b/src/components/battleFrontierView.html
@@ -54,6 +54,10 @@
                                         Battle.enemyPokemon().type1,
                                         Battle.enemyPokemon().type2,
                                         true,
+                                        GameConstants.Region.none,
+                                        false,
+                                        false, 
+                                        WeatherType.Clear,
                                     ).toLocaleString('en-US')} against ${Battle.enemyPokemon().name}`
                                     : '',
                                 trigger: 'hover'}">

--- a/src/components/battleFrontierView.html
+++ b/src/components/battleFrontierView.html
@@ -43,6 +43,10 @@
                                 PokemonType.None,
                                 PokemonType.None,
                                 true,
+                                GameConstants.Region.none,
+                                false,
+                                false, 
+                                WeatherType.Clear,
                             ).toLocaleString('en-US'),
                             tooltip: {
                                 title: Battle.enemyPokemon()

--- a/src/scripts/battleFrontier/BattleFrontierBattle.ts
+++ b/src/scripts/battleFrontier/BattleFrontierBattle.ts
@@ -27,7 +27,7 @@ class BattleFrontierBattle extends Battle {
         if (!this.enemyPokemon()?.isAlive()) {
             return;
         }
-        this.enemyPokemon().damage(App.game.party.calculatePokemonAttack(this.enemyPokemon().type1, this.enemyPokemon().type2, true));
+        this.enemyPokemon().damage(App.game.party.calculatePokemonAttack(this.enemyPokemon().type1, this.enemyPokemon().type2, true, GameConstants.Region.none, false, false, WeatherType.Clear));
         if (!this.enemyPokemon().isAlive()) {
             this.defeatPokemon();
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Battle Frontier now is set to always calculate damage with Clear weather. Also added a line to the description to inform players of this, plus the fact that there is no regional attack debuff present in this building.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Battle Frontier uses None damage so I thought it should also use Clear weather. So, the only randomness you will get will be the enemy Pokémon.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Battle Frontier. I went there. I checked the tooltips, the damage displayed, and the damage done.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Battle Frontier
- Balance (?)
