### PR TITLE
Use Pokerus Progress for routes and dungeons instead of default icons

### DIFF
--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -122,12 +122,12 @@
                   <!--Pokérus image-->
                   <knockout data-bind="using: DungeonRunner.dungeon.allAvailablePokemon()"">
                       <knockout data-bind="if: RouteHelper.minPokerusCheck($data)">
-                          <!-- ko let: {minPokerus: RouteHelper.minPokerus($data)} -->
-                              <!-- ko ifnot: minPokerus > GameConstants.Pokerus.Infected -->
+                          <!-- ko let: {minPokerus: RouteHelper.minPokerus($data), usePokerusProgress: Settings.getSetting('usePokerusProgress').observableValue()} -->
+                              <!-- ko ifnot: usePokerusProgress && minPokerus > GameConstants.Pokerus.Infected -->
                               <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[minPokerus] + '.png',
                                   title: RouteHelper.dungeonPokerusEVs(DungeonRunner.dungeon)}" src=""/>
                               <!-- /ko -->
-                              <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
+                              <!-- ko if: usePokerusProgress && minPokerus > GameConstants.Pokerus.Infected -->
                               <div data-bind="text: RouteHelper.getPokerusProgress($data),
                                   class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus],
                                   attr: {title: RouteHelper.routePokerusEVs(player.route, player.region)}"></div>

--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -120,11 +120,21 @@
                   </knockout>
 
                   <!--Pokérus image-->
-                  <knockout data-bind="if: RouteHelper.minPokerusCheck(DungeonRunner.dungeon.allAvailablePokemon())">
-                      <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(DungeonRunner.dungeon.allAvailablePokemon())] + '.png',
-                            title: RouteHelper.dungeonPokerusEVs(DungeonRunner.dungeon)}"
-                    src=""/>
-                  </knockout>
+                  <knockout data-bind="using: DungeonRunner.dungeon.allAvailablePokemon()"">
+                      <knockout data-bind="if: RouteHelper.minPokerusCheck($data)">
+                          <!-- ko let: {minPokerus: RouteHelper.minPokerus($data)} -->
+                              <!-- ko ifnot: minPokerus > GameConstants.Pokerus.Infected -->
+                              <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[minPokerus] + '.png',
+                                  title: RouteHelper.dungeonPokerusEVs(DungeonRunner.dungeon)}" src=""/>
+                              <!-- /ko -->
+                              <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
+                              <div data-bind="text: RouteHelper.getPokerusProgress($data),
+                                  class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus],
+                                  attr: {title: RouteHelper.routePokerusEVs(player.route, player.region)}"></div>
+                              <!-- /ko -->
+                          <!-- /ko -->
+                      </knockout>
+                   </knockout>
                 </td>
                 <td width="50%">
                   <knockout data-bind="text: `${App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]().toLocaleString('en-US')} Clears`"></knockout>

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -82,6 +82,7 @@
                                 <tr data-bind="visible: Object.values(App.game.challenges.list).filter(c => c.active()).length > 0, template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('hideChallengeRelatedModules')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showGymGoAnimation')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showMuteButton')}"></tr>
+                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('usePokerusProgress')}"></tr>
                             </tbody>
                             <thead>
                                 <tr><th colspan="2">Map Colors</th></tr>

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -18,15 +18,26 @@
                             </div>
 
                             <!--Pokérus image-->
-                            <div data-bind="if: RouteHelper.minPokerusCheck(player.town.dungeon.allAvailablePokemon())" style="font-size: 0;">
-                                <img src="" data-bind="
-                                attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(player.town.dungeon.allAvailablePokemon())] + '.png'},
-                                tooltip: {
-                                    title: RouteHelper.dungeonPokerusEVs(player.town.dungeon),
-                                    placement: 'bottom',
-                                    trigger: 'hover'
-                                }" />
-                            </div>
+                            <knockout data-bind="using: player.town.dungeon.allAvailablePokemon()" style="font-size: 0;">
+                                <knockout data-bind="if: RouteHelper.minPokerusCheck($data),
+                                    tooltip: {
+                                        title: RouteHelper.dungeonPokerusEVs(player.town.dungeon),
+                                        placement: 'bottom',
+                                        trigger: 'hover'
+                                    }">
+                                    <!-- ko let: {minPokerus: RouteHelper.minPokerus($data)} -->
+                                        <!-- ko ifnot: minPokerus > GameConstants.Pokerus.Infected -->
+                                        <img src="" data-bind="
+                                            attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(player.town.dungeon.allAvailablePokemon())] + '.png'},
+                                            " />
+                                        <!-- /ko -->
+                                        <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
+                                        <div data-bind="text: RouteHelper.getPokerusProgress($data),
+                                            class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus]"></div>
+                                        <!-- /ko -->
+                                    <!-- /ko -->
+                                </knockout>
+                            </knockout>
                         </div>
 
                         <!-- ko if: player.town.dungeon.allAvailableShadowPokemon().length -->

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -28,8 +28,7 @@
                                     <!-- ko let: {minPokerus: RouteHelper.minPokerus($data)} -->
                                         <!-- ko ifnot: minPokerus > GameConstants.Pokerus.Infected -->
                                         <img src="" data-bind="
