### PR TITLE
Reduced Fossils toggle

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -129,6 +129,7 @@
                                 'data': {'totalBonus': App.game.underground.getSurvey_Cost(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Survey_Cost)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeTemplate',
                                 'data': {'totalBonus' : App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Items_All).calculateBonus(), 'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Items_All)}}"></tr>
+                            <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Fossils)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Shards)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Plates)}}"></tr>
                             <tr data-bind="template: { name: 'undergroundUpgradeToggleTemplate', 'data': {'upgrade': App.game.underground.getUpgrade(UndergroundUpgrade.Upgrades.Reduced_Evolution_Items)}}"></tr>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -214,6 +214,7 @@ Object.values(NotificationConstants.NotificationSetting).forEach((settingsGroup)
  */
 
 // Underground
+Settings.add(new BooleanSetting('underground.Reduced_Fossils', 'Reduced Fossils', true, undefined, false));
 Settings.add(new BooleanSetting('underground.Reduced_Shards', 'Reduced Shards', true, undefined, false));
 Settings.add(new BooleanSetting('underground.Reduced_Plates', 'Reduced Plates', true, undefined, false));
 Settings.add(new BooleanSetting('underground.Reduced_Evolution_Items', 'Reduced Evolution Items', true, undefined, false));

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -223,7 +223,7 @@ export class Underground implements Feature {
             new UndergroundUpgrade(
                 UndergroundUpgrade.Upgrades.Reduced_Fossils, 'Reduced Fossils', 1,
                 [new Amount(0, Currency.diamond)],
-                [],
+                GameHelper.createArray(0, 1, 1),
                 true,
                 'Greatly reduces the number of previously found fossils (toggleable)',
                 undefined, 1,

--- a/src/modules/underground/Underground.ts
+++ b/src/modules/underground/Underground.ts
@@ -18,6 +18,7 @@ import UndergroundItems from './UndergroundItems';
 import UndergroundUpgrade, { Upgrades } from './UndergroundUpgrade';
 import MaxRegionRequirement from '../requirements/MaxRegionRequirement';
 import Settings from '../settings/Settings';
+import Amount from '../wallet/Amount';
 
 export class Underground implements Feature {
     name = 'Underground';
@@ -217,6 +218,15 @@ export class Underground implements Feature {
                 true,
                 'Greatly reduces the number of Galar fossil pieces (toggleable)',
                 new MaxRegionRequirement(Region.galar),
+            ),
+            // Available & enabled by default
+            new UndergroundUpgrade(
+                UndergroundUpgrade.Upgrades.Reduced_Fossils, 'Reduced Fossils', 1,
+                [new Amount(0, Currency.diamond)],
+                [],
+                true,
+                'Greatly reduces the number of previously found fossils (toggleable)',
+                undefined, 1,
             ),
         ];
     }
@@ -492,7 +502,8 @@ export class Underground implements Feature {
         const upgrades = json.upgrades;
         for (const item in UndergroundUpgrade.Upgrades) {
             if (isNaN(Number(item))) {
-                this.getUpgrade((<any>UndergroundUpgrade.Upgrades)[item]).level = upgrades[item] || 0;
+                const upgrade = this.getUpgrade((<any>UndergroundUpgrade.Upgrades)[item]);
+                upgrade.level = upgrades[item] || upgrade.startLevel;
             }
         }
         this.energy = json.energy || 0;

--- a/src/modules/underground/UndergroundFossilItem.ts
+++ b/src/modules/underground/UndergroundFossilItem.ts
@@ -1,0 +1,25 @@
+import UndergroundItemValueType from '../enums/UndergroundItemValueType';
+import { FossilToPokemon } from '../GameConstants';
+import Requirement from '../requirements/Requirement';
+import Settings from '../settings';
+import UndergroundItem from './UndergroundItem';
+
+export default class UndergroundFossilItem extends UndergroundItem {
+    constructor(
+        id: number,
+        itemName: string,
+        space: Array<Array<number>>,
+        value = 1,
+        requirement?: Requirement,
+    ) {
+        const weightFunc = (): number => {
+            if (player.itemList[itemName]() == 0 && !App.game.party.alreadyCaughtPokemonByName(FossilToPokemon[this.name])) {
+                return 1.5;
+            }
+
+            return Settings.getSetting('underground.Reduced_Fossils').observableValue() ? 0.1 : 1;
+        };
+
+        super(id, itemName, space, value, UndergroundItemValueType.Fossil, requirement, weightFunc);
+    }
+}

--- a/src/modules/underground/UndergroundItems.ts
+++ b/src/modules/underground/UndergroundItems.ts
@@ -4,6 +4,7 @@ import { MegaStoneType, Region, StoneType } from '../GameConstants';
 import MaxRegionRequirement from '../requirements/MaxRegionRequirement';
 import Rand from '../utilities/Rand';
 import UndergroundEvolutionItem from './UndergroundEvolutionItem';
+import UndergroundFossilItem from './UndergroundFossilItem';
 import UndergroundFossilPieceItem from './UndergroundFossilPieceItem';
 import UndergroundGemItem from './UndergroundGemItem';
 import UndergroundItem from './UndergroundItem';
@@ -90,28 +91,17 @@ UndergroundItems.addItem(new UndergroundGemItem(116, 'Pixie_plate', [[1, 1, 1, 1
 UndergroundItems.addItem(new UndergroundGemItem(117, 'Blank_plate', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], PokemonType.Normal));
 
 // Fossils/Fossil Pieces
-UndergroundItems.addItem(new UndergroundItem(200, 'Helix_fossil', [[0, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, null,
-    () => (App.game.party.alreadyCaughtPokemonByName('Omanyte') || player.itemList.Helix_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(201, 'Dome_fossil', [[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, null,
-    () => (App.game.party.alreadyCaughtPokemonByName('Kabuto') || player.itemList.Dome_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(202, 'Old_amber', [[0, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, null,
-    () => (App.game.party.alreadyCaughtPokemonByName('Aerodactyl') || player.itemList.Old_amber() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(203, 'Root_fossil', [[0, 0, 1, 1, 1], [0, 0, 1, 1, 1], [1, 0, 0, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.hoenn),
-    () => (App.game.party.alreadyCaughtPokemonByName('Lileep') || player.itemList.Root_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(204, 'Claw_fossil', [[1, 1, 1, 0, 0], [1, 1, 1, 1, 0], [0, 1, 1, 1, 1], [0, 0, 0, 1, 1]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.hoenn),
-    () => (App.game.party.alreadyCaughtPokemonByName('Anorith') || player.itemList.Claw_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(205, 'Armor_fossil', [[0, 1, 1, 1, 0], [0, 1, 1, 1, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.sinnoh),
-    () => (App.game.party.alreadyCaughtPokemonByName('Shieldon') || player.itemList.Armor_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(206, 'Skull_fossil', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [0, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.sinnoh),
-    () => (App.game.party.alreadyCaughtPokemonByName('Cranidos') || player.itemList.Skull_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(207, 'Cover_fossil', [[1, 1, 1, 1, 0], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 1]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.unova),
-    () => (App.game.party.alreadyCaughtPokemonByName('Tirtouga') || player.itemList.Cover_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(208, 'Plume_fossil', [[0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 0], [1, 1, 1, 1, 0], [1, 1, 0, 0, 0]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.unova),
-    () => (App.game.party.alreadyCaughtPokemonByName('Archen') || player.itemList.Plume_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(209, 'Jaw_fossil', [[0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.kalos),
-    () => (App.game.party.alreadyCaughtPokemonByName('Tyrunt') || player.itemList.Jaw_fossil() > 0 ? 0.1 : 1.5)));
-UndergroundItems.addItem(new UndergroundItem(210, 'Sail_fossil', [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, UndergroundItemValueType.Fossil, new MaxRegionRequirement(Region.kalos),
-    () => (App.game.party.alreadyCaughtPokemonByName('Amaura') || player.itemList.Sail_fossil() > 0 ? 0.1 : 1.5)));
+UndergroundItems.addItem(new UndergroundFossilItem(200, 'Helix_fossil', [[0, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 0]], 0, null));
+UndergroundItems.addItem(new UndergroundFossilItem(201, 'Dome_fossil', [[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, null));
+UndergroundItems.addItem(new UndergroundFossilItem(202, 'Old_amber', [[0, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 0]], 0, null));
+UndergroundItems.addItem(new UndergroundFossilItem(203, 'Root_fossil', [[0, 0, 1, 1, 1], [0, 0, 1, 1, 1], [1, 0, 0, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, new MaxRegionRequirement(Region.hoenn)));
+UndergroundItems.addItem(new UndergroundFossilItem(204, 'Claw_fossil', [[1, 1, 1, 0, 0], [1, 1, 1, 1, 0], [0, 1, 1, 1, 1], [0, 0, 0, 1, 1]], 0, new MaxRegionRequirement(Region.hoenn)));
+UndergroundItems.addItem(new UndergroundFossilItem(205, 'Armor_fossil', [[0, 1, 1, 1, 0], [0, 1, 1, 1, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, new MaxRegionRequirement(Region.sinnoh)));
+UndergroundItems.addItem(new UndergroundFossilItem(206, 'Skull_fossil', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [0, 1, 1, 0]], 0, new MaxRegionRequirement(Region.sinnoh)));
+UndergroundItems.addItem(new UndergroundFossilItem(207, 'Cover_fossil', [[1, 1, 1, 1, 0], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 1]], 0, new MaxRegionRequirement(Region.unova)));
+UndergroundItems.addItem(new UndergroundFossilItem(208, 'Plume_fossil', [[0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 0], [1, 1, 1, 1, 0], [1, 1, 0, 0, 0]], 0, new MaxRegionRequirement(Region.unova)));
+UndergroundItems.addItem(new UndergroundFossilItem(209, 'Jaw_fossil', [[0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 0]], 0, new MaxRegionRequirement(Region.kalos)));
+UndergroundItems.addItem(new UndergroundFossilItem(210, 'Sail_fossil', [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 1], [0, 1, 1, 1, 0]], 0, new MaxRegionRequirement(Region.kalos)));
 UndergroundItems.addItem(new UndergroundFossilPieceItem(211, 'Fossilized_bird', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, new MaxRegionRequirement(Region.galar)));
 UndergroundItems.addItem(new UndergroundFossilPieceItem(212, 'Fossilized_fish', [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]], 0, new MaxRegionRequirement(Region.galar)));
 UndergroundItems.addItem(new UndergroundFossilPieceItem(213, 'Fossilized_drake', [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]], 0, new MaxRegionRequirement(Region.galar)));

--- a/src/modules/underground/UndergroundUpgrade.ts
+++ b/src/modules/underground/UndergroundUpgrade.ts
@@ -17,6 +17,7 @@ export enum Upgrades {
     'Reduced_Plates',
     'Reduced_Evolution_Items',
     'Reduced_Fossil_Pieces',
+    'Reduced_Fossils',
 }
 
 export default class UndergroundUpgrade extends Upgrade {
@@ -27,8 +28,9 @@ export default class UndergroundUpgrade extends Upgrade {
         name: Upgrades, displayName: string, maxLevel: number,
         costList: Amount[], bonusList: number[], increasing = true,
         public description?: string, private requirement?: Requirement,
+        startLevel: number = 0,
     ) {
-        super(name, displayName, maxLevel, costList, bonusList, increasing);
+        super(name, displayName, maxLevel, costList, bonusList, increasing, startLevel);
     }
 
 

--- a/src/modules/upgrades/Upgrade.ts
+++ b/src/modules/upgrades/Upgrade.ts
@@ -7,9 +7,7 @@ import Notifier from '../notifications/Notifier';
 import Amount from '../wallet/Amount';
 
 export default class Upgrade implements Saveable {
-    defaults = {
-        level: 0,
-    };
+    defaults = {};
     saveKey: string;
 
     levelKO: KnockoutObservable<number> = ko.observable();
@@ -25,9 +23,10 @@ export default class Upgrade implements Saveable {
         // Describes whether this upgrade increases or decreases a number.
         // (e.g. power is increasing, time is decreasing).
         public increasing = true,
+        public startLevel: number = 0,
     ) {
         this.saveKey = name;
-        this.level = this.defaults.level;
+        this.level = startLevel;
     }
 
     calculateCost(): Amount {
@@ -83,7 +82,7 @@ export default class Upgrade implements Saveable {
         if (json == null) {
             return;
         }
-        this.level = json.level ?? this.defaults.level;
+        this.level = json.level ?? this.startLevel;
     }
 
     toJSON(): Record<string, any> {


### PR DESCRIPTION
## Description
Adds a Reduced Fossils upgrade toggle that's unlocked and enabled by default. Some weirdos might want to find more fossils so why not let them?

## How Has This Been Tested?
Checked that the fossil weights were calculated correctly with and without the pokemon/fossil and while the toggle was enabled/disabled
