### PR TITLE
Fix TextMerger when multiple keys are being merged

### DIFF
--- a/src/modules/utilities/TextMerger.ts
+++ b/src/modules/utilities/TextMerger.ts
@@ -17,7 +17,7 @@ export default class TextMerger {
         mergeSubstrings.forEach((s) => {
             const key = s.substring(1, s.length - 1).toLocaleLowerCase();
             if (this.mergeValues[key]()) {
-                textResult = text.replace(s, this.escapeHtml(this.mergeValues[key]()));
+                textResult = textResult.replace(s, this.escapeHtml(this.mergeValues[key]()));
             }
         });
 


### PR DESCRIPTION
## Description
TextMerger was repeatedly replacing on the original input text, so could only handle a single key

Fixes the `Pokémon Trainer Lillie` temporary battle victory text

## Types of changes
- Bug fix