### PR TITLE
Make Treasure Scanner affected by notification setting

### DIFF
--- a/src/modules/underground/Mine.ts
+++ b/src/modules/underground/Mine.ts
@@ -384,7 +384,7 @@ export class Mine {
                             message = `${amount == 3 ? 'Lucky' : 'Jackpot'}${jackpotMultiplier}! You found another ${humanifyString(itemName)}!`;
                         }
                         const timeout = Math.min(amount, 4) * 2000 + Math.max(amount - 4, 0) * 100;
-                        Notifier.notify({ message, type, title, timeout });
+                        Notifier.notify({ message, type, title, setting, timeout });
                     }
                 }
 


### PR DESCRIPTION
Gave Treasure Scanner notifications the `Underground.underground_item_found` type so they'll respect the corresponding notification setting.