### PR TITLE
Fix egg name tooltips flickering and blocking clicks

### DIFF
--- a/src/components/breedingDisplay.html
+++ b/src/components/breedingDisplay.html
@@ -39,6 +39,7 @@
                     title: BreedingController.getEggPokemonName($data) || '???',
                     trigger: 'hover',
                     placement: 'bottom',
+                    class: 'no-click',
                 }">
                 <!-- ko if: $data.type == EggType.Fossil -->
                 <img class="egg" data-bind="attr: {src: BreedingController.getEggImage($data)}, class: BreedingController.getEggCssClass($data)"/>

--- a/src/modules/koBindingHandlers.ts
+++ b/src/modules/koBindingHandlers.ts
@@ -156,11 +156,14 @@ const resizableHandler = {
 const tooltipHandler = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
-        const local = ko.utils.unwrapObservable(valueAccessor()),
-            options = {};
+        const local = ko.utils.unwrapObservable(valueAccessor());
+        const options = {} as any;
 
         ko.utils.extend(options, ko.bindingHandlers.tooltip.options);
         ko.utils.extend(options, local);
+
+        // TODO Bootstrap 5: Use customClass rather than rewriting the template
+        options.template = `<div class="tooltip ${options.class ?? ''}" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>`;
 
         $(element).tooltip(options);
 


### PR DESCRIPTION
## Description
Add ability to define custom classes to be added to the bootstrap tooltip, and use this to avoid pointer events on the egg name tooltip

## Motivation and Context
Hovering over the egg name tooltip would block clicks on the egg itself, and would flicker as the tooltip steals the hover event

## How Has This Been Tested?
Check that tooltips still render correctly, and that the egg name ones don't block interactions/flicker

## Types of changes
- Bug fix
