### PR TITLE
Fixed "Agnol" being misspelled

### DIFF
--- a/src/modules/Credits.ts
+++ b/src/modules/Credits.ts
@@ -15,7 +15,7 @@ export const SpriteCredits: Credit[] = [
         link: 'https://www.deviantart.com/akuma-tsubasa',
         image: 'https://a.deviantart.net/avatars-big/a/k/akuma-tsubasa.png?13',
         resources: [
-            'Angol',
+            'Agnol',
             'Cail',
             'Cipher Peon (male and female)',
             'Cipher Peon XD (male and female)',

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -5841,7 +5841,7 @@ dungeonList['Deep Colosseum'] = new Dungeon('Deep Colosseum',
                 new GymPokemon('Kingdra', 1750000, 70),
                 new GymPokemon('Shedinja', 1750000, 68),
                 new GymPokemon('Shuckle', 1750000, 45, undefined, undefined, GameConstants.ShadowStatus.Shadow),
-            ], { weight: 1 }, 'Angol', '(angol)'),
+            ], { weight: 1 }, 'Agnol', '(angol)'),
     ],
     88800, 134);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

Fixed "Agnol" being spelled "Angol".
Didn't make changes in the image, so the correct sprite is still pulled.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

https://bulbapedia.bulbagarden.net/wiki/Agnol and the bug report on Discord. Spelling mistake bad.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Made fix. Went to Credits and the Deep Coloseum, checked if Agnol now has his name spelled correctly. He does. Everything's great.

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
