### PR TITLE
Easier Crystallized Shadow

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -253,6 +253,7 @@ export const HELD_UNDERGROUND_ITEM_CHANCE = 2048;
 export const GRISEOUS_ITEM_CHANCE = 50;
 export const DNA_ITEM_CHANCE = 45;
 export const LIGHT_ITEM_CHANCE = 75;
+export const SHADOW_ITEM_CHANCE = 8;
 export const RUST_ITEM_CHANCE = 90;
 export const MANE_ITEM_CHANCE = 10;
 export const CHRISTMAS_ITEM_CHANCE = 10;

--- a/src/scripts/GameConstants.d.ts
+++ b/src/scripts/GameConstants.d.ts
@@ -224,6 +224,7 @@ namespace GameConstants {
     declare const GRISEOUS_ITEM_CHANCE: number;
     declare const DNA_ITEM_CHANCE: number;
     declare const LIGHT_ITEM_CHANCE: number;
+    declare const SHADOW_ITEM_CHANCE: number;
     declare const RUST_ITEM_CHANCE: number;
     declare const MANE_ITEM_CHANCE: number;
     declare const CHRISTMAS_ITEM_CHANCE: number;

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -297,13 +297,15 @@ class PokemonFactory {
             case 'Pure_light':
                 chance = GameConstants.LIGHT_ITEM_CHANCE;
                 break;
+            case 'Crystallized_shadow':
+                chance = GameConstants.SHADOW_ITEM_CHANCE;
+                break;
             case 'Rusted_Sword':
             case 'Rusted_Shield':
                 chance = GameConstants.RUST_ITEM_CHANCE;
                 break;
             case 'Black_mane_hair':
             case 'White_mane_hair':
-            case 'Crystallized_shadow':
                 chance = GameConstants.MANE_ITEM_CHANCE;
                 break;
             case 'Magikarp_Biscuit':


### PR DESCRIPTION
## Description
Makes the Crystallised Shadow slightly more common, due to being in Alola rather than Galar

## Motivation and Context
Dungeon boss items that are required to gain a certain pokemon are more common in earlier regions, so it makes sense for those that drop from roamers to be the same

## How Has This Been Tested?
I've tested that it still drops at around the rate I'd expect.

## Types of changes
- Balance
