### PR TITLE
Fixed Farm submodule breaking eggsteps again...

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -2477,6 +2477,9 @@ export const ModalCollapseList = [
     'pokemonListBody',
     'shortcutsBody',
     'currencyBody',
+    'undergroundCard',
+    'plotListCard',
+    'zCrystalItemContainerBody',
 ];
 
 export enum ConsumableType {


### PR DESCRIPTION
## Description
Kidding !
I just added Farm, UG and Z-Crystal modules to the collapsible module list for settings as they got forgotten.

## Motivation and Context
Collapse status was not saved across loadings.

## How Has This Been Tested?
Reloaded the game a bunch of times with different configurations.
~~Ensured eggsteps stayed the same.~~

## Types of changes
- Bug fix
