### PR TITLE
Reduced Fossil Pieces underground upgrade

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -132,6 +132,7 @@
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Shards)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Plates)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Evolution_Items)}}"></tr>
+                            <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Fossil_Pieces)}}"></tr>
                         </tbody>
                     </table>
                 </div>
@@ -312,13 +313,23 @@
             data-bind="text: upgrade.isMaxLevel() ? '' : upgrade.calculateCost().amount.toLocaleString('en-US') + ' Diamonds'"></td>
         <td class='vertical-middle'>
             <button class='btn btn-block'
-                    data-bind='css: {
-                            disabled: !upgrade.isMaxLevel() && !upgrade.canAfford(),
-                            "btn-success": !upgrade.isMaxLevel() || Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).observableValue(),
-                            "btn-danger": upgrade.isMaxLevel() && !Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).observableValue(),
-                        },
-                        text: upgrade.isMaxLevel() ? Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).observableValue() ? "Enabled" : "Disabled" : "Unlock",
-                        click: () => upgrade.canBuy() ? upgrade.buy() : Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).toggle()'>
+                data-bind='css: {
+                        disabled: (!upgrade.isMaxLevel() && !upgrade.canAfford()) || !upgrade.isUnlocked(),
+                        "btn-success": !upgrade.isMaxLevel() || Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).observableValue(),
+                        "btn-danger": upgrade.isMaxLevel() && !Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).observableValue(),
+                    },
+                    text: upgrade.isMaxLevel()
+                        ? Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).observableValue()
+                            ? "Enabled" : "Disabled"
+                        : !upgrade.isUnlocked() ? "🔒" : "Unlock",
+                    tooltip: {
+                        title: upgrade.isUnlocked() ? "" : upgrade.requirement.hint(),
+                        trigger: "hover",
+                        placement: "left",
+                    },
+                    click: () => !upgrade.isMaxLevel() && upgrade.isUnlocked()
+                        ? upgrade.buy()
+                        : Settings.getSetting(`underground.${UndergroundUpgrade.Upgrades[upgrade.name]}`).toggle()'>
             </button>
         </td>
     </script>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -37,9 +37,9 @@ export default Settings;
 
 // Region SettingOptions that unlock when the player reaches each region
 const regionOptionsNoneFirst = Settings.enumToNumberSettingOptionArray(Region, (r) => r !== 'final')
-    .map(o => { 
+    .map(o => {
         o.requirement = o.value > Region.kanto ? new MaxRegionRequirement(o.value) : undefined;
-        return o; 
+        return o;
     });
 const regionOptionsNoneLast = [...regionOptionsNoneFirst.filter(o => o.value !== Region.none), regionOptionsNoneFirst.find(o => o.value === Region.none)];
 
@@ -216,6 +216,7 @@ Object.values(NotificationConstants.NotificationSetting).forEach((settingsGroup)
 Settings.add(new BooleanSetting('underground.Reduced_Shards', 'Reduced Shards', true));
 Settings.add(new BooleanSetting('underground.Reduced_Plates', 'Reduced Plates', true));
 Settings.add(new BooleanSetting('underground.Reduced_Evolution_Items', 'Reduced Evolution Items', true));
+Settings.add(new BooleanSetting('underground.Reduced_Fossil_Pieces', 'Reduced Fossil Pieces', true));
 
 // Party
 Settings.add(new BooleanSetting('partyHideShinySprites', 'Hide party shiny sprites', false));

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -1,7 +1,7 @@
 import type { Observable, Computed } from 'knockout';
 import '../koExtenders';
 import { Feature } from '../DataStore/common/Feature';
-import { Currency, EnergyRestoreSize, EnergyRestoreEffect, PLATE_VALUE } from '../GameConstants';
+import { Currency, EnergyRestoreSize, EnergyRestoreEffect, PLATE_VALUE, Region } from '../GameConstants';
 import GameHelper from '../GameHelper';
 import KeyItemType from '../enums/KeyItemType';
 import OakItemType from '../enums/OakItemType';
@@ -16,6 +16,7 @@ import { Mine } from './Mine';
 import UndergroundItem from './UndergroundItem';
 import UndergroundItems from './UndergroundItems';
 import UndergroundUpgrade, { Upgrades } from './UndergroundUpgrade';
+import MaxRegionRequirement from '../requirements/MaxRegionRequirement';
 
 export class Underground implements Feature {
     name = 'Underground';
@@ -187,6 +188,12 @@ export class Underground implements Feature {
                 AmountFactory.createArray(
                     GameHelper.createArray(1000, 1000, 1000), Currency.diamond),
                 GameHelper.createArray(0, 1, 1),
+            ),
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Reduced_Fossil_Pieces, 'Reduced Fossil Pieces', 1,
+                AmountFactory.createArray(
+                    GameHelper.createArray(1000, 1000, 1000), Currency.diamond),
+                GameHelper.createArray(0, 1, 1), true, new MaxRegionRequirement(Region.galar),
             ),
         ];
     }

--- a/src/modules/underground/UndergroundFossilPieceItem.ts
+++ b/src/modules/underground/UndergroundFossilPieceItem.ts
@@ -1,0 +1,20 @@
+import UndergroundItemValueType from '../enums/UndergroundItemValueType';
+import Requirement from '../requirements/Requirement';
+import Settings from '../settings';
+import UndergroundItem from './UndergroundItem';
+import UndergroundUpgrade from './UndergroundUpgrade';
+
+
+export default class UndergroundEvolutionItem extends UndergroundItem {
+    constructor(
+        id: number,
+        itemName: string,
+        space: Array<Array<number>>,
+        value = 1,
+        requirement?: Requirement,
+    ) {
+        super(id, itemName, space, value, UndergroundItemValueType.FossilPiece, requirement, ()=>{
+            return App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Fossil_Pieces).isMaxLevel() && Settings.getSetting('underground.Reduced_Fossil_Pieces').observableValue() ? 0.1 : 1;
+        });
+    }
+}

