### PR TITLE
Add temporary battle's location to TemporaryBattleRequirement hints

### DIFF
--- a/src/modules/globals.ts
+++ b/src/modules/globals.ts
@@ -150,6 +150,19 @@ type TmpAchievementHandler = {
     load: ()=>void
 };
 
+type TmpTemporaryBattleListType = {
+    [battleName: string]: TmpTemporaryBattleType;
+};
+
+type TmpTemporaryBattleType = {
+    name: string;
+    parent?: TmpTownType;
+    getTown: () => TmpTownType;
+};
+
+type TmpTownType = {
+    name: string;
+};
 
 export type TmpPokemonFactoryType = {
     generateShiny(chance: number, skipBonus?: boolean): boolean;
@@ -172,4 +185,5 @@ declare global {
     const AchievementHandler: TmpAchievementHandler;
     const PokemonFactory: TmpPokemonFactoryType;
     const PartyController: TmpPartyControllerType;
+    const TemporaryBattleList: TmpTemporaryBattleListType;
 }

--- a/src/modules/requirements/TemporaryBattleRequirement.ts
+++ b/src/modules/requirements/TemporaryBattleRequirement.ts
@@ -11,6 +11,8 @@ export default class TemporaryBattleRequirement extends Requirement {
     }
 
     public hint(): string {
-        return `Requires beating ${this.battleName.replace(/\s(?=[\d])\d/g, '')}.`;
+        const tempBattle = TemporaryBattleList[this.battleName];
+        const locationHint = ` ${tempBattle.parent ? 'in' : 'near'} ${tempBattle.getTown().name.replace(/\.$/, '')}`;
+        return `Requires beating ${this.battleName.replace(/(?: route)?\s\d+$/, '')}${locationHint}.`;
     }
 }

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -2346,7 +2346,7 @@ TemporaryBattleList['Red Genesect 2'] = new TemporaryBattle(
         visibleRequirement: new QuestLineStepCompletedRequirement('The Legend Awakened', 4),
     }
 );
-TemporaryBattleList.DreamResearcher = new TemporaryBattle(
+TemporaryBattleList['Dream Researcher'] = new TemporaryBattle(
     'Dream Researcher',
     [new GymPokemon('Mega Audino', 125000000, 32)],
     'Wow! You have proven that you have total power over the realm of dreams! The location of this Audinite was revealed to me in a dream, you deserve to have it!</br><img src="assets/images/megaStone/Audinite.png"/>',

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -5472,7 +5472,7 @@ TownList['Black and White Park'] = new Town(
     'Black and White Park',
     GameConstants.Region.unova,
     GameConstants.UnovaSubRegions.Unova,
-    [new DreamOrbTownContent(), BlackAndWhiteParkShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Black and White Park']), TemporaryBattleList.DreamResearcher],
+    [new DreamOrbTownContent(), BlackAndWhiteParkShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Black and White Park']), TemporaryBattleList['Dream Researcher']],
     {
         requirements: [new OneFromManyRequirement([
             new MultiRequirement([


### PR DESCRIPTION
TemporaryBattleRequirement hints now tell the player where to find the battle. This will make temporary battles much easier to find, especially for a) repeated battles against the same opponent b) players further in the progression than a newly-added battle.

## How Has This Been Tested?
Generated a hint for every single temporary battle and confirmed they read coherently.