### PR TITLE
Bulletin Board locked behind Tutorial Requirement

### DIFF
--- a/src/scripts/quests/BulletinBoard.ts
+++ b/src/scripts/quests/BulletinBoard.ts
@@ -50,7 +50,7 @@ class BulletinBoard extends TownContent {
     }
 
     constructor(public board: GameConstants.BulletinBoards) {
-        super();
+        super([new QuestLineCompletedRequirement('Tutorial Quests')]);
     }
 
 }


### PR DESCRIPTION
## Description
Locked all Bulletin Boards behind having completed the Tutorial Quests. The button still appears but is greyed out and tells the player to finish the tutorial, when clicked on.

## Motivation and Context
It prevents people from triggering an event questline too early.
That is literally dumbproofing the thing, lol.
The main reason is Easter event questline being available before the player defeated Viridian Forest once as it could be annoying and kind of softlocking.

## How Has This Been Tested?
Created a new save during Easter.

## Types of changes
- Bug fix, I guess ?