-                                            attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(player.town.dungeon.allAvailablePokemon())] + '.png'},
-                                            " />
+                                            attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[minPokerus] + '.png'}" />
                                         <!-- /ko -->
                                         <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
                                         <div data-bind="text: RouteHelper.getPokerusProgress($data),

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -25,12 +25,12 @@
                                         placement: 'bottom',
                                         trigger: 'hover'
                                     }">
-                                    <!-- ko let: {minPokerus: RouteHelper.minPokerus($data)} -->
-                                        <!-- ko ifnot: minPokerus > GameConstants.Pokerus.Infected -->
+                                    <!-- ko let: {minPokerus: RouteHelper.minPokerus($data), usePokerusProgress: Settings.getSetting('usePokerusProgress').observableValue()} -->
+                                        <!-- ko ifnot:  usePokerusProgress && minPokerus > GameConstants.Pokerus.Infected -->
                                         <img src="" data-bind="
                                             attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[minPokerus] + '.png'}" />
                                         <!-- /ko -->
-                                        <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
+                                        <!-- ko if: usePokerusProgress && minPokerus > GameConstants.Pokerus.Infected -->
                                         <div data-bind="text: RouteHelper.getPokerusProgress($data),
                                             class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus]"></div>
                                         <!-- /ko -->

--- a/src/index.html
+++ b/src/index.html
@@ -234,12 +234,12 @@
                                         <!--Pokérus image-->
                                         <knockout data-bind="using: RouteHelper.getAvailablePokemonList(player.route, player.region, true)">
                                             <knockout data-bind="if: RouteHelper.minPokerusCheck($data)">
-                                                <!-- ko let: {minPokerus: RouteHelper.minPokerus($data)} -->
-                                                    <!-- ko ifnot: minPokerus > GameConstants.Pokerus.Infected -->
+                                                <!-- ko let: {minPokerus: RouteHelper.minPokerus($data), usePokerusProgress: Settings.getSetting('usePokerusProgress').observableValue()} -->
+                                                    <!-- ko ifnot: usePokerusProgress && minPokerus > GameConstants.Pokerus.Infected -->
                                                     <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[minPokerus] + '.png',
                                                         title: RouteHelper.routePokerusEVs(player.route, player.region)}" src=""/>
                                                     <!-- /ko -->
-                                                    <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
+                                                    <!-- ko if: usePokerusProgress && minPokerus > GameConstants.Pokerus.Infected -->
                                                     <div data-bind="text: RouteHelper.getPokerusProgress($data),
                                                         class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus],
                                                         attr: {title: RouteHelper.routePokerusEVs(player.route, player.region)}"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -241,7 +241,8 @@
                                                     <!-- /ko -->
                                                     <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
                                                     <div data-bind="text: RouteHelper.getPokerusProgress($data),
-                                                        class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus]"></div>
+                                                        class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus],
+                                                        attr: {title: RouteHelper.routePokerusEVs(player.route, player.region)}"></div>
                                                     <!-- /ko -->
                                                 <!-- /ko -->
                                             </knockout>

--- a/src/index.html
+++ b/src/index.html
@@ -232,10 +232,19 @@
                                         </knockout>
 
                                         <!--Pokérus image-->
-                                        <knockout data-bind="if: RouteHelper.minPokerusCheck(RouteHelper.getAvailablePokemonList(player.route, player.region, true))">
-                                            <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(RouteHelper.getAvailablePokemonList(player.route, player.region, true))] + '.png',
-                                                title: RouteHelper.routePokerusEVs(player.route, player.region)}"
-                                          src=""/>
+                                        <knockout data-bind="using: RouteHelper.getAvailablePokemonList(player.route, player.region, true)">
+                                            <knockout data-bind="if: RouteHelper.minPokerusCheck($data)">
+                                                <!-- ko let: {minPokerus: RouteHelper.minPokerus($data)} -->
+                                                    <!-- ko ifnot: minPokerus > GameConstants.Pokerus.Infected -->
+                                                    <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[minPokerus] + '.png',
+                                                        title: RouteHelper.routePokerusEVs(player.route, player.region)}" src=""/>
+                                                    <!-- /ko -->
+                                                    <!-- ko if: minPokerus > GameConstants.Pokerus.Infected -->
+                                                    <div data-bind="text: RouteHelper.getPokerusProgress($data),
+                                                        class: 'pokerusProgress' + GameConstants.Pokerus[minPokerus]"></div>
+                                                    <!-- /ko -->
+                                                <!-- /ko -->
+                                            </knockout>
                                         </knockout>
                                       </span>
                                     </td>
@@ -287,7 +296,7 @@
                             <img title="Chests opened in current dungeon" src="assets/images/dungeons/chest.png" height="25px" />
                             <span data-bind="text: `${DungeonRunner.chestsOpened()}/${DungeonRunner.map.totalChests()}`"></span>
                         </div>
