### PR TITLE
Berrydex not to round aura values

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -2258,7 +2258,7 @@ class Farming implements Feature {
     };
 
     public auraDisplay(berry: BerryType, stage: number) {
-        return `×${App.game.farming.berryData[berry].aura.auraMultipliers[stage].toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        return `×${App.game.farming.berryData[berry].aura.auraMultipliers[stage].toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 3 })}`;
     }
 
     public handleWanderer(plot: Plot) {


### PR DESCRIPTION
## Description
The rounding was displaying Starf aura as 1.02 fir instance, which is just false.

## Motivation and Context
Unplayable !

## How Has This Been Tested?
Just looked at the display.

## Types of changes
- Bug fix
- Fighting misinformation !
