### PR TITLE
Fixed a typo in Magikarp Jump Safari

### DIFF
--- a/src/modules/Credits.ts
+++ b/src/modules/Credits.ts
@@ -575,7 +575,7 @@ export const SpriteCredits: Credit[] = [
         link: 'https://discordapp.com/users/736029608587296819',
         image: 'assets/images/profile/trainer-119.png',
         resources: [
-            'Ditto (Transforming)',
+            'Ditto (Magikarp)',
             'Dugtrio (Punk)',
             'Genesect (High-Speed) and Drive Forms',
             'Koga Trainer',

--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -6090,7 +6090,7 @@ export const pokemonList = createPokemonArray(
     },
     {
         'id': 132.01,
-        'name': 'Ditto (Transforming)',
+        'name': 'Ditto (Magikarp)',
         'catchRate': 35,
         'type': [PokemonType.Normal],
         'levelType': LevelType.mediumfast,

--- a/src/modules/pokemons/PokemonNameType.ts
+++ b/src/modules/pokemons/PokemonNameType.ts
@@ -322,7 +322,7 @@ export type PokemonNameType
     | 'Lapras'
     | 'Gigantamax Lapras'
     | 'Ditto'
-    | 'Ditto (Transforming)'
+    | 'Ditto (Magikarp)'
     | 'Eevee'
     | 'Gigantamax Eevee'
     | 'Let\'s Go Eevee'

--- a/src/scripts/safari/SafariPokemonList.ts
+++ b/src/scripts/safari/SafariPokemonList.ts
@@ -224,7 +224,7 @@ class SafariPokemonList {
             new SafariEncounter('Magikarp Black Mask', 2, [SafariEnvironments.Water], new TemporaryBattleRequirement('Magikarp Jump Tykarp 2'), false, 'self'),
             new SafariEncounter('Magikarp Saucy Blue', 2, [SafariEnvironments.Water], new QuestLineCompletedRequirement('Dr. Splash\'s Research Project'), false, 'self'),
             // Both, meme encounter
-            new SafariEncounter('Ditto (Transforming)', 0.3, [SafariEnvironments.Water, SafariEnvironments.Grass],
+            new SafariEncounter('Ditto (Magikarp)', 0.3, [SafariEnvironments.Water, SafariEnvironments.Grass],
                 new CaughtUniquePokemonByFilterRequirement((p: PartyPokemon) => Math.floor(p.id) === pokemonMap.Magikarp.id, 'Catch more Magikarp species.', 6),
                 false,
                 'Magikarp'


### PR DESCRIPTION
## Description
I misspelled Magikarp. :^)

## Motivation and Context
Very motivated.

## How Has This Been Tested?
Ensured the game would not explode.

## Types of changes
- Bug fix
