### PR TITLE
Changed Fossil Notification

### DIFF
--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -413,7 +413,7 @@ class Breeding implements Feature {
         let fossilEgg: Egg;
         if (pokemonNativeRegion > player.highestRegion()) {
             Notifier.notify({
-                message: 'You must progress further before you can uncover this fossil Pokémon!',
+                message: `You must reach ${GameConstants.camelCaseToString(GameConstants.Region[pokemonNativeRegion])} before you can uncover this fossil Pokémon!`,
                 type: NotificationConstants.NotificationOption.warning,
                 timeout: 5e3,
             });


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Changed the "you can't use fossil" notification since it was too vague. I added the Region to it for better clarity.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
The original message was unhelpful.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Got a fossil from a later Region. Checked that it displayed the updated message correctly.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
Before:
![fossil-notifier-b](https://github.com/pokeclicker/pokeclicker/assets/106291026/4aeb67f2-af24-49a8-8e38-b4e9017e357b)

After:
![fossil-notifier](https://github.com/pokeclicker/pokeclicker/assets/106291026/28cac14b-7644-4492-a9cb-bd1bb8ea5c3c)


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
