### PR TITLE
Hide outdated contest town entries in dev

### DIFF
--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3370,7 +3370,8 @@ TownList['Lilycove City'] = new Town(
     'Lilycove City',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Hoenn,
-    [new PokemonContestTownContent(), DepartmentStoreShop, HoennContestShop],
+    [DepartmentStoreShop],
+    //[new PokemonContestTownContent(), DepartmentStoreShop, HoennContestShop],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.hoenn, 121)],
     }


### PR DESCRIPTION
## Description
Contests will most likely be changing entirely from the current dev implementation. This removes the Pokemon Contest and Contest Shop entries from Lilycove. They were only available in dev but there's no point leaving outdated content accessible. The contest pokemon were also appearing as available from the shop on the wiki.

## How Has This Been Tested?
Checked Lilycove