--- a/src/modules/underground/UndergroundFossilPieceItem.ts
+++ b/src/modules/underground/UndergroundFossilPieceItem.ts
@@ -5,7 +5,7 @@ import UndergroundItem from './UndergroundItem';
 import UndergroundUpgrade from './UndergroundUpgrade';
 
 
-export default class UndergroundEvolutionItem extends UndergroundItem {
+export default class UndergroundFossilPieceItem extends UndergroundItem {
     constructor(
         id: number,
         itemName: string,

--- a/src/modules/underground/UndergroundItems.ts
+++ b/src/modules/underground/UndergroundItems.ts
@@ -4,6 +4,7 @@ import { MegaStoneType, Region, StoneType } from '../GameConstants';
 import MaxRegionRequirement from '../requirements/MaxRegionRequirement';
 import Rand from '../utilities/Rand';
 import UndergroundEvolutionItem from './UndergroundEvolutionItem';
+import UndergroundFossilPieceItem from './UndergroundFossilPieceItem';
 import UndergroundGemItem from './UndergroundGemItem';
 import UndergroundItem from './UndergroundItem';
 import UndergroundMegaStoneItem from './UndergroundMegaStoneItem';
@@ -111,10 +112,10 @@ UndergroundItems.addItem(new UndergroundItem(209, 'Jaw_fossil', [[0, 0, 1, 1, 1]
     () => (App.game.party.alreadyCaughtPokemonByName('Tyrunt') || player.itemList.Jaw_fossil() > 0 ? 0.1 : 1.5)));
 UndergroundItems.addItem(new UndergroundItem(210, 'Sail_fossil', [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.kalos),
     () => (App.game.party.alreadyCaughtPokemonByName('Amaura') || player.itemList.Sail_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(211, 'Fossilized_bird', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, UndergroundItemValueType.FossilPiece, new MaxRegionRequirement(Region.galar)));
-UndergroundItems.addItem(new UndergroundItem(212, 'Fossilized_fish', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, UndergroundItemValueType.FossilPiece, new MaxRegionRequirement(Region.galar)));
-UndergroundItems.addItem(new UndergroundItem(213, 'Fossilized_drake', [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]], 0, UndergroundItemValueType.FossilPiece, new MaxRegionRequirement(Region.galar)));
-UndergroundItems.addItem(new UndergroundItem(214, 'Fossilized_dino', [[1, 1, 1, 0], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, UndergroundItemValueType.FossilPiece, new MaxRegionRequirement(Region.galar)));
+UndergroundItems.addItem(new UndergroundFossilPieceItem(211, 'Fossilized_bird', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, new MaxRegionRequirement(Region.galar)));
+UndergroundItems.addItem(new UndergroundFossilPieceItem(212, 'Fossilized_fish', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, new MaxRegionRequirement(Region.galar)));
+UndergroundItems.addItem(new UndergroundFossilPieceItem(213, 'Fossilized_drake', [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]], 0, new MaxRegionRequirement(Region.galar)));
+UndergroundItems.addItem(new UndergroundFossilPieceItem(214, 'Fossilized_dino', [[1, 1, 1, 0], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, new MaxRegionRequirement(Region.galar)));
 
 // Evolution Stones
 UndergroundItems.addItem(new UndergroundEvolutionItem(300, 'Fire_stone', [[1, 1, 1], [1, 1, 1], [1, 1, 1]], StoneType.Fire_stone));

--- a/src/modules/underground/UndergroundUpgrade.ts
+++ b/src/modules/underground/UndergroundUpgrade.ts
@@ -1,4 +1,5 @@
 import KeyItemType from '../enums/KeyItemType';
+import Requirement from '../requirements/Requirement';
 import Upgrade from '../upgrades/Upgrade';
 import Amount from '../wallet/Amount';
 
@@ -16,6 +17,7 @@ export enum Upgrades {
     'Reduced_Shards',
     'Reduced_Plates',
     'Reduced_Evolution_Items',
+    'Reduced_Fossil_Pieces',
 }
 
 export default class UndergroundUpgrade extends Upgrade {
@@ -25,14 +27,18 @@ export default class UndergroundUpgrade extends Upgrade {
     constructor(
         name: Upgrades, displayName: string, maxLevel: number,
         costList: Amount[], bonusList: number[], increasing = true,
+        private requirement?: Requirement,
     ) {
         super(name, displayName, maxLevel, costList, bonusList, increasing);
     }
 
 
     canBuy(): boolean {
-        return super.canBuy() && App.game.keyItems.hasKeyItem(KeyItemType.Explorer_kit);
+        return super.canBuy() && App.game.keyItems.hasKeyItem(KeyItemType.Explorer_kit) && this.isUnlocked();
     }
 
+    isUnlocked(): boolean {
+        return this.requirement?.isCompleted() ?? true;
+    }
 }
 


### PR DESCRIPTION
## Description
Adds an additional toggle-able underground upgrade to reduce fossil piece spawns. It is visible in the upgrade list but locked and cannot be purchased until the player has reached Galar (when fossil pieces begin appearing).

## How Has This Been Tested?
Used 🪄 to generate layers and check how many fossil pieces spawned with the option enabled vs disabled

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/0763c3a3-e4b2-48c4-9451-c9b48c8b32f9)

## Types of changes
- New underground upgrade
