### PR TITLE
Changed Key Stone price

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2743,6 +2743,9 @@ class Update implements Saveable {
 
             // Fix all weird amounts of Pokéballs
             saveData.pokeballs.pokeballs = saveData.pokeballs.pokeballs.map(n => Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, n)));
+
+            // Reset Key Stone multiplier
+            delete playerData._itemMultipliers.Key_stone;
         },
     };
 

--- a/src/scripts/items/EvolutionStone.ts
+++ b/src/scripts/items/EvolutionStone.ts
@@ -3,8 +3,8 @@ class EvolutionStone extends CaughtIndicatingItem {
     type: GameConstants.StoneType;
     public unlockedRegion: GameConstants.Region;
 
-    constructor(type: GameConstants.StoneType, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.questPoint, displayName: string, unlockedRegion?: GameConstants.Region) {
-        super(GameConstants.StoneType[type], basePrice, currency, undefined, displayName, 'An evolution item. See your Item Bag for more information.', 'evolution');
+    constructor(type: GameConstants.StoneType, basePrice: number, currency: GameConstants.Currency = GameConstants.Currency.questPoint, displayName: string, unlockedRegion?: GameConstants.Region, options?: ShopOptions) {
+        super(GameConstants.StoneType[type], basePrice, currency, options, displayName, 'An evolution item. See your Item Bag for more information.', 'evolution');
         this.type = type;
         this.unlockedRegion = unlockedRegion;
     }
@@ -104,7 +104,7 @@ ItemList.Black_DNA         = new EvolutionStone(GameConstants.StoneType.Black_DN
 ItemList.White_DNA         = new EvolutionStone(GameConstants.StoneType.White_DNA, 2500, undefined, 'White DNA');
 ItemList.Sachet            = new EvolutionStone(GameConstants.StoneType.Sachet, 2500, undefined , 'Sachet');
 ItemList.Whipped_dream     = new EvolutionStone(GameConstants.StoneType.Whipped_dream, 2500, undefined , 'Whipped Dream');
-ItemList.Key_stone         = new EvolutionStone(GameConstants.StoneType.Key_stone, 25000, GameConstants.Currency.battlePoint, 'Key Stone', GameConstants.Region.kalos);
+ItemList.Key_stone         = new EvolutionStone(GameConstants.StoneType.Key_stone, 250, GameConstants.Currency.battlePoint, 'Key Stone', GameConstants.Region.kalos, {multiplier: 1.1, multiplierDecrease: false});
 ItemList.Ice_stone         = new EvolutionStone(GameConstants.StoneType.Ice_stone, 2500, undefined , 'Ice Stone');
 ItemList.Solar_light       = new EvolutionStone(GameConstants.StoneType.Solar_light, 2500, undefined, 'Solar Light');
 ItemList.Lunar_light       = new EvolutionStone(GameConstants.StoneType.Lunar_light, 2500, undefined, 'Lunar Light');


### PR DESCRIPTION
## Description
Base price is 250 and get multiplied by 1.1 on each purchase. It never goes down again, reaching its peak of usual 25000 at 49 purchases.
The price multiplier is reset for everyone, just in case.

## Motivation and Context
That makes for a much more linear progress toward obtaining all the Mega Pokémon, without making it too easy.

## How Has This Been Tested?
I bought a bunch of Key Stones. Checked the price increase, and made sure it does not decrease.

## Types of changes
- Feature improvement