### PR TITLE
Workaround? Fix? For the obscure achievement, flute, locale bug

### DIFF
--- a/src/modules/achievements/Achievement.ts
+++ b/src/modules/achievements/Achievement.ts
@@ -24,7 +24,7 @@ export default class Achievement {
         public achievableFunction: () => boolean | null = null,
     ) {}
 
-    public check() {
+    public check(): boolean {
         if (this.isCompleted() && !this.unlocked()) {
             Notifier.notify({
                 title: `[Achievement] ${this.name}`,
@@ -44,7 +44,9 @@ export default class Achievement {
             }
             // TODO: refilter within achievement bonus
             // AchievementHandler.filterAchievementList(true);
+            return true;
         }
+        return false;
     }
 
     public getProgress() {

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -6,7 +6,7 @@ class AchievementHandler {
     public static navigateIndex: KnockoutObservable<number> = ko.observable(0);
     public static achievementListFiltered: KnockoutObservableArray<Achievement> = ko.observableArray([]);
     public static numberOfTabs: KnockoutObservable<number> = ko.observable(0);
-    public static _cachedAchievementBonus: KnockoutObservable<number> = ko.observable(1);
+    public static _cachedAchievementBonus: KnockoutObservable<number> = ko.observable(0);
 
     public static setNavigateIndex(index: number): void {
         if (index < 0 || index >= AchievementHandler.numberOfTabs()) {

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -173,6 +173,7 @@ class AchievementHandler {
             category.totalWeight = AchievementHandler.achievementList.filter(a => a.category == category && a.achievable()).reduce((sum, a) => sum + a.bonusWeight, 0);
         });
         AchievementHandler.calculateBonus();
+        AchievementHandler.updateAchievementBonus();
     }
 
     public static achievementBonus(): number {

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -121,13 +121,16 @@ class AchievementHandler {
     }
 
     public static checkAchievements() {
-        let unlocked = false;
+        let updateBonus = false;
         for (let i = 0; i < AchievementHandler.achievementList.length; i++) {
             if (!AchievementHandler.achievementList[i].unlocked()) {
-                unlocked = unlocked || AchievementHandler.achievementList[i].check();
+                const unlocked = AchievementHandler.achievementList[i].check();
+                if (unlocked) {
+                    updateBonus = true;
+                }
             }
         }
-        if (unlocked) {
+        if (updateBonus) {
             AchievementHandler.updateAchievementBonus();
         }
     }

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -6,6 +6,7 @@ class AchievementHandler {
     public static navigateIndex: KnockoutObservable<number> = ko.observable(0);
     public static achievementListFiltered: KnockoutObservableArray<Achievement> = ko.observableArray([]);
     public static numberOfTabs: KnockoutObservable<number> = ko.observable(0);
+    public static _cachedAchievementBonus: KnockoutObservable<number> = ko.observable(1);
 
     public static setNavigateIndex(index: number): void {
         if (index < 0 || index >= AchievementHandler.numberOfTabs()) {
@@ -116,13 +117,18 @@ class AchievementHandler {
         for (let i = 0; i < AchievementHandler.achievementList.length; i++) {
             AchievementHandler.achievementList[i].unlocked(AchievementHandler.achievementList[i].isCompleted());
         }
+        AchievementHandler.updateAchievementBonus();
     }
 
     public static checkAchievements() {
+        let unlocked = false;
         for (let i = 0; i < AchievementHandler.achievementList.length; i++) {
             if (!AchievementHandler.achievementList[i].unlocked()) {
-                AchievementHandler.achievementList[i].check();
+                unlocked = unlocked || AchievementHandler.achievementList[i].check();
             }
+        }
+        if (unlocked) {
+            AchievementHandler.updateAchievementBonus();
         }
     }
 
@@ -167,6 +173,10 @@ class AchievementHandler {
     }
 
     public static achievementBonus(): number {
+        return AchievementHandler._cachedAchievementBonus();
+    }
+
+    public static updateAchievementBonus() {
         let sum = 0;
         AchievementHandler.getAchievementCategories().forEach(category => {
             const total = AchievementHandler.achievementList.filter(a => {
@@ -176,7 +186,7 @@ class AchievementHandler {
                 sum += total;
             }
         });
-        return sum;
+        AchievementHandler._cachedAchievementBonus(sum);
     }
 
     public static achievementBonusPercent(): string {


### PR DESCRIPTION
## Description
Implements a workaround for the crash some players experience on load while the pokemon attack flute is active during certain periods of time.

No idea what the root cause is or why it only affects some locales and only happens during certain periods of time, but this seems to take care of it.

## How Has This Been Tested?
The two files I have that are affected by this bug both load successfully with these changes.

## Types of changes
- Bug fix????
