### PR TITLE
Added Blitzle to Unova Route 3

### DIFF
--- a/src/modules/routes/RouteData.ts
+++ b/src/modules/routes/RouteData.ts
@@ -1529,7 +1529,10 @@ Routes.add(new RegionRoute(
     new RoutePokemon({
         land: ['Yanma', 'Yanmega', 'Watchog', 'Herdier', 'Purrloin', 'Tranquill'],
         special:
-        [new SpecialRoutePokemon(['Zebstrika'], new ObtainedPokemonRequirement('Zebstrika'))],
+        [
+            new SpecialRoutePokemon(['Zebstrika'], new ObtainedPokemonRequirement('Zebstrika')),
+            new SpecialRoutePokemon(['Blitzle'], new ObtainedPokemonRequirement('Blitzle')),
+        ],
     }),
     [new ClearDungeonRequirement(1, getDungeonIndex('Pinwheel Forest'))],
     23.1,


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Added Blitzle with a "Caught" requirement to Unova Route 3.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Blitzle being unavailable after egg because BW2 didn't have it always seemed odd to me as it's available in BW. This will remove it from Friend Safari and make it available at a more natural location.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Went to the route. Saw the thing. Tested with a file with no Blitzle. Didn't see the thing. 


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Route Data
