### PR TITLE
Fix region filter settings crash during loading

### DIFF
--- a/src/modules/settings/SettingOption.ts
+++ b/src/modules/settings/SettingOption.ts
@@ -8,7 +8,7 @@ export default class SettingOption<T> {
         if (!this.requirement) {
             return true;
         }
-        if (App.game.gameState === GameState.loading) {
+        if (!App.game || App.game.gameState === GameState.loading) {
             // Requirements will error, assume the value is fine
             return true;
         }


### PR DESCRIPTION
Fixed several region filter settings crashing during loading. `SettingOptions` with requirements are supposed to ignore them while the game loads to avoid this sort of issue, but the check didn't account for evaluation before `App.game` is even defined.