### PR TITLE
Upgraded the Shovel + visual fix

### DIFF
--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -125,10 +125,13 @@
                                         FarmController.selectedFarmTool(FarmingTool.Shovel);
                                     },
                                     css: { 'active': FarmController.selectedFarmTool() == FarmingTool.Shovel },
-                                    tooltip: {title: 'Clear a Plant from a plot.', trigger: 'hover', animation: false}">
+                                    tooltip: {title: `${ItemList['Berry_Shovel'].description}${App.game.farming.savedPlant() ? `<br/>Or replant the removed ${BerryType[App.game.farming.savedPlant().type]} before it dies.` : ''}`, trigger: 'hover', animation: false, html: true}">
                                     <img src="" height="24px"
-                                        data-bind="attr:{ src: ItemList['Berry_Shovel'].image }">
+                                        data-bind="attr: { src: ItemList['Berry_Shovel'].image }">
                                     <span>Shovel</span>
+                                    <!-- ko if: App.game.farming.savedPlant -->
+                                    <img class="float-right ml-1" src="" height="24px" data-bind="attr: { src: App.game.farming.savedPlant().img }"/>
+                                    <!-- /ko -->
                                     <span class="float-right" data-bind="text: App.game.farming.shovelAmt().toLocaleString('en-US')"></span>
                                 </li>
                                 <!-- /ko -->
@@ -140,7 +143,7 @@
                                         FarmController.selectedFarmTool(FarmingTool.MulchShovel);
                                     },
                             css: { 'active': FarmController.selectedFarmTool() == FarmingTool.MulchShovel },
-                            tooltip: {title: 'Clear a Mulch from a plot.', trigger: 'hover', animation: false}">
+                            tooltip: {title: ItemList['Mulch_Shovel'].description, trigger: 'hover', animation: false}">
                                     <img src="" height="21px"
                                          data-bind="attr:{ src: ItemList['Mulch_Shovel'].image }">
                                     <span>MulchShovel</span>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -125,7 +125,7 @@
                                         FarmController.selectedFarmTool(FarmingTool.Shovel);
                                     },
                                     css: { 'active': FarmController.selectedFarmTool() == FarmingTool.Shovel },
-                                    tooltip: {title: `${ItemList['Berry_Shovel'].description}${App.game.farming.savedPlant() ? `<br/>Or replant the removed ${BerryType[App.game.farming.savedPlant().type]} before it dies.` : ''}`, trigger: 'hover', animation: false, html: true}">
+                                    tooltip: {title: `${ItemList['Berry_Shovel'].description}${App.game.farming.savedPlant() ? `<br/>Or replant the removed ${BerryType[App.game.farming.savedPlant().type]} before it decays.` : ''}`, trigger: 'hover', animation: false, html: true}">
                                     <img src="" height="24px"
                                         data-bind="attr: { src: ItemList['Berry_Shovel'].image }">
                                     <span>Shovel</span>

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -2285,7 +2285,7 @@ class Farming implements Feature {
     };
 
     public auraDisplay(berry: BerryType, stage: number) {
-        return `×${App.game.farming.berryData[berry].aura.auraMultipliers[stage].toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        return `×${App.game.farming.berryData[berry].aura.auraMultipliers[stage].toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 3 })}`;
     }
 
     public handleWanderer(plot: Plot) {

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -2285,7 +2285,7 @@ class Farming implements Feature {
     };
 
     public auraDisplay(berry: BerryType, stage: number) {
-        return `×${App.game.farming.berryData[berry].aura.auraMultipliers[stage].toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 3 })}`;
+        return `×${App.game.farming.berryData[berry].aura.auraMultipliers[stage].toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
     }
 
     public handleWanderer(plot: Plot) {

--- a/src/styles/farm.less
+++ b/src/styles/farm.less
@@ -282,5 +282,5 @@
 .pokemonSprite.walkDownFlee {
   background-position: 0.00000% 0.00000%;
   opacity: 1;
-  animation: walkDown 0.6s steps(4) infinite, flee 0.250s linear 1;
+  animation: walkDown 0.6s steps(4) infinite, flee 0.250s linear 1 forwards;
 }


### PR DESCRIPTION
## Description
The removed berry is now kept alive for a few more seconds and the player is able to replant it again.
Fixed wanderer flee animation.

## Motivation and Context
More realistic farm simulator. :^)
Closes #3949. If the player mistakingly removes a berry, they can quickly put it back. If different setups require Petaya to be at different spots, they can just move it around instead of having to grow it again.
The wanderer animation was reset to first frame thus making the sprite blink thanks to tick inconsistency.

## How Has This Been Tested
Used some spoons.

## Types of changes
- Bug fix
- QOL Feature
