### PR TITLE
Feature/underground scaling

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -66,7 +66,7 @@
                         data-bind="tooltip: {title: 'Chisel will mine 2 layers on a single chosen tile.', trigger: 'hover', placement: 'top', boundary: 'window'}">Chisel (<knockout data-bind="text: Underground.CHISEL_ENERGY"></knockout> energy)</button>
                         <button class='col-12 col-md-4 btn btn-success'
                                 onClick='Mine.survey(); $(this).tooltip("hide")'
-                                data-bind="disable: Mine.surveyResult() ? true : false, tooltip: {title: `Survey gives you information about the items to be found on this layer. It also fully damages ${App.game.underground.getSurvey_Efficiency()} (cleared or uncleared) random tile${App.game.underground.getSurvey_Efficiency() > 1 ? 's' : ''}.`, trigger: 'hover', placement: 'bottom', boundary: 'window'}">
+                                data-bind="disable: Mine.surveyResult() ? true : false, tooltip: {title: `Survey gives you information about the items to be found on this layer.`, trigger: 'hover', placement: 'bottom', boundary: 'window'}">
                             Survey (<knockout data-bind="text: App.game.underground.getSurvey_Cost()"></knockout> energy)
                         </button>
                         <!-- FIX NUMBER-->
@@ -126,8 +126,6 @@
                                 'data': {'totalBonus': App.game.underground.getBombEfficiency(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Bomb_Efficiency)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
                                 'data': {'totalBonus': App.game.underground.getSurvey_Cost(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Survey_Cost)}}"></tr>
-                            <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus': App.game.underground.getSurvey_Efficiency(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Survey_Efficiency)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
                                 'data': {'totalBonus' : App.game.underground.getSizeY() - Underground.sizeY, 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.NewYLayer)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Shards)}}"></tr>

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -127,7 +127,7 @@
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
                                 'data': {'totalBonus': App.game.underground.getSurvey_Cost(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Survey_Cost)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
-                                'data': {'totalBonus' : App.game.underground.getSizeY() - Underground.sizeY, 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.NewYLayer)}}"></tr>
+                                'data': {'totalBonus' : App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Items_All).calculateBonus(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Items_All)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Shards)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Plates)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Evolution_Items)}}"></tr>

--- a/src/components/undergroundDisplay.html
+++ b/src/components/undergroundDisplay.html
@@ -52,7 +52,7 @@
                     <button class='col btn btn-warning' onClick='Mine.bomb(); $(this).tooltip("hide")' data-bind="tooltip: {title: `Bomb will mine 2 layers of ${App.game.underground.getBombEfficiency()} (cleared or uncleared) random tiles.<br/>(${Underground.BOMB_ENERGY} energy)`, html: true, trigger: 'hover', placement: 'bottom', boundary: 'window'}">Bomb</button>
                     <button class='col btn btn-success'
                             onClick='Mine.survey("#mine-display-survey-result"); $(this).tooltip("hide")'
-                            data-bind="disable: Mine.surveyResult() ? true : false, tooltip: {title: `Survey gives you information about the items to be found on this layer. It also fully damages ${App.game.underground.getSurvey_Efficiency()} (cleared or uncleared) random tile${App.game.underground.getSurvey_Efficiency() > 1 ? 's' : ''}.<br/>(${App.game.underground.getSurvey_Cost()} energy)`, html: true, trigger: 'hover', placement: 'bottom', boundary: 'window'}">
+                            data-bind="disable: Mine.surveyResult() ? true : false, tooltip: {title: `Survey gives you information about the items to be found on this layer.<br/>(${App.game.underground.getSurvey_Cost()} energy)`, html: true, trigger: 'hover', placement: 'bottom', boundary: 'window'}">
                         Survey
                     </button>
                     <button class='col btn btn-danger' onClick='Mine.skipLayer(true)'

--- a/src/modules/underground/Mine.ts
+++ b/src/modules/underground/Mine.ts
@@ -200,13 +200,6 @@ export class Mine {
             return;
         }
 
