### PR TITLE
Make sevii island roamers be determined by starter

### DIFF
--- a/src/modules/pokemons/RoamingPokemonList.ts
+++ b/src/modules/pokemons/RoamingPokemonList.ts
@@ -20,6 +20,7 @@ import { PokemonNameType } from './PokemonNameType';
 import RoamingPokemon from './RoamingPokemon';
 import RoamingGroup from './RoamingGroup';
 import SpecialEventRequirement from '../requirements/SpecialEventRequirement';
+import OneFromManyRequirement from '../requirements/OneFromManyRequirement';
 
 export default class RoamingPokemonList {
     public static roamerGroups: RoamingGroup[][] = [
@@ -93,9 +94,9 @@ export default class RoamingPokemonList {
 RoamingPokemonList.add(Region.kanto, 0, new RoamingPokemon('Mew'));
 
 // Kanto - Sevii Islands
-RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Raikou', new QuestLineCompletedRequirement('Celio\'s Errand')));
-RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Entei', new QuestLineCompletedRequirement('Celio\'s Errand')));
-RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Suicune', new MultiRequirement([new QuestLineCompletedRequirement('Celio\'s Errand'), new ObtainedPokemonRequirement('Suicune')])));
+RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Raikou', new MultiRequirement([new QuestLineCompletedRequirement('Celio\'s Errand'), new StarterRequirement(Region.kanto, Starter.Water)])));
+RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Entei', new MultiRequirement([new QuestLineCompletedRequirement('Celio\'s Errand'), new OneFromManyRequirement([new StarterRequirement(Region.kanto, Starter.Grass), new StarterRequirement(Region.kanto, Starter.Special)])])));
+RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Suicune', new MultiRequirement([new QuestLineCompletedRequirement('Celio\'s Errand'), new ObtainedPokemonRequirement('Suicune'), new StarterRequirement(Region.kanto, Starter.Fire)])));
 RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Pink Butterfree', new GymBadgeRequirement(BadgeEnums.Elite_OrangeChampion)));
 RoamingPokemonList.add(Region.kanto, 1, new RoamingPokemon('Ash\'s Butterfree', new GymBadgeRequirement(BadgeEnums.Elite_OrangeChampion)));
 

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -631,7 +631,7 @@ const SeviiGideon2 = new NPC ('Gideon', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Celio\'s Errand', 7), new QuestLineStepCompletedRequirement('Celio\'s Errand', 9, GameConstants.AchievementOption.less)]),
 });
 const SixIslandSeviiRoamerNPC = new RoamerNPC('Bug Catcher John', [
-    'Apparently some kid released one of his Pokémon around here. That Pokémon, its partner, and for whatever reason, the Legendary Beasts from Johto have been seen roaming on {ROUTE_NAME}.',
+    'Apparently some kid released one of his Pokémon around here. That Pokémon, its partner, and for whatever reason, one of the Legendary Beasts from Johto have been seen roaming on {ROUTE_NAME}.',
 ], GameConstants.Region.kanto, RoamingPokemonList.findGroup(GameConstants.Region.kanto, GameConstants.KantoSubRegions.Sevii4567), 'assets/images/npcs/Bug Catcher.png', new GymBadgeRequirement(BadgeEnums.Elite_OrangeChampion));
 const AlteringCaveRuinManiac1 = new NPC ('Ruin Maniac', [
     'Hello. You want to know what I\'m doing in this pointless dead end cave?',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Changed the sevii island roamers so only one of the beasts is roaming. If Pikachu is chosen Entei is roaming (same as bulbasaur)


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
5 roamers are a bit too much. EVs can be obtained from shadow bosses in orre. Kalos handles it the same with the three birds. Its ✨canon✨


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Checked the roaming NPC on island 6


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://github.com/pokeclicker/pokeclicker/assets/143606926/716c4236-f22d-4d56-b66f-12675edcf10f)



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- roaming pokemon
