### PR TITLE
Show effect of Petaya with altered berry growth times

### DIFF
--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -203,13 +203,17 @@ class Plot implements Saveable {
 
                 tooltip.push(`<u>${BerryType[this.berry]}</u>`);
 
+                const timeBoostType = Settings.getSetting('farmBoostDisplay').observableValue();
                 // Petaya Effect
                 if (App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && this.berry !== BerryType.Petaya && this.stage() == PlotStage.Berry) {
                     tooltip.push('∞ until death');
+                    if (timeBoostType) {
+                        tooltip.push(`(altered from ${this.formattedBaseStageTimeLeft()})`);
+                    }
                 // Normal Time
                 } else {
                     const timeType = Settings.getSetting('farmDisplay').observableValue();
-                    const timeBoostType = Settings.getSetting('farmBoostDisplay').observableValue();
+
                     const growthMultiplierNumber = App.game.farming.getGrowthMultiplier() * this.getGrowthMultiplier();
                     const altered = growthMultiplierNumber !== 1;
 
@@ -252,7 +256,10 @@ class Plot implements Saveable {
                         }
                     }
 
-                    tooltip.push(`${timetip}${altered && timeBoostType ? ` (altered from ${formattedBaseTime})` : ''}`);
+                    tooltip.push(timetip);
+                    if (altered && timeBoostType) {
+                        tooltip.push(`(altered from ${formattedBaseTime})`);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description
Updated tooltip for berries affected by Petaya to also show the base time when "Include base farm timer during altered berry growth times" is enabled
Also split the altered tooltips onto their own line, as they always break weirdly in the middle

## Motivation and Context
The wither time resetting property of Petaya is not obvious from the plot tooltip, nor is the tooltip consistent with others when you have the altered timer setting

## How Has This Been Tested?
Checked the tooltips in various situations

## Screenshots (optional):
Berry affected by Petaya:
![image](https://github.com/pokeclicker/pokeclicker/assets/16630222/3e8e7c75-e2b8-4b4e-b1b3-26b0c73653fb)

Berry with Boost Mulch:
![image](https://github.com/pokeclicker/pokeclicker/assets/16630222/46fa7952-56d2-4c8c-a275-0e781b337ab1)


## Types of changes
- UI improvement
