### PR TITLE
Updated Farm Help Tab

### DIFF
--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -420,6 +420,10 @@
                             <td>Freeze Mulch</td>
                             <td>Stops Berry growth and auras. Mutations will still occur while berries are frozen.</td>
                         </tr>
+                        <tr>
+                            <td>Gooey Mulch</td>
+                            <td>Boosts Wanderer catch rate by 10% and increases the chance of non-base Wanderers appearing. Available from Unova.</td>
+                        </tr>
                     </table>
 
                     <h4><u>Shovel</u></h4>
@@ -443,14 +447,16 @@
 
                     <h4><u>Wandering Pokémon</u></h4>
                     <p>Ripe Berry plants may attract wild Pokémon that you can then capture. Some Pokémon can only be found using certain Berry species.</p>
-                    <p>Some Berry Auras will increase or decrease the chance of encountering Wandering Pokémon. If your total Repel Aura value reaches 1 or greater, no Wandering Pokémon will appear.</p>
-                    <p>Pokémon are more likely to let you catch them when attracted to berries.</p>
+                    <p>Some Berry Auras will increase or decrease the chance of encountering Wandering Pokémon.</p>
+                    <p>When a Pokémon wanders onto your farm they will appear on a plot next to the berry and will remain there until interacted with or will flee a couple minutes after the berry is harvested or withers.</p>
+                    <p>Your Poké Ball Filters will be used when attempting to capture a Wanderer. Farm Hands can also be used for this by enabling their Manage Wanderers setting.</p>
+                    <p>Interacting with a Wanderer will earn you Farm Points whether you catch it or not. Successfully capturing one will net you Dungeon Tokens.</p>
 
                     <h4><u>Farm Hands</u></h4>
                     <p><i>(unlocked after obtaining 8 unique berries)</i></p>
                     <p>Farm Hands can help around the Farm; they will harvest and plant berries as needed or catch wild wanderers, and accrue Farm Points while doing so.</p>
                     <p>Up to 3 Farm Hands can be hired at a time.</p>
-                    <p>If they run out of energy, they won't do any work for that cycle, but will regenerate some energy instead. If there's no work to do currently, they will also regenerate some energy.</p>
+                    <p>If they run out of energy, they won't do any work for that cycle, but will regenerate some energy instead. If there's no work to do currently, they will also regenerate some energy. Firing them will allow them to recover energy at the same rate as if they were still hired.</p>
                     <p>Efficiency refers to how many actions they can do per work cycle.</p>
                     <p><i>More Farm Hands can be unlocked through shops and unlocking unique berries</i></p>
 

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -389,12 +389,12 @@
 
                     <h4><u>Mutations</u></h4>
                     <p>Berries have the chance to cause mutations and create new Berry species in empty plots based on certain conditions.
-                    <br/><i>(the Berry Master in Kanto will give you daily hints to what these conditions may be)</i></p>
+                    <br/><i>(The Berry Master in Kanto will give you daily hints to what these conditions may be.)</i></p>
 
                     <p>There are two types of mutations:</p>
 
-                    <p><b>Common mutations:</b> They requires specific berries to happen. <i>This mutations only happens at Ripe stage.</i>
-                    <br/><b>Evolution mutations:</b> They usually require a berry changing into other and are related with flavour profiles or use of objects. <i>This mutations can start to happen at Taller stage.</i></p>
+                    <p><b>Common mutations:</b> They require specific Berries to happen. <i>These mutations only happen at Ripe stage.</i>
+                    <br/><b>Evolution mutations:</b> They usually require a Berry changing into other and are related with flavour profiles or use of objects. <i>These mutations can start to happen at Taller stage.</i></p>
 
                     <h4><u>Mulches</u></h4>
                     <p>Mulches can be bought in later regions from Berry Masters,
@@ -418,7 +418,7 @@
                         </tr>
                         <tr>
                             <td>Freeze Mulch</td>
-                            <td>Stops Berry growth and auras. Mutations will still occur while berries are frozen.</td>
+                            <td>Stops Berry growth and auras. Mutations will still occur while Berries are frozen.</td>
                         </tr>
                         <tr>
                             <td>Gooey Mulch</td>
@@ -426,15 +426,15 @@
                         </tr>
                     </table>
 