-        const tiles = App.game.underground.getSurvey_Efficiency();
-        for (let i = 0; i < tiles; i++) {
-            const x = Rand.intBetween(0, this.getHeight() - 1);
-            const y = Rand.intBetween(0, Underground.sizeX - 1);
-            this.breakTile(x, y, Mine.maxLayerDepth);
-        }
-
         App.game.underground.energy -= surveyCost;
         const rewards = Mine.rewardSummary();
         Mine.updatesurveyResult(rewards, resultTooltipID);

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -42,7 +42,6 @@ export class Underground implements Feature {
     public static BASE_ENERGY_REGEN_TIME = 60;
     public static BASE_DAILY_DEALS_MAX = 3;
     public static BASE_BOMB_EFFICIENCY = 10;
-    public static BASE_SURVEY_CHARGE_EFFICIENCY = 1;
 
     public static sizeX = 25;
     public static sizeY = 12;
@@ -160,12 +159,6 @@ export class Underground implements Feature {
                 false,
             ),
             new UndergroundUpgrade(
-                UndergroundUpgrade.Upgrades.Survey_Efficiency, 'Survey Efficiency', 4,
-                AmountFactory.createArray(
-                    GameHelper.createArray(100, 400, 100), Currency.diamond),
-                GameHelper.createArray(0, 4, 1),
-            ),
-            new UndergroundUpgrade(
                 UndergroundUpgrade.Upgrades.NewYLayer, 'Larger Underground, +1 Item', 1,
                 AmountFactory.createArray(
                     GameHelper.createArray(3000, 3000, 3000), Currency.diamond),
@@ -227,10 +220,6 @@ export class Underground implements Feature {
 
     getSurvey_Cost() {
         return Underground.SURVEY_ENERGY - this.getUpgrade(UndergroundUpgrade.Upgrades.Survey_Cost).calculateBonus();
-    }
-
-    getSurvey_Efficiency() {
-        return Underground.BASE_SURVEY_CHARGE_EFFICIENCY + this.getUpgrade(UndergroundUpgrade.Upgrades.Survey_Efficiency).calculateBonus();
     }
 
     getSizeY() {

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -159,7 +159,7 @@ export class Underground implements Feature {
                 false,
             ),
             new UndergroundUpgrade(
-                UndergroundUpgrade.Upgrades.NewYLayer, 'Larger Underground, +1 Item', 1,
+                UndergroundUpgrade.Upgrades.Items_All, '+1 Item', 1,
                 AmountFactory.createArray(
                     GameHelper.createArray(3000, 3000, 3000), Currency.diamond),
                 GameHelper.createArray(0, 1, 1),
@@ -199,7 +199,7 @@ export class Underground implements Feature {
     }
 
     getMaxItems() {
-        return Underground.BASE_ITEMS_MAX + this.getUpgrade(UndergroundUpgrade.Upgrades.Items_Max).calculateBonus() + this.getUpgrade(UndergroundUpgrade.Upgrades.NewYLayer).calculateBonus();
+        return Underground.BASE_ITEMS_MAX + this.getUpgrade(UndergroundUpgrade.Upgrades.Items_Max).calculateBonus() + this.getUpgrade(UndergroundUpgrade.Upgrades.Items_All).calculateBonus();
     }
 
     getEnergyGain() {
@@ -223,11 +223,11 @@ export class Underground implements Feature {
     }
 
     getSizeY() {
-        return Underground.sizeY + this.getUpgrade(UndergroundUpgrade.Upgrades.NewYLayer).calculateBonus();
+        return Underground.sizeY;
     }
 
     getMinItems() {
-        return Underground.BASE_ITEMS_MIN + this.getUpgrade(UndergroundUpgrade.Upgrades.Items_Min).calculateBonus() + this.getUpgrade(UndergroundUpgrade.Upgrades.NewYLayer).calculateBonus();
+        return Underground.BASE_ITEMS_MIN + this.getUpgrade(UndergroundUpgrade.Upgrades.Items_Min).calculateBonus() + this.getUpgrade(UndergroundUpgrade.Upgrades.Items_All).calculateBonus();
     }
 
     getUpgrade(upgrade: Upgrades) {

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -174,7 +174,7 @@ export class Underground implements Feature {
             new UndergroundUpgrade(
                 UndergroundUpgrade.Upgrades.Reduced_Shards, 'Reduced Shards', 1,
                 AmountFactory.createArray(
-                    GameHelper.createArray(1000, 1000, 1000), Currency.diamond),
+                    GameHelper.createArray(750, 750, 750), Currency.diamond),
                 GameHelper.createArray(0, 1, 1),
             ),
             new UndergroundUpgrade(
@@ -186,13 +186,13 @@ export class Underground implements Feature {
             new UndergroundUpgrade(
                 UndergroundUpgrade.Upgrades.Reduced_Evolution_Items, 'Reduced Evolution Items', 1,
                 AmountFactory.createArray(
-                    GameHelper.createArray(1000, 1000, 1000), Currency.diamond),
+                    GameHelper.createArray(500, 500, 500), Currency.diamond),
                 GameHelper.createArray(0, 1, 1),
             ),
             new UndergroundUpgrade(
                 UndergroundUpgrade.Upgrades.Reduced_Fossil_Pieces, 'Reduced Fossil Pieces', 1,
                 AmountFactory.createArray(
-                    GameHelper.createArray(1000, 1000, 1000), Currency.diamond),
+                    GameHelper.createArray(200, 200, 200), Currency.diamond),
                 GameHelper.createArray(0, 1, 1), true, new MaxRegionRequirement(Region.galar),
             ),
         ];

--- a/src/modules/underground/UndergroundUpgrade.ts
+++ b/src/modules/underground/UndergroundUpgrade.ts
@@ -12,7 +12,7 @@ export enum Upgrades {
     'Daily_Deals_Max',
     'Bomb_Efficiency',
     'Survey_Cost',
-    'NewYLayer',
+    'Items_All',
     'Reduced_Shards',
     'Reduced_Plates',
     'Reduced_Evolution_Items',

--- a/src/modules/underground/UndergroundUpgrade.ts
+++ b/src/modules/underground/UndergroundUpgrade.ts
@@ -12,7 +12,6 @@ export enum Upgrades {
     'Daily_Deals_Max',
     'Bomb_Efficiency',
     'Survey_Cost',
-    'Survey_Efficiency',
     'NewYLayer',
     'Reduced_Shards',
     'Reduced_Plates',

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2700,8 +2700,10 @@ class Update implements Saveable {
                 const surveyEfficiencyCost = GameHelper.createArray(100, 400, 100);
                 const investedDiamonds = surveyEfficiencyCost.slice(0, surveyEfficiencyLevel).reduce((acc, cur) => acc + cur, 0);
                 saveData.wallet.currencies[GameConstants.Currency.diamond] += investedDiamonds;
-                delete saveData.underground.upgrades.Survey_Efficiency;
             }
+
+            // The NewYLayer upgrades has been refactored to Items_All, copy the level
+            saveData.underground.upgrades.Items_All = saveData.underground.upgrades.NewYLayer;
         },
     };
 

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2693,6 +2693,15 @@ class Update implements Saveable {
             if (saveData.statistics.temporaryBattleDefeated[241]) {
                 Update.startQuestLine(saveData, 'Child of the Stars');
             }
+
+            // Reimburse Survey Efficiency upgrade
+            const surveyEfficiencyLevel = saveData.underground.upgrades.Survey_Efficiency;
+            if (surveyEfficiencyLevel) {
+                const surveyEfficiencyCost = GameHelper.createArray(100, 400, 100);
+                const investedDiamonds = surveyEfficiencyCost.slice(0, surveyEfficiencyLevel).reduce((acc, cur) => acc + cur, 0);
+                saveData.wallet.currencies[GameConstants.Currency.diamond] += investedDiamonds;
+                delete saveData.underground.upgrades.Survey_Efficiency;
+            }
         },
     };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Split PR from #5283 to include some of the changes for this update, but needs more balancing and refactoring in a future update.

## Changes
* Removed the tile breaking from Survey, as it's pretty useless when you have bombing
* Removed the extra underground row from Larger Underground upgrade. This had no effect on diamonds gained.
* Refactored the Larger Underground to +1 All Items

## Upgrade cost changes
* Survey Efficiency: 1,000 -> Removed
* Reduced Shards: 1,000 -> 750
* Reduced Evolution Items: 1,000 -> 500
* Reduced Fossil Pieces: 1,000 -> 200

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Imported a 0.10.19 file, check if I still had all upgrades I had previously unlocked. -> Yes
Did I gain 1,000 diamonds when I had Survey Efficiency fully unlocked -> Yes
Are costs reduced for changed upgrades -> Yes

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Balancing