### PR TITLE
Removed Micle's Aura Exception

### DIFF
--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -260,7 +260,7 @@ class Plot implements Saveable {
 
             if (this.emittingAura.type() !== null) {
                 tooltip.push('<u>Aura Emitted:</u>');
-                tooltip.push(`${AuraType[this.emittingAura.type()]}: ${this.berry === BerryType.Micle ? `+${this.emittingAura.value().toLocaleString('en-US', { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : `×${this.emittingAura.value().toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}`);
+                tooltip.push(`${AuraType[this.emittingAura.type()]}: ×${this.emittingAura.value().toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
             }
             const auraStr = this.formattedAuras();
             if (auraStr) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Removed Micle's aura exception in the code that displayed it as `+Number%` as it no longer works like that.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
`+Number%`, as mentioned in one of the bug threads in the Discord, makes people think that it boosts wanderers chance. This is incorrect. `xNumber` like the other berries is clearer.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Checked the Plot's tooltip. Checked a few berries to make sure their auras still displayed correctly.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
Before:
![micle-b](https://github.com/pokeclicker/pokeclicker/assets/106291026/ada5e546-eecd-4fe5-bee7-b848e914f439)

After:
![micle](https://github.com/pokeclicker/pokeclicker/assets/106291026/5f1135b3-f8e8-432b-a8f2-cc90db4082f6)


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
