### PR TITLE
Close/prevent some frequent notifications

### DIFF
--- a/src/modules/items/EnergyRestore.ts
+++ b/src/modules/items/EnergyRestore.ts
@@ -4,6 +4,7 @@ import Notifier from '../notifications/Notifier';
 import Item from './Item';
 
 export default class EnergyRestore extends Item {
+    private lastNotification: { close: () => void, closed: boolean } = { close: () => null, closed: true };
     type: EnergyRestoreSize;
 
     constructor(type: EnergyRestoreSize, basePrice: number, currency: Currency = Currency.money, displayName?: string) {
@@ -16,7 +17,8 @@ export default class EnergyRestore extends Item {
             return false;
         }
         if (App.game.underground.energy === App.game.underground.getMaxEnergy()) {
-            Notifier.notify({
+            if (!this.lastNotification.closed) return false;
+            this.lastNotification = Notifier.notify({
                 message: 'Your mining energy is already full!',
                 type: NotificationConstants.NotificationOption.danger,
             });

--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -10,6 +10,7 @@ class GymRunner {
     public static running: KnockoutObservable<boolean> = ko.observable(false);
     public static autoRestart: KnockoutObservable<boolean> = ko.observable(false);
     public static initialRun = true;
+    public static lastWinNotification: {notification: {close: () => void, closed: boolean}, gym: Gym} = {notification: {closed: true, close: () => null}, gym: null};
 
     public static startGym(
         gym: Gym,
@@ -99,11 +100,15 @@ class GymRunner {
     public static gymWon(gym: Gym) {
         if (GymRunner.running()) {
             GymRunner.running(false);
-            Notifier.notify({
-                message: `Congratulations, you defeated ${GymBattle.gym.leaderName.replace(/\d/g, '')}!`,
-                type: NotificationConstants.NotificationOption.success,
-                setting: NotificationConstants.NotificationSetting.General.gym_won,
-            });
+            // don't show notifications for the same gym too fast
+            if (this.lastWinNotification.notification.closed || this.lastWinNotification.gym !== gym) {
+                this.lastWinNotification.notification = Notifier.notify({
+                    message: `Congratulations, you defeated ${GymBattle.gym.leaderName.replace(/\d/g, '')}!`,
+                    type: NotificationConstants.NotificationOption.success,
+                    setting: NotificationConstants.NotificationSetting.General.gym_won,
+                });
+                this.lastWinNotification.gym = gym;
+            }
             // If this is the first time defeating this gym
             if (!App.game.badgeCase.hasBadge(gym.badgeReward)) {
                 gym.firstWinReward();

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -319,7 +319,7 @@ class PartyPokemon implements Saveable {
     public useConsumable(type: GameConstants.ConsumableType, amount: number): void {
         const itemName = GameConstants.ConsumableType[type];
         if (!player.itemList[itemName]()) {
-            return Notifier.notify({
+            Notifier.notify({
                 message : `You do not have any more ${ItemList[itemName].displayName}`,
                 type : NotificationConstants.NotificationOption.danger,
             });

--- a/src/scripts/towns/PurifyChamber.ts
+++ b/src/scripts/towns/PurifyChamber.ts
@@ -30,6 +30,7 @@ class PurifyChamber implements Saveable {
     public currentFlow: KnockoutObservable<number>;
     public flowNeeded: KnockoutComputed<number>;
     private notified = false;
+    private flowNotification: {close: () => void}
 
     constructor() {
         this.selectedPokemon = ko.observable(undefined);
@@ -63,6 +64,7 @@ class PurifyChamber implements Saveable {
         this.selectedPokemon().shadow = GameConstants.ShadowStatus.Purified;
         this.currentFlow(0);
         this.notified = false;
+        this.flowNotification.close();
     }
 
     public gainFlow(exp: number) {
@@ -74,7 +76,7 @@ class PurifyChamber implements Saveable {
 
         if (!this.notified && this.currentFlow() >= this.flowNeeded()) {
             this.notified = true;
-            Notifier.notify({
+            this.flowNotification = Notifier.notify({
                 title: 'Purify Chamber',
                 message: 'Maximum Flow has accumulated at the Purify Chamber in Orre!',
                 type: NotificationConstants.NotificationOption.primary,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

- Energy restores now only display one "Your energy is already full!" at a time. Previously, when holding a hotkey to restore energy, notifications would be spammed
- Maximum flow notifications now close when purifying a shadow pokemon. The duration has not been changed, although it could be increased
- Gym clear notifications now only occur when the previous notification has closed or the player is at a new gym


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

People were complaining about it on the discord
(I've never contributed on github before and wanted to try it out, so tell me if it could be improved or anything)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Used some restores, purified some pokemon, cleared some gyms. Everything works as expected



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement