### PR TITLE
Improved save selector context menu access

### DIFF
--- a/src/components/saveSelector.html
+++ b/src/components/saveSelector.html
@@ -38,6 +38,7 @@
     <div class="trainer-card-container mb-3 col-lg-4 col-md-6 col-sm-12 xol-xs-12">
         <div class="trainer-card clickable card font-weight-bold">
             <div class="card-body">
+                <div class="position-absolute context-menu-button px-1" style="top: 0; left: 2px; cursor: help;">⋮</div>
                 <div class="position-absolute small trainer-id" style="top: 0; right: 5px;"></div>
                 <h5 class="align-middle font-weight-bold">
                     <img class="trainer-image"/>

--- a/src/modules/SaveSelector.ts
+++ b/src/modules/SaveSelector.ts
@@ -24,23 +24,34 @@ export default class SaveSelector {
 
         $('[data-toggle="tooltip"]').tooltip();
 
+        const showContextMenu = (top: number, left: number, key: string) => {
+            $('#saveSelectorContextMenu').html(`
+                <a class="dropdown-item bg-success" href="#" onclick="Save.key = '${key}'; SaveSelector.Download('${key}')">Download (backup)</a>
+                <a class="dropdown-item bg-info" href="#" onclick="Save.key = '${key}'; document.querySelector('#saveSelector').remove(); App.start();">Load</a>
+                <a class="dropdown-item bg-warning" href="#"><label class="clickable my-0" for="import-save" onclick="Save.key = '${key}';">Import (overwrite)</label></a>
+                <a class="dropdown-item bg-danger" href="#" onclick="Save.key = '${key}'; Save.delete();">Delete</a>
+            `).css({
+                display: 'block',
+                position: 'absolute',
+                top,
+                left,
+            }).addClass('show');
+        };
+
         $(container).on('contextmenu', '.trainer-card.clickable', (e) => {
-            const top = e.pageY;
-            const left = e.pageX;
             const { key } = e.currentTarget.dataset;
             if (key) {
-                $('#saveSelectorContextMenu').html(`
-                    <a class="dropdown-item bg-success" href="#" onclick="Save.key = '${key}'; SaveSelector.Download('${key}')">Download (backup)</a>
-                    <a class="dropdown-item bg-info" href="#" onclick="Save.key = '${key}'; document.querySelector('#saveSelector').remove(); App.start();">Load</a>
-                    <a class="dropdown-item bg-warning" href="#"><label class="clickable my-0" for="import-save" onclick="Save.key = '${key}';">Import (overwrite)</label></a>
-                    <a class="dropdown-item bg-danger" href="#" onclick="Save.key = '${key}'; Save.delete();">Delete</a>
-                `).css({
-                    display: 'block',
-                    position: 'absolute',
-                    top,
-                    left,
-                }).addClass('show');
+                showContextMenu(e.pageY, e.pageX, key);
                 return false; // blocks default Webbrowser right click menu
+            }
+            return true;
+        });
+
+        $(container).on('click', '.context-menu-button', (e) => {
+            const { key } = e.currentTarget.closest('.trainer-card.clickable').dataset;
+            if (key) {
+                showContextMenu(e.pageY, e.pageX, key);
+                return false;
             }
             return true;
         });

--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -68,7 +68,10 @@ export default class Profile implements Saveable {
         card.classList.add(`trainer-bg-${background}`);
         card.style.color = textColor;
         card.dataset.key = key;
-        card.addEventListener('click', () => {
+        card.addEventListener('click', (e) => {
+            if ((e.target as HTMLElement).classList.contains('context-menu-button')) {
+                return;
+            }
             // If no key provided, this is a preview
             if (key === undefined) {
                 Notifier.notify({ message: 'What a lovely profile!' });

--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -113,6 +113,9 @@ export default class Profile implements Saveable {
             });
         const trainerId: HTMLElement = node.querySelector('.trainer-id');
         trainerId.innerText = id.length ? `#${id}` : '';
+        if (key === undefined) {
+            node.querySelector('.context-menu-button').remove();
+        }
         return container;
     }
 


### PR DESCRIPTION
## Description
Adds a vertical ellipsis to the top left of save selector trainer cards that can be clicked/tapped to access the context menu.

## Motivation and Context
Recently we learned that certain mobile devices/browsers (iOS / Safari) don't handle the `contextmenu` event so accessing the context menu to download a copy of a save from the save selector screen is not possible on these devices.

## Screenshots (optional):
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/29d14aff-4888-4c2f-a170-b50d434d40fa)
![image](https://github.com/pokeclicker/pokeclicker/assets/672420/0a185744-aef3-4991-ad3f-f01fcd14daa2)

## Types of changes
- UI improvement
