### PR TITLE
Fix dungeon guide next floor timer bug

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2743,6 +2743,13 @@ class Update implements Saveable {
 
             // Fix all weird amounts of Pokéballs
             saveData.pokeballs.pokeballs = saveData.pokeballs.pokeballs.map(n => Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, n)));
+
+            // Fix pokemon multi-category bug from 0.10.20 update for very old files
+            saveData.party.caughtPokemon.forEach(pokemon => {
+                if (!Array.isArray(pokemon[6])) {
+                    pokemon[6] = [pokemon[6] ?? 0];
+                }
+            });
         },
     };
 

--- a/src/scripts/dungeons/DungeonGuides.ts
+++ b/src/scripts/dungeons/DungeonGuides.ts
@@ -36,11 +36,8 @@ class DungeonGuide {
                 switch (DungeonRunner.map.currentTile().type()) {
                     case GameConstants.DungeonTileType.chest:
                     case GameConstants.DungeonTileType.boss:
-                        DungeonRunner.handleInteraction();
-                        break;
                     case GameConstants.DungeonTileType.ladder:
                         DungeonRunner.handleInteraction();
-                        DungeonRunner.map.playerMoved(true);
                         break;
                 }
             } catch (e) {

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -265,7 +265,9 @@ class DungeonRunner {
         );
         DungeonRunner.map.playerPosition.notifySubscribers();
         DungeonRunner.timeLeft(DungeonRunner.timeLeft() + GameConstants.DUNGEON_LADDER_BONUS);
-        DungeonRunner.map.playerMoved(false);
+        if (!DungeonGuides.hired()) {
+            DungeonRunner.map.playerMoved(false);
+        }
     }
 
     public static async dungeonLeave(shouldConfirm = Settings.getSetting('confirmLeaveDungeon').observableValue()): Promise<void> {


### PR DESCRIPTION
While a dungeon guide is hired if the player manually progresses to the next floor the guide will continue to explore but the timer will remain paused.

Also includes a small update fix for a multi-category bug for very old files

## How Has This Been Tested?
Manually clicked the ladder tile and next floor button and verified the timer continued.

## Types of changes
- Bug fix