### PR TITLE
Solar is a Dark theme

### DIFF
--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -9,7 +9,7 @@
 }
 
 /* Dark themes */
-.cyborg, .darkly, .slate, .superhero {
+.cyborg, .darkly, .slate, .superhero, .solar {
   // make pokeball and gear images lighter
   img[src="assets/images/pokeball/None.svg"], img[src="assets/images/fa-cog.svg"] {
     filter: invert(1) brightness(90%);


### PR DESCRIPTION
## Description
Made Solar a dark theme.

## Motivation and Context
Motivated by that pitch black gear when using Solar.

## How Has This Been Tested?
I used Solar. Also ensured no other CSS or theme broke.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/68825215/067e8c80-fef9-4b36-884a-3a05e6155f81)

## Types of changes
- Solar fix