-                        
+
                         <div style="position: absolute; right: 4px">
                             <img title="Encounters won in current dungeon" src="assets/images/dungeons/encounter.png" height="25px" />
                             <span data-bind="text: `${DungeonRunner.encountersWon()}/${DungeonRunner.map.totalFights()}`"></span>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -154,6 +154,7 @@ Settings.add(new Setting<string>('gameDisplayStyle', 'Game display style',
     ],
     'standard3'));
 Settings.add(new BooleanSetting('showMuteButton', 'Show mute/unmute button', true));
+Settings.add(new BooleanSetting('usePokerusProgress', 'Use Pokerus Progress for routes and dungeons instead of default icons', false));
 
 // CSS variable settings
 Settings.add(new CssVariableSetting('locked', 'Locked Location', [], '#000000'));

--- a/src/scripts/wildBattle/RouteHelper.ts
+++ b/src/scripts/wildBattle/RouteHelper.ts
@@ -111,6 +111,11 @@ class RouteHelper {
         return this.minPokerus(possiblePokemon) > 0;
     }
 
+    public static getPokerusProgress(possiblePokemon: PokemonNameType[]): string {
+        const resistants = possiblePokemon.filter((p) => (App.game.party.getPokemonByName(p)?.pokerus == GameConstants.Pokerus.Resistant));
+        return `${resistants.length} / ${possiblePokemon.length}`;
+    }
+
     public static isAchievementsComplete(route: number, region: GameConstants.Region) {
         return AchievementHandler.achievementList.every(achievement => {
             return !(achievement.property instanceof RouteKillRequirement && achievement.property.region === region && achievement.property.route === route && !achievement.isCompleted());

--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -186,7 +186,7 @@
   font-family: Arial, sans-serif;
   font-size: 11px;
   font-weight: 600;
-  line-height: 12px;
+  line-height: 11px;
   text-shadow: 1.25px 1.25px 1.2px rgba(0, 0, 0, 0.3);
   background-color: rgb(209, 125, 255);
   border-top: 1.2px rgba(247, 188, 255, 0.6) solid;
@@ -203,7 +203,7 @@
   font-family: Arial, sans-serif;
   font-size: 11px;
   font-weight: 600;
-  line-height: 12px;
+  line-height: 11px;
   text-shadow: 1.25px 1.25px 1.2px rgba(0, 0, 0, 0.3);
   background-color: rgb(170, 210, 248);
   border-top: 1.2px rgba(195, 216, 253, 0.6) solid;

--- a/src/styles/dungeon.less
+++ b/src/styles/dungeon.less
@@ -176,3 +176,37 @@
   width: 70%;
   z-index: 2;
 }
+
+.pokerusProgressContagious {
+  display: inline-block;
+  width: 40px;
+  height: 14px;
+  text-align: center;
+  color: rgb(235 234 249);
+  font-family: Arial, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 12px;
+  text-shadow: 1.25px 1.25px 1.2px rgba(0, 0, 0, 0.3);
+  background-color: rgb(209, 125, 255);
+  border-top: 1.2px rgba(247, 188, 255, 0.6) solid;
+  border-bottom: 1.2px rgba(107, 55, 135, 0.35) solid;
+  border-radius: 2px;
+}
+
+.pokerusProgressResistant {
+  display: inline-block;
+  width: 40px;
+  height: 14px;
+  text-align: center;
+  color: rgb(2 2 2);
+  font-family: Arial, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 12px;
+  text-shadow: 1.25px 1.25px 1.2px rgba(0, 0, 0, 0.3);
+  background-color: rgb(170, 210, 248);
+  border-top: 1.2px rgba(195, 216, 253, 0.6) solid;
+  border-bottom: 1.2px rgba(92, 162, 132, 0.9) solid;
+  border-radius: 2px;
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Use Pokerus Progress for routes and dungeons instead of default icons, and it can be toggle in settings.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
The default PKRS icons are so boring, players can't know the specific progress from them.
So I wanna change it, and I think it will be very cool, if players can know at a glance the specific pokerus progress of routes and dungeons or even the total numbers of pokemons on the routes.

The default icons are PNG that can't be modified easily, so I used CSS to simulate it. But I'm poor at CSS, I have no idea if there's better way to handle it. Maybe I need some help.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Toggle the new setting and then observe whether the changes are the same as below.
`Uninfected`: None.
`Infected`: Only icon. Whether enabled or not.
`Contagious & Resistant`:  Icon if disabled or Progress if enabled.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![dungeonView](https://github.com/pokeclicker/pokeclicker/assets/34838824/9179d249-9ea7-49b3-98da-501567045d09)
![dungeon](https://github.com/pokeclicker/pokeclicker/assets/34838824/166ad53c-17b3-4625-8191-6ba17fab1e04)
![route](https://github.com/pokeclicker/pokeclicker/assets/34838824/346a8f65-0787-4382-923d-3f433b4f7ef5)



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