-                    <h4><u>Shovel</u></h4>
-                    <p>If you want to remove a Berry plant before it is fully grown,
-                    <br/>you can use a Shovel to uproot it.
-                    <br/><i>(shovels can be purchased in later regions from Berry Masters)</i></p>
+                    <h4><u>Shovels</u></h4>
+                    <p>If you want to remove a Berry plant before it is fully grown, you can use a Shovel to uproot it. This will consume the Shovel. Using it on a ripe Berry, however, will function the same as a normal harvest, and the Shovel will not be consumed!</p>
+                    <p>If you want to remove a mulch, you can use Mulch Shovels. Using one will remove the full mulch effect, regardless of the time remaining.</p>
+                    <p><i>(Both types of shovels can be purchased in later regions from Berry Masters.)</i></p>
 
                     <h4><u>Locking Plots</u></h4>
                     <p>You can lock specific plots by toggling on the lock with the lock button
                     <br/>or using the hotkey <kbd data-bind="text: Settings.getSetting('hotkey.farm.togglePlotSafeLock').observableValue()"></kbd>.
-                    <br/>You can also press <kbd>Shift + Click</kbd> while having any tool/berry selected to safely lock a plot.</p>
+                    <br/>You can also press <kbd>Shift + Click</kbd> while having any tool/Berry selected to safely lock a plot.</p>
 
                     <p>Locking a plot prevents you from planting, harvesting,<br/>or interacting with the plot in any way.</p>
 
@@ -448,22 +448,22 @@
                     <h4><u>Wandering Pokémon</u></h4>
                     <p>Ripe Berry plants may attract wild Pokémon that you can then capture. Some Pokémon can only be found using certain Berry species.</p>
                     <p>Some Berry Auras will increase or decrease the chance of encountering Wandering Pokémon.</p>
-                    <p>When a Pokémon wanders onto your farm they will appear on a plot next to the berry and will remain there until interacted with or will flee a couple minutes after the berry is harvested or withers.</p>
+                    <p>When a Pokémon wanders onto your farm they will appear on a plot next to the Berry and will remain there until interacted with or will flee a couple minutes after the Berry is harvested or withers.</p>
                     <p>Your Poké Ball Filters will be used when attempting to capture a Wanderer. Farm Hands can also be used for this by enabling their Manage Wanderers setting.</p>
                     <p>Interacting with a Wanderer will earn you Farm Points whether you catch it or not. Successfully capturing one will net you Dungeon Tokens.</p>
 
                     <h4><u>Farm Hands</u></h4>
-                    <p><i>(unlocked after obtaining 8 unique berries)</i></p>
-                    <p>Farm Hands can help around the Farm; they will harvest and plant berries as needed or catch wild wanderers, and accrue Farm Points while doing so.</p>
+                    <p><i>(Unlocked after obtaining 8 unique Berries.)</i></p>
+                    <p>Farm Hands can help around the Farm; they will harvest and plant Berries as needed or catch wild wanderers, and accrue Farm Points while doing so.</p>
                     <p>Up to 3 Farm Hands can be hired at a time.</p>
                     <p>If they run out of energy, they won't do any work for that cycle, but will regenerate some energy instead. If there's no work to do currently, they will also regenerate some energy. Firing them will allow them to recover energy at the same rate as if they were still hired.</p>
                     <p>Efficiency refers to how many actions they can do per work cycle.</p>
-                    <p><i>More Farm Hands can be unlocked through shops and unlocking unique berries</i></p>
+                    <p><i>More Farm Hands can be unlocked through shops and unlocking unique Berries.</i></p>
 
                     <h4><u>Farm Module</u></h4>
                     <p>
-                        Monitor and interact with the farm in a limited capacity without opening the full modal. Harvest or plant berries, apply mulch, use shovels, and lock/unlock plots with the extended controls.<br />
-                        Hide the extended controls for less clutter while still being able to plant and harvest berries or disable the module completely in the settings.<br />
+                        Monitor and interact with the farm in a limited capacity without opening the full modal. Harvest or plant Berries, apply mulch, use shovels, and lock/unlock plots with the extended controls.<br />
+                        Hide the extended controls for less clutter while still being able to plant and harvest Berries or disable the module completely in the settings.<br />
                         You can also use <kbd>Shift + Click</kbd> to safely lock/unlock a plot.<br />
                         The Farm shortcut will be hidden when the Farm module is enabled.
                     </p>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Updated Farm Help Tab:
- Added Gooey Mulch information.
- Removed mention of Repel aura as it no longer exists.
- Updated the Wandering Pokémon section with the relevant information.
- Added that Farm Hands also recover energy while not hired.
- Updated Shovels information and added Mulch Shovel to it. 
- Fixed some typos. 
- All "berries" are now "Berries" for consistency.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
With the wanderer rework I noticed that the Farm Help tab was outdated and it needed fixing.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Checked the Farm Help tab.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Text update
