### PR TITLE
Added Notifier to Safari if trying to run from Shiny

### DIFF
--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -270,9 +270,21 @@ class SafariBattle {
         }
     }
 
-    public static run() {
+    public static async run() {
         if (Safari.inBattle() && !SafariBattle.busy()) {
             SafariBattle.busy(true);
+            if (SafariBattle.enemy.shiny) {
+                if (!await Notifier.confirm({
+                    title: 'Shiny Encounter',
+                    message: 'Are you sure you want to run away from this battle?',
+                    type: NotificationConstants.NotificationOption.danger,
+                    confirm: 'Yes',
+                    cancel: 'No',
+                })) {
+                    SafariBattle.busy(false);
+                    return;
+                }
+            }
             SafariBattle.text('You flee.');
             SafariBattle.delay(SafariBattle.Speed.turnLength)
                 .then(() => SafariBattle.endBattle());


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Added a Notifier to the Safari's `run()` method in case the Pokémon is a shiny and the player tries to run away.

Closes #5262 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Unlike Route or Dungeon encounters that check for your capture filters and act accordingly, it's way simpler to accidentally run away from a shiny while inside the Safari Zones. This check helps people react to it in case they are constantly running away from battles for any reason.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Went to the Safari Zone. Encountered some shinies and normal Pokémon. Made sure that the run function triggered correctly. Checked that the Notifier only happened if the Pokémon was a shiny. Checked that "yes" and "no" worked accordingly. 


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![shny-safari](https://github.com/pokeclicker/pokeclicker/assets/106291026/01e2d539-439a-4dee-9ee3-0ea7d927ee66)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement (?)
