### PR TITLE
Fix rare Yellow Flute loading crash

### DIFF
--- a/src/modules/achievements/Achievement.ts
+++ b/src/modules/achievements/Achievement.ts
@@ -25,7 +25,7 @@ export default class Achievement {
     ) {}
 
     public check() {
-        if (this.isCompleted()) {
+        if (this.isCompleted() && !this.unlocked()) {
             Notifier.notify({
                 title: `[Achievement] ${this.name}`,
                 message: this.description,

--- a/src/modules/items/ItemHandler.ts
+++ b/src/modules/items/ItemHandler.ts
@@ -95,7 +95,7 @@ export default class ItemHandler {
         });
     }
 
-    public static initilizeEvoStones() {
+    public static initializeItems() {
         // Set our unlock regions
         Object.values(ItemList).forEach((item) => item.init());
     }

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -70,12 +70,8 @@ class Game {
                 console.error('Unable to load sava data from JSON for:', key, '\nError:\n', error);
             }
         });
-        saveObject.achievements?.forEach(achName => {
-            const ach = AchievementHandler.findByName(achName);
-            if (ach) {
-                ach.unlocked(true);
-            }
-        });
+
+        AchievementHandler.fromJSON(saveObject.achievements);
     }
 
     initialize() {

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -78,7 +78,7 @@ class Game {
         AchievementHandler.initialize(this.multiplier, this.challenges);
         FarmController.initialize();
         EffectEngineRunner.initialize(this.multiplier, GameHelper.enumStrings(GameConstants.BattleItemType).map((name) => ItemList[name]));
-        ItemHandler.initilizeEvoStones();
+        ItemHandler.initializeItems();
         BreedingController.initialize();
         PokedexHelper.initialize();
         this.profile.initialize();

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -78,7 +78,6 @@ class Game {
         AchievementHandler.initialize(this.multiplier, this.challenges);
         FarmController.initialize();
         EffectEngineRunner.initialize(this.multiplier, GameHelper.enumStrings(GameConstants.BattleItemType).map((name) => ItemList[name]));
-        FluteEffectRunner.initialize(this.multiplier);
         ItemHandler.initilizeEvoStones();
         BreedingController.initialize();
         PokedexHelper.initialize();
@@ -93,7 +92,11 @@ class Game {
         this.pokeballFilters.initialize();
         this.load();
 
-        // Update if the achievements are already completed
+        // Unlock achievements that have already been completed, avoids renotifying
+        AchievementHandler.preCheckAchievements();
+        // Flute bonuses depend on achievements so should be initialized afterwards
+        // but the bonuses can affect some achievements so we need to recheck them once flutes are online
+        FluteEffectRunner.initialize(this.multiplier);
         AchievementHandler.preCheckAchievements();
 
         // TODO refactor to proper initialization methods

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -116,13 +116,6 @@ class AchievementHandler {
         for (let i = 0; i < AchievementHandler.achievementList.length; i++) {
             AchievementHandler.achievementList[i].unlocked(AchievementHandler.achievementList[i].isCompleted());
         }
-
-        // Some achievements' requirements can be circularly dependent on themselves through achievementBonus
-        // i.e. attack achievements potentially using flute attack bonus, which is calculated from achievementBonus
-        // If this happens, achievementBonus() throws an error the first time it's calculated so get that out of the way
-        try {
-            AchievementHandler.achievementBonus();
-        } catch {}
     }
 
     public static checkAchievements() {


### PR DESCRIPTION
Fixed a rare dev build crash when loading a save with the yellow flute active if the stars aligned just right. It seems to be a circular dependency where the flute's bonus is based on the achievement bonus, which checks the attack achievements and thus checks the flute bonus. Why did this only become an issue in #5104? Why don't all the attack achievements throw errors? No clue.

When it does happen, the error is only thrown the first time achievement bonus is calculated, so I had it safely do so as part of the AchievementHandler loading process. Not really an *ideal* solution, but if it works... Tested on the same saves that were crashing earlier and now they're working fine, so, as fixed as it's likely to get for now.