### PR TITLE
Include settings in update save backups

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2803,7 +2803,7 @@ class Update implements Saveable {
         const settingsData = this.getSettingsData();
 
         // Save the data by stringifying it, so that it isn't mutated during update
-        const backupSaveData = JSON.stringify({ player: playerData, save: saveData });
+        const backupSaveData = JSON.stringify({ player: playerData, save: saveData, settings: settingsData });
 
         const button = document.createElement('a');
         try {


### PR DESCRIPTION
Changed `Update.ts` to include settings in its save backups, as you would expect it to.

## Motivation and Context
Recently I loaded an update backup and discovered all my pokeball filters had been reversed. This was extremely annoying to fix.

I'm pretty sure settings not being backed up was just an oversight, given this line hadn't been touched before since its addition prior to Update.ts updating settings.

## How Has This Been Tested?
Updated an old save, cleared localStorage and loaded the backup, confirmed settings data was present.