### PR TITLE
Have special balls fallback to Ultra/Great/Poké if they run out

### DIFF
--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -187,8 +187,6 @@ class Pokeballs implements Feature {
             category: App.game.party.getPokemon(id)?.category,
         })?.ball() ?? GameConstants.Pokeball.None;
 
-        let use: GameConstants.Pokeball = GameConstants.Pokeball.None;
-
         if (pref == GameConstants.Pokeball.Beastball) {
             if (isUltraBeast && this.pokeballs[GameConstants.Pokeball.Beastball].quantity() > 0) {
                 return GameConstants.Pokeball.Beastball;
@@ -201,18 +199,17 @@ class Pokeballs implements Feature {
 
         if (this.pokeballs[pref]?.quantity() > 0) {
             return pref;
-        } else if (pref <= GameConstants.Pokeball.Masterball) {
-            // Check which Pokeballs we have in stock that are of equal or lesser than selection (upto Masterball)
-            for (let i: number = pref; i >= 0; i--) {
+        } else {
+            // Use a lesser, Pokédollar purchaseable, ball if we have one
+            let use: GameConstants.Pokeball = GameConstants.Pokeball.None;
+            const maxToCheck = Math.min(pref, GameConstants.Pokeball.Ultraball);
+            for (let i: number = maxToCheck; i >= 0; i--) {
                 if (this.pokeballs[i].quantity() > 0) {
                     use = i;
                     break;
                 }
             }
             return use;
-        } else {
-            // Use a normal Pokeball or None if we don't have Pokeballs in stock
-            return this.pokeballs[GameConstants.Pokeball.Pokeball].quantity() > 0 ? GameConstants.Pokeball.Pokeball : GameConstants.Pokeball.None;
         }
     }
 


### PR DESCRIPTION
## Description
Updates the Pokéball selection logic to try to use Ultra/Great/Pokéball when a special ball runs out. Given that all the special balls are available far later than Ultras, are are orders of magnitude less common, I feel it makes sense for them to be considered "better" than Ultras in the same way Masterballs are

## How Has This Been Tested?
Tested running out of a few Special balls and the Masterball, confirming it falls back to the 3 purchasable ones (or None) as expected
