### PR TITLE
Complete translations/poke ball module

### DIFF
--- a/src/components/pokeballSelector.html
+++ b/src/components/pokeballSelector.html
@@ -34,7 +34,10 @@
                             <td><span data-bind="
                                 text: $data.name,
                                 tooltip: {
-                                    title: $data.description,
+                                    title: () => PokeballFilter.tooltipDescription(
+                                        $data,
+                                        (key, namespace) => App.translation.get(key, namespace)(),
+                                    ),
                                     trigger: 'hover',
                                     boundary: 'window',
                                     animation: false,

--- a/src/components/pokeballSelector.html
+++ b/src/components/pokeballSelector.html
@@ -1,6 +1,6 @@
 <div id="pokeballSelector" class="card sortable border-secondary mb-3" data-bind="visible: player.regionStarters[GameConstants.Region.kanto]() != GameConstants.Starter.None">
     <div class="card-header p-0" data-toggle="collapse" href="#pokeballSelectorBody">
-        <span>Poké Balls</span>
+        <span data-bind="text: App.translation.get('pokeball.title', 'modules')"></span>
     </div>
     <!-- ko if: QuestLineHelper.isQuestLineCompleted('Tutorial Quests') -->
     <img class="clickable" src="assets/images/fa-cog.svg"
@@ -11,7 +11,11 @@
     <!-- /ko -->
     <button type="button" class="btn btn-info"
             style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px; padding: 4px;"
-            data-bind="tooltip: { title: 'Select which Poké Ball to use on Pokémon depending on their status. Right click (or long press on mobile) can be used to toggle filter enabled/disabled.', trigger: 'hover', placement:'left' }">
+            data-bind="tooltip: {
+                title: App.translation.get('pokeball.tooltip.help', 'modules'),
+                trigger: 'hover',
+                placement:'left'
+            }">
         ?
     </button>
     <div id="pokeballSelectorBody" class="card-body p-0 show">
@@ -20,9 +24,9 @@
                 <table class="table table-sm m-0">
                     <thead>
                         <tr>
-                            <th>Name</th>
-                            <th>Ball</th>
-                            <th>Qty</th>
+                            <th data-bind="text: App.translation.get('pokeball.column.name', 'modules')"></th>
+                            <th data-bind="text: App.translation.get('pokeball.column.ball', 'modules')"></th>
+                            <th data-bind="text: App.translation.get('pokeball.column.quantity', 'modules')"></th>
                         </tr>
                     </thead>
                     <tbody id="pokeballFilters" data-bind="foreach: App.game.pokeballFilters.displayList">

--- a/src/components/pokeballSelector.html
+++ b/src/components/pokeballSelector.html
@@ -47,7 +47,7 @@
                                         attr: {src: 'assets/images/pokeball/' + GameConstants.Pokeball[$data.ball()] + '.svg'},
                                         css: { 'pokeball-selected': $data.enabled() },
                                         tooltip: {
-                                            title: $data.ball() === GameConstants.Pokeball.None ? 'None' : ItemList[GameConstants.Pokeball[$data.ball()]].displayName,
+                                            title: App.translation.get(`pokeball.${GameConstants.Pokeball[$data.ball()]}.name`, 'constants'),
                                             trigger: 'hover', animation: false,
                                             placement: 'right'
                                         },

--- a/src/components/pokeballSelectorAdvModal.html
+++ b/src/components/pokeballSelectorAdvModal.html
@@ -5,18 +5,21 @@
             <div class="modal-header p-0" style='justify-content: space-around;'>
                 <ul class="nav nav-tabs nav-fill w-100">
                     <li class="nav-item">
-                        <a data-toggle='tab' class='nav-link active' href="#pokeballFilterConfigTab">
-                            Configure Filters
+                        <a class="nav-link active" href="#pokeballFilterConfigTab"
+                            data-toggle="tab"
+                            data-bind="text: App.translation.get('pokeball.modal.filters.configure.title', 'modules')">
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a data-toggle='tab' class='nav-link' href="#pokeballFilterTestTab">
-                            Test Filters
+                        <a class="nav-link" href="#pokeballFilterTestTab"
+                            data-toggle="tab"
+                            data-bind="text: App.translation.get('pokeball.modal.filters.test.title', 'modules')">
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a data-toggle="tab" class="nav-link" href="#pokeballFilterHelpTab">
-                            Help
+                        <a class="nav-link" href="#pokeballFilterHelpTab"
+                            data-toggle="tab"
+                            data-bind="text: App.translation.get('pokeball.modal.filters.help.title', 'modules')">
                         </a>
                     </li>
                 </ul>
@@ -25,17 +28,22 @@
                 <div class="tab-content">
                     <div id="pokeballFilterConfigTab" class="tab-pane active p-3">
                         <div>
-                            <button class="btn btn-primary my-2 mr-2" onclick="App.game.pokeballFilters.createFilter()">
-                                Create New Filter
+                            <button class="btn btn-primary my-2 mr-2" onclick="App.game.pokeballFilters.createFilter()"
+                                data-bind="text: App.translation.get('pokeball.modal.filters.configure.action.create', 'modules')">
                             </button>
-                            <button class="btn btn-primary my-2" onclick="App.game.pokeballFilters.reset()">
-                                Reset Filters
+                            <button class="btn btn-primary my-2" onclick="App.game.pokeballFilters.reset()"
+                                data-bind="text: App.translation.get('pokeball.modal.filters.configure.action.reset', 'modules')">
                             </button>
                         </div>
                         <p class="mb-1 small">
-                            ** Filters closer to the
-                            <strong class="text-warning" data-bind="text: Settings.getSetting('catchFilters.invertPriorityOrder').observableValue() ? 'bottom' : 'top'">top</strong>
-                            have a higher priority! **
+                            **
+                            <span data-bind="text: App.translation.get('pokeball.modal.filters.configure.hint.first', 'modules')">Filters closer to the</span>
+                            <strong class="text-warning" data-bind="text: Settings.getSetting('catchFilters.invertPriorityOrder').observableValue()
+                                ? App.translation.get('pokeball.modal.filters.configure.hint.bottom', 'modules')
+                                : App.translation.get('pokeball.modal.filters.configure.hint.top', 'modules')"
+                            ></strong>
+                            <span data-bind="text: App.translation.get('pokeball.modal.filters.configure.hint.second', 'modules')">have a higher priority!</span>
+                            **
                         </p>
                         <div id="pokeballFilterConfigs"
                             data-bind="sortable: {
@@ -99,8 +107,11 @@
                                     </div>
                                     <button class="pokeballFilterExpandBtn btn btn-secondary btn-block"
                                             data-toggle="collapse"
-                                            data-bind="attr: { href: `#pokeball-filter-options-${$index()}` }"
-                                    >Toggle Settings</button>
+                                            data-bind="
+                                                attr: { href: `#pokeball-filter-options-${$index()}` },
+                                                text: App.translation.get('pokeball.modal.filters.configure.action.toggleSettings', 'modules')
+                                            "
+                                    ></button>
                                     <div class="collapse pokeballFilterBody"
                                         data-bind="attr: { id: `pokeball-filter-options-${$index()}`}">
                                         <table class="pokeballFilterOptions">
@@ -161,10 +172,10 @@
                     </div>
                     <div id="pokeballFilterTestTab" class="tab-pane p-3">
                         <div>
-                            <p>This tab is useful for making sure what your filters match, and which ones take precedence. See the Help tab for more details.</p>
+                            <p data-bind="text: App.translation.get('pokeball.modal.filters.test.description', 'modules')"></p>
                         </div>
                         <div id="pokeballFilterTestInput">
-                            <p>Configure these options to describe a Pokémon you want to test:</p>
+                            <p data-bind="text: App.translation.get('pokeball.modal.filters.test.legend', 'modules')"></p>
                             <table>
                                 <tbody data-bind="foreach: Object.entries(App.game.pokeballFilters.testSettings)
                                                                 .filter(([k]) => pokeballFilterOptions[k]?.canUse() ?? true)
@@ -180,8 +191,8 @@
                                                                     App.game.pokeballFilters.testSettingsData()
                                                                 )">
                             <p id="pokeballFilterTestMatch">
-                                <span data-bind='visible: $data, text: `This will use your "${$data?.name}" filter`'></span>
-                                <span data-bind='visible: !$data'>None of your enabled filters match this scenario</span>
+                                <span data-bind="visible: $data, text: `${App.translation.get('pokeball.modal.filters.test.result', 'modules').peek()} ${$data?.name}`"></span>
+                                <span data-bind="visible: !$data, text: App.translation.get('pokeball.modal.filters.test.noResult', 'modules')"></span>
                                 <!-- ko if: $data -->
                                 <img class="pokeball-selected pokeball-small" data-bind="
                                     attr: {
@@ -212,62 +223,37 @@
                         </div>
                     </div>
                     <div id="pokeballFilterHelpTab" class="tab-pane p-3">
-                        <h2>Configure Filters</h2>
+                        <h2 data-bind="text: App.translation.get('pokeball.modal.filters.configure.title', 'modules')"></h2>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph1', 'modules')"></p>
                         <p>
-                            Use this tab to add, edit, re-order, and remove Pokéball filters.
+                            <span data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph2.line1', 'modules')"></span>
+                            <button class="btn-circle btn-danger float-none">&minus;</button>
+                            <span data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph2.line2', 'modules')"></span>
+                            <button class="btn-circle btn-success float-none">&plus;</button>
+                            <span data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph2.line3', 'modules')"></span>
                         </p>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph3', 'modules')"></p>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph4', 'modules')"></p>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph5', 'modules')"></p>
                         <p>
-                            Click the "Toggle Settings" button for a filter to configure how it works.
-                            Options listed first are all the values that are checked when catching - you can click their <button class="btn-circle btn-danger float-none">&minus;</button> to remove these.
-                            The darker options below that are not checked.
-                            You can click their <button class="btn-circle btn-success float-none">&plus;</button> button to include it in the filter, and choose a value it must match.
+                            <span data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph6.line1', 'modules')"></span>
+                            <button class="btn-circle btn-info float-none">&#8505;</button>
+                            <span data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph6.line2', 'modules')"></span>
                         </p>
-                        <p>
-                            Filters can be re-ordered by dragging them from the bar on the left side of each filter.
-                            You can click the x on the right of each filter to remove them - this will open a confirmation box to prevent accidentally deleting one.
-                        </p>
-                        <p>
-                            Some filter options and default filters are hidden at the start of the game, and will unlock as they become relevant.
-                        </p>
-                        <p>
-                            The "Enabled" toggle allows you to turn a filter off.
-                            Disabled filters will be grayed out in the filter list on the main game screen, and also in the Test Filters tab.
-                            The "Inverted" toggle, when turned on, will make that filter <i>ignore</i> any Pokémon that match its conditions, and catch all the rest.
-                        </p>
-                        <p>
-                            You can hover (or tap) the <button class="btn-circle btn-info float-none">&#8505;</button> icon for a description of what the filter will catch.
-                        </p>
-                        <p>
-                            Right click (or long press on mobile) can be used to enable/disable filters from the main screen without opening this menu.
-                        </p>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.configure.paragraph7', 'modules')"></p>
 
-                        <h2>Test Filters</h2>
-                        <p>
-                            In some scenario, multiple of your filters may meet all of their conditions,
-                            but only one can be used to choose a ball for catching.
-                        </p>
-                        <p>
-                            This tab will allow you to see exactly which will be chosen,
-                            for some scenario you configure with the settings in the tab.
-                        </p>
-                        <p>
-                            For instance, if you wanted to know what is used for a shiny Rattata,
-                            when you already have a normal Rattata,
-                            you would turn on the "Shiny" and "Caught" toggles,
-                            but leave the others off.
-                        </p>
-                        <p>
-                            With the default catch filters,
-                            you will see that both "Caught" and "New Shiny" meet their conditions,
-                            but the "New Shiny" filter is the one used for catching.
-                            The filter furthest down in your list that matches all conditions is the one used.
-                            The highlighted filters are ones that matched the scenario.
-                        </p>
+                        <h2 data-bind="text: App.translation.get('pokeball.modal.filters.test.title', 'modules')"></h2>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.test.paragraph1', 'modules')"></p>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.test.paragraph2', 'modules')"></p>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.test.paragraph3', 'modules')"></p>
+                        <p data-bind="text: App.translation.get('pokeball.modal.filters.help.test.paragraph4', 'modules')"></p>
                     </div>
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary"
+                    data-dismiss="modal"
+                    data-bind="text: App.translation.get('modal.action.close', 'app')"></button>
             </div>
         </div>
     </div>

--- a/src/components/pokeballSelectorAdvModal.html
+++ b/src/components/pokeballSelectorAdvModal.html
@@ -64,7 +64,7 @@
                                     <div class="pokeballFilterHeader">
                                         <div class="pokeballFilterEnableToggle" data-bind="
                                             tooltip: {
-                                                title: $data.enabled() ? 'Enabled' : 'Disabled',
+                                                title: App.translation.get(`switch.${$data.enabled() ? 'enabled' : 'disabled'}`, 'app').peek(),
                                                 trigger: 'hover',
                                                 animation: false,
                                                 placement: 'bottom',
@@ -142,7 +142,7 @@
                                                         </button>
                                                     </td>
                                                     <td class="p-2"
-                                                        data-bind="text: pokeballFilterOptions[$data].defaultSetting.displayName">
+                                                        data-bind="text: App.translation.get(`pokeball.filters.${$data}`, 'modules')">
                                                     </td>
                                                     <td></td>
                                                 </tr>
@@ -276,9 +276,10 @@
 </script>
 <script type="text/html" id="pokeballFilterSlider">
     <td class="p-2">
-        <label class="m-0" data-bind="attr: { for: `checkbox-${setting.name}-${key}` }, text: `${setting.displayName}:`">
-            setting name
-        </label>
+        <label class="m-0" data-bind="
+            attr: { for: `checkbox-${setting.name}-${key}` },
+            text: App.translation.get(`pokeball.filters.${setting.name}`, 'modules'),
+        "></label>
     </td>
     <td class="p-2">
         <label class="form-check-label toggler-wrapper style-1 m-auto">
@@ -292,12 +293,14 @@
 </script>
 
 <script type="text/html" id="pokeballFilterMultipleChoice">
-    <td class="p-2" data-bind="text: `${setting.displayName}:`">setting name</td>
+    <td class="p-2" data-bind="text: App.translation.get(`pokeball.filters.${setting.name}`, 'modules')"></td>
     <td class="p-0">
         <select class="form-control" data-bind="
             options: setting.getValidOptions(),
             optionsValue: 'value',
-            optionsText: 'text',
+            optionsText: (option) => setting.name === 'category'
+                ? option.text
+                : App.translation.get(`${setting.name.replace(/\d/g, '')}.${option.text.replace(/\s/g, '')}`, 'constants'),
             value: setting.observableValue
         "></select>
     </td>

--- a/src/components/pokeballSelectorAdvModal.html
+++ b/src/components/pokeballSelectorAdvModal.html
@@ -79,7 +79,10 @@
                                         "></div>
                                         <button class="btn-circle btn-info"
                                                 data-bind="tooltip: {
-                                                    title: $data.description,
+                                                    title: () => PokeballFilter.tooltipDescription(
+                                                        $data,
+                                                        (key, namespace) => App.translation.get(key, namespace)(),
+                                                    ),
                                                     trigger: 'hover',
                                                     animation: false,
                                                     placement: 'right',

--- a/src/components/pokeballSelectorAdvModal.html
+++ b/src/components/pokeballSelectorAdvModal.html
@@ -93,7 +93,7 @@
                                         attr: {
                                             src: 'assets/images/pokeball/' + GameConstants.Pokeball[$data.ball()] + '.svg'},
                                             tooltip: {
-                                                title: $data.ball() === -1 ? 'None' : ItemList[GameConstants.Pokeball[$data.ball()]].displayName,
+                                                title: App.translation.get(`pokeball.${GameConstants.Pokeball[$data.ball()]}.name`, 'constants'),
                                                 trigger: 'hover',
                                                 animation: false,
                                                 placement: 'bottom'
@@ -198,7 +198,7 @@
                                     attr: {
                                         src: 'assets/images/pokeball/' + GameConstants.Pokeball[$data?.ball()] + '.svg'},
                                         tooltip: {
-                                            title: $data?.ball() === -1 ? 'None' : ItemList[GameConstants.Pokeball[$data?.ball()]].displayName,
+                                            title: App.translation.get(`pokeball.${GameConstants.Pokeball[$data.ball()]}.name`, 'constants'),
                                             trigger: 'hover',
                                             animation: false,
                                             placement: 'bottom'

--- a/src/components/pokeballSelectorModal.html
+++ b/src/components/pokeballSelectorModal.html
@@ -59,10 +59,18 @@
 <script type="text/html" id="pokeballSelectionTemplate">
   <td class="text-center">
     <img class="pokeball-small"
-      data-bind="attr: {src: 'assets/images/pokeball/' + GameConstants.Pokeball[$data.type] + '.svg'}, css: {'pokeball-selected': App.game.pokeballs.selectedSelection()?.() === $data.type}, tooltip: {title: $data.type === -1 ? 'None' : ItemList[GameConstants.Pokeball[$data.type]].displayName, trigger: 'hover', animation: false, placement: 'bottom'}"/>
+        data-bind="
+            attr: { src: 'assets/images/pokeball/' + GameConstants.Pokeball[$data.type] + '.svg' },
+            css: { 'pokeball-selected': App.game.pokeballs.selectedSelection()?.() === $data.type },
+            tooltip: {
+                title: App.translation.get(`pokeball.${GameConstants.Pokeball[$data.type]}.name`, 'constants'),
+                trigger: 'hover',
+                animation: false,
+                placement: 'bottom'
+            }"/>
   </td>
   <td class="align-middle">
-    <span data-bind="text: $data.description"></span>
+    <span data-bind="text: App.translation.get(`pokeball.${GameConstants.Pokeball[$data.type]}.description`, 'constants')"></span>
   </td>
   <td class="text-center align-middle">
     <span data-bind="text: $data.quantity && $data.quantity() ? GameConstants.formatNumber($data.quantity()) : '-', tooltip: $data.quantity && {title: $data.quantity().toLocaleString('en-US'), trigger: 'hover', animation: false, placement: 'left'}"></span>

--- a/src/components/pokeballSelectorModal.html
+++ b/src/components/pokeballSelectorModal.html
@@ -3,7 +3,9 @@
   <div class="modal-dialog modal-dialog-scrollable modal-sm" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="pokeballSelectorModalLabel">Poké Ball Selection</h5>
+        <h5 class="modal-title"
+            id="pokeballSelectorModalLabel"
+            data-bind="text: App.translation.get('pokeball.modal.selection.title', 'modules')"></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -14,14 +16,22 @@
           <table class="table table-sm m-0">
             <thead>
               <tr>
-                <th class="text-center" width="20%">Ball</th>
-                <th>Description</th>
-                <th class="text-center">Qty</th>
+                <th data-bind="text: App.translation.get('pokeball.modal.selection.column.ball', 'modules')" class="text-center" width="20%"></th>
+                <th data-bind="text: App.translation.get('pokeball.modal.selection.column.description', 'modules')"></th>
+                <th data-bind="text: App.translation.get('pokeball.modal.selection.column.quantity', 'modules')" class="text-center"></th>
               </tr>
             </thead>
             <tbody>
               <tr class="clickable"
-                data-bind="template: { name: 'pokeballSelectionTemplate', data: { 'image': 'None', 'type': -1, 'description': 'Do not catch' }},
+                data-bind="
+                    template: {
+                        name: 'pokeballSelectionTemplate',
+                        data: {
+                            'image': 'None',
+                            'type': -1,
+                            'description': App.translation.get('pokeball.None.description', 'constants'),
+                        }
+                    },
                     click: function(){App.game.pokeballs.selectedSelection()?.(GameConstants.Pokeball.None)}"></tr>
               <!-- ko foreach: App.game.pokeballs.pokeballs -->
               <tr class="clickable"
@@ -38,7 +48,9 @@
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary"
+            data-dismiss="modal"
+            data-bind="text: App.translation.get('modal.action.close', 'app')"></button>
       </div>
     </div>
   </div>

--- a/src/modules/pokeballs/PokeballFilter.ts
+++ b/src/modules/pokeballs/PokeballFilter.ts
@@ -65,35 +65,6 @@ export default class PokeballFilter {
             );
     }
 
-    get description(): string {
-        const disabledText = this.enabled()
-            ? ''
-            : 'This filter is disabled.</br></br>';
-
-        const optionList = Object.entries(this.options);
-        if (optionList.length === 0) {
-            return `${disabledText}${[
-                'This filter will catch all Pokémon.',
-            ].join('</br>')}`;
-        }
-
-        const bulletPoints = `<ul class="pokeballFilterOptionDescriptions">${
-            optionList
-                .map(([opt, setting]) => `<li>${
-                    pokeballFilterOptions[opt].describe(
-                        setting.observableValue(),
-                    )
-                }</li>`)
-                .join('')
-        }</ul>`;
-
-        return `${disabledText}This filter affects wild Pokémon ${
-            this.inverted()
-                ? 'without'
-                : 'with'
-        } the combined traits of: ${bulletPoints}`;
-    }
-
     get name(): string {
         return this._name();
     }

--- a/src/modules/pokeballs/PokeballFilter.ts
+++ b/src/modules/pokeballs/PokeballFilter.ts
@@ -121,4 +121,65 @@ export default class PokeballFilter {
             enabled: this.enabled(),
         };
     }
+
+    static tooltipDescription = (
+        data: PokeballFilter,
+        translator: (key: string, namespace: string) => string,
+    ): string => {
+        let description = '';
+
+        if (!data.enabled()) {
+            description += translator('pokeball.tooltip.filters.disabled', 'modules');
+            description += '<br/><br/>';
+        }
+
+        const options = Object.entries(data.options);
+        if (!options.length) {
+            description += translator('pokeball.tooltip.filters.all', 'modules');
+            return description;
+        }
+
+        description += translator(
+            data.inverted()
+                ? 'pokeball.tooltip.filters.affectWithoutTraits'
+                : 'pokeball.tooltip.filters.affectWithTraits',
+            'modules',
+        );
+
+        description += '<ul class="pokeballFilterOptionDescriptions">';
+        description += options
+            .map(([opt, setting]) => {
+                const value = setting.observableValue();
+
+                const result = translator(
+                    `pokeball.filters.${setting.name}.description${value === false ? '.negative' : ''}`,
+                    'modules',
+                );
+                if (typeof value === 'boolean') {
+                    return result;
+                }
+
+                let valueText = undefined;
+                for (let index = 0; index < setting.options.length; ++index) {
+                    if (setting.options[index].value === value) {
+                        valueText = setting.options[index].text;
+                        break;
+                    }
+                }
+                if (!valueText) {
+                    return result;
+                }
+
+                if (opt !== 'category') {
+                    valueText = translator(`${opt}.${valueText.replace(/\s/g, '')}`, 'constants');
+                }
+
+                return  `${result} ${valueText}`;
+            })
+            .map((option) => `<li>${option}</li>`)
+            .join('');
+        description += '</ul>';
+
+        return description;
+    };
 }

--- a/src/modules/pokeballs/PokeballFilterOptions.ts
+++ b/src/modules/pokeballs/PokeballFilterOptions.ts
@@ -16,7 +16,6 @@ class PokeballFilterOption<T, M = T> {
 
     constructor(
         public createSetting: (defaultVal?: T, name?: string, defaultName?: string) => Setting<T>,
-        public describe: (value: T) => string,
         public requirement?: Requirement,
         public matchTest: (optionValue: T, testValue: M) => boolean = (
             optionValue: T, testValue: M,
@@ -44,9 +43,6 @@ export const pokeballFilterOptions = {
             'Shiny',
             bool,
         ),
-        (isShiny) => `Are ${
-            isShiny ? '' : 'not '
-        }Shiny`,
     ),
 
     shadow: new PokeballFilterOption<boolean>(
@@ -55,9 +51,6 @@ export const pokeballFilterOptions = {
             'Shadow',
             bool,
         ),
-        (isShadow) => `Are ${
-            isShadow ? '' : 'not '
-        }Shadow`,
         tempShadowRequirement,
     ),
 
@@ -67,9 +60,6 @@ export const pokeballFilterOptions = {
             'Caught',
             bool,
         ),
-        (isCaught) => `${
-            isCaught ? 'Already' : 'Not yet'
-        } caught`,
     ),
 
     caughtShiny: new PokeballFilterOption<boolean>(
@@ -78,9 +68,6 @@ export const pokeballFilterOptions = {
             'Caught Shiny',
             bool,
         ),
-        (isCaughtShiny) => `Shiny form ${
-            isCaughtShiny ? 'already ' : 'not yet '
-        }caught`,
     ),
 
     caughtShadow: new PokeballFilterOption<boolean>(
@@ -89,9 +76,6 @@ export const pokeballFilterOptions = {
             'Caught Shadow',
             bool,
         ),
-        (isCaughtShadow) => `Shadow form ${
-            isCaughtShadow ? 'already ' : 'not yet '
-        }caught`,
         tempShadowRequirement,
     ),
 
@@ -102,9 +86,6 @@ export const pokeballFilterOptions = {
             GameHelper.enumStrings(Pokerus).map((k) => new SettingOption(k, Pokerus[k])),
             pokerus,
         ),
-        (pokerusState) => `Are in the ${
-            Pokerus[pokerusState]
-        } Pokérus state`,
         new CustomRequirement(
             ko.pureComputed(() => App.game.keyItems.hasKeyItem(KeyItemType.Pokerus_virus)),
             true, 'Pokérus virus is required',
@@ -118,7 +99,6 @@ export const pokeballFilterOptions = {
             GameHelper.enumStrings(PokemonType).map((k) => new SettingOption(k, PokemonType[k])),
             type,
         ),
-        (pokemonType) => `Is ${PokemonType[pokemonType]} type`,
         undefined,
         (
             optionValue: PokemonType,
@@ -133,7 +113,6 @@ export const pokeballFilterOptions = {
             Object.values(EncounterType).map((v) => new SettingOption(v, v, encounterTypeRequirements[v])),
             type,
         ),
-        (type) => `Is ${GameHelper.anOrA(type)} ${type} encounter`,
     ),
 
     category: new PokeballFilterOption<number, number[]>(
@@ -143,7 +122,6 @@ export const pokeballFilterOptions = {
             () => PokemonCategories.categories().map((c) => new SettingOption(c.name(), c.id)),
             category,
         ),
-        (category) => `In the ${PokemonCategories.categories().find(c => c.id == category)?.name()} category`,
         undefined,
         (
             optionValue: number,

--- a/src/modules/pokeballs/PokeballFilterOptions.ts
+++ b/src/modules/pokeballs/PokeballFilterOptions.ts
@@ -40,7 +40,7 @@ const encounterTypeRequirements: Partial<Record<EncounterType, Requirement>> = {
 export const pokeballFilterOptions = {
     shiny: new PokeballFilterOption<boolean>(
         (bool = true) => new BooleanSetting(
-            'pokeballFilterShiny',
+            'shiny',
             'Shiny',
             bool,
         ),
@@ -51,7 +51,7 @@ export const pokeballFilterOptions = {
 
     shadow: new PokeballFilterOption<boolean>(
         (bool = true) => new BooleanSetting(
-            'pokeballFilterShadow',
+            'shadow',
             'Shadow',
             bool,
         ),
@@ -63,7 +63,7 @@ export const pokeballFilterOptions = {
 
     caught: new PokeballFilterOption<boolean>(
         (bool = true) => new BooleanSetting(
-            'pokeballFilterCaught',
+            'caught',
             'Caught',
             bool,
         ),
@@ -74,7 +74,7 @@ export const pokeballFilterOptions = {
 
     caughtShiny: new PokeballFilterOption<boolean>(
         (bool = true) => new BooleanSetting(
-            'pokeballFilterCaughtShiny',
+            'caughtShiny',
             'Caught Shiny',
             bool,
         ),
@@ -85,7 +85,7 @@ export const pokeballFilterOptions = {
 
     caughtShadow: new PokeballFilterOption<boolean>(
         (bool = true) => new BooleanSetting(
-            'pokeballFilterCaughtShadow',
+            'caughtShadow',
             'Caught Shadow',
             bool,
         ),
@@ -97,7 +97,7 @@ export const pokeballFilterOptions = {
 
     pokerus: new PokeballFilterOption<Pokerus>(
         (pokerus = Pokerus.Uninfected) => new Setting(
-            'pokeballFilterPokerus',
+            'pokerus',
             'Pokérus State',
             GameHelper.enumStrings(Pokerus).map((k) => new SettingOption(k, Pokerus[k])),
             pokerus,
@@ -112,7 +112,7 @@ export const pokeballFilterOptions = {
     ),
 
     pokemonType: new PokeballFilterOption<PokemonType, [PokemonType, PokemonType]>(
-        (type = PokemonType.Normal, name = 'pokeballFilterPokemonType', defaultName = 'Pokémon Type') => new Setting(
+        (type = PokemonType.Normal, name = 'pokemonType', defaultName = 'Pokémon Type') => new Setting(
             name,
             defaultName,
             GameHelper.enumStrings(PokemonType).map((k) => new SettingOption(k, PokemonType[k])),
@@ -128,7 +128,7 @@ export const pokeballFilterOptions = {
 
     encounterType: new PokeballFilterOption<EncounterType>(
         (type: EncounterType = EncounterType.route) => new Setting(
-            'pokeballFilterEncounterType',
+            'encounterType',
             'Encounter Type',
             Object.values(EncounterType).map((v) => new SettingOption(v, v, encounterTypeRequirements[v])),
             type,
@@ -138,7 +138,7 @@ export const pokeballFilterOptions = {
 
     category: new PokeballFilterOption<number, number[]>(
         (category = 0) => new Setting(
-            'pokeballFilterCategory',
+            'category',
             'Category',
             () => PokemonCategories.categories().map((c) => new SettingOption(c.name(), c.id)),
             category,

--- a/src/modules/pokeballs/PokeballFilters.ts
+++ b/src/modules/pokeballs/PokeballFilters.ts
@@ -36,10 +36,10 @@ export default class PokeballFilters implements Feature {
         // Create two Pokemon Type settings
         delete settings.pokemonType;
         settings.type1 = pokeballFilterOptions.pokemonType.createSetting(
-            PokemonType.Normal, 'pokeballFilterPokemonType1', 'Pokémon Type 1',
+            PokemonType.Normal, 'pokemonType1', 'Pokémon Type 1',
         );
         settings.type2 = pokeballFilterOptions.pokemonType.createSetting(
-            PokemonType.Normal, 'pokeballFilterPokemonType2', 'Pokémon Type 2',
+            PokemonType.Normal, 'pokemonType2', 'Pokémon Type 2',
         );
 
         return settings;

--- a/src/modules/pokeballs/__tests__/PokeballFilter.test.ts
+++ b/src/modules/pokeballs/__tests__/PokeballFilter.test.ts
@@ -1,0 +1,156 @@
+import { Pokerus } from '../../GameConstants';
+import EncounterType from '../../enums/EncounterType';
+import PokemonType from '../../enums/PokemonType';
+import PokeballFilter from '../PokeballFilter';
+
+describe('Test PokeballFilter', () => {
+    const stubTranslator = (key: string, namespace: string) => `(${namespace})${key}`;
+
+    it.each([
+        { enabled: false },
+        { enabled: true },
+    ])('tooltipDescription - return "all catch" filter description with "enabled" set to $enabled', ({ enabled }) => {
+        // Arrange
+        const data = new PokeballFilter('some filter', {}, undefined, enabled);
+
+        const expectedResult = enabled
+            ? '(modules)pokeball.tooltip.filters.all'
+            : '(modules)pokeball.tooltip.filters.disabled'
+            + '<br/><br/>'
+            + '(modules)pokeball.tooltip.filters.all';
+
+        // Act
+        const result = PokeballFilter.tooltipDescription(data, stubTranslator);
+
+        // Assert
+        expect(result).toEqual(expectedResult);
+    });
+
+    it.each(Array.from({ length: 2 * 2 * 2 }).map((_, i) => ({
+        enabled: !!(Math.round(i / 4)),
+        inverted: !!(Math.round(i / 2) % 2),
+        value: !!(i % 2),
+    })))('tooltipDescription - return "boolean" filter description as "$value" with inverted set to "$inverted" and "enabled" set to "$enabled"', ({ enabled, inverted, value }) => {
+        // Arrange
+        const data = new PokeballFilter('some filter', {
+            shiny: value,
+            shadow: value,
+            caught: value,
+            caughtShiny: value,
+            caughtShadow: value,
+        }, undefined, enabled, inverted);
+
+        let expectedResult = '';
+        expectedResult += enabled ? '' : '(modules)pokeball.tooltip.filters.disabled<br/><br/>';
+        expectedResult += `(modules)pokeball.tooltip.filters.${inverted ? 'affectWithoutTraits' : 'affectWithTraits'}`;
+        expectedResult += '<ul class="pokeballFilterOptionDescriptions">';
+        expectedResult += `<li>(modules)pokeball.filters.shiny.description${value ? '' : '.negative'}</li>`;
+        expectedResult += `<li>(modules)pokeball.filters.shadow.description${value ? '' : '.negative'}</li>`;
+        expectedResult += `<li>(modules)pokeball.filters.caught.description${value ? '' : '.negative'}</li>`;
+        expectedResult += `<li>(modules)pokeball.filters.caughtShiny.description${value ? '' : '.negative'}</li>`;
+        expectedResult += `<li>(modules)pokeball.filters.caughtShadow.description${value ? '' : '.negative'}</li>`;
+        expectedResult += '</ul>';
+
+        // Act
+        const result = PokeballFilter.tooltipDescription(data, stubTranslator);
+
+        // Assert
+        expect(result).toEqual(expectedResult);
+    });
+
+    it.each(Array.from({ length: 2 * 2 * 4 }).map((_, i) => ({
+        enabled: !!(Math.round(i / 8)),
+        inverted: !!(Math.round(i / 4) % 2),
+        value: Pokerus[i % 4],
+    })))('tooltipDescription - return "pokerus" filter description as $value with inverted set to "$inverted" and "enabled" set to "$enabled"', ({ enabled, inverted, value }) => {
+        // Arrange
+        const data = new PokeballFilter('some filter', {
+            pokerus: Pokerus[value],
+        }, undefined, enabled, inverted);
+
+        let expectedResult = '';
+        expectedResult += enabled ? '' : '(modules)pokeball.tooltip.filters.disabled<br/><br/>';
+        expectedResult += `(modules)pokeball.tooltip.filters.${inverted ? 'affectWithoutTraits' : 'affectWithTraits'}`;
+        expectedResult += '<ul class="pokeballFilterOptionDescriptions">';
+        expectedResult += `<li>(modules)pokeball.filters.pokerus.description (constants)pokerus.${value}</li>`;
+        expectedResult += '</ul>';
+
+        // Act
+        const result = PokeballFilter.tooltipDescription(data, stubTranslator);
+
+        // Assert
+        expect(result).toEqual(expectedResult);
+    });
+
+    it.each(Array.from({ length: 2 * 2 }).map((_, i) => ({
+        enabled: !!(Math.round(i / 2) % 2),
+        inverted: !!(i % 2),
+    })))('tooltipDescription - return "pokemonType" filter description as \'None\' with inverted set to "$inverted" and "enabled" set to "$enabled"', ({ enabled, inverted }) => {
+        // Arrange
+        const data = new PokeballFilter('some filter', {
+            pokemonType: PokemonType.None,
+        }, undefined, enabled, inverted);
+
+        let expectedResult = '';
+        expectedResult += enabled ? '' : '(modules)pokeball.tooltip.filters.disabled<br/><br/>';
+        expectedResult += `(modules)pokeball.tooltip.filters.${inverted ? 'affectWithoutTraits' : 'affectWithTraits'}`;
+        expectedResult += '<ul class="pokeballFilterOptionDescriptions">';
+        expectedResult += '<li>(modules)pokeball.filters.pokemonType.description (constants)pokemonType.None</li>';
+        expectedResult += '</ul>';
+
+        // Act
+        const result = PokeballFilter.tooltipDescription(data, stubTranslator);
+
+        // Assert
+        expect(result).toEqual(expectedResult);
+    });
+
+    it.each(Array.from({ length: 2 * 2 * 18 }).map((_, i) => ({
+        enabled: !!(Math.round(i / 36)),
+        inverted: !!(Math.round(i / 18) % 2),
+        value: PokemonType[i % 18],
+    })))('tooltipDescription - return "pokemonType" filter description as $value with inverted set to "$inverted" and "enabled" set to "$enabled"', ({ enabled, inverted, value }) => {
+        // Arrange
+        const data = new PokeballFilter('some filter', {
+            pokemonType: PokemonType[value],
+        }, undefined, enabled, inverted);
+
+        let expectedResult = '';
+        expectedResult += enabled ? '' : '(modules)pokeball.tooltip.filters.disabled<br/><br/>';
+        expectedResult += `(modules)pokeball.tooltip.filters.${inverted ? 'affectWithoutTraits' : 'affectWithTraits'}`;
+        expectedResult += '<ul class="pokeballFilterOptionDescriptions">';
+        expectedResult += `<li>(modules)pokeball.filters.pokemonType.description (constants)pokemonType.${value}</li>`;
+        expectedResult += '</ul>';
+
+        // Act
+        const result = PokeballFilter.tooltipDescription(data, stubTranslator);
+
+        // Assert
+        expect(result).toEqual(expectedResult);
+    });
+
+    it.each(Array.from({ length: 2 * 2 * 8 }).map((_, i) => ({
+        enabled: !!(Math.round(i / 16)),
+        inverted: !!(Math.round(i / 8) % 2),
+        key: Object.keys(EncounterType)[i % 8],
+    })))('tooltipDescription - return "encounterType" filter description at key $key with inverted set to "$inverted" and "enabled" set to "$enabled"', ({ enabled, inverted, key }) => {
+        // Arrange
+        const data = new PokeballFilter('some filter', {
+            encounterType: EncounterType[key],
+        }, undefined, enabled, inverted);
+
+        const value = EncounterType[key].replace(/\s/g, '');
+        let expectedResult = '';
+        expectedResult += enabled ? '' : '(modules)pokeball.tooltip.filters.disabled<br/><br/>';
+        expectedResult += `(modules)pokeball.tooltip.filters.${inverted ? 'affectWithoutTraits' : 'affectWithTraits'}`;
+        expectedResult += '<ul class="pokeballFilterOptionDescriptions">';
+        expectedResult += `<li>(modules)pokeball.filters.encounterType.description (constants)encounterType.${value}</li>`;
+        expectedResult += '</ul>';
+
+        // Act
+        const result = PokeballFilter.tooltipDescription(data, stubTranslator);
+
+        // Assert
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/src/modules/translation/Translation.ts
+++ b/src/modules/translation/Translation.ts
@@ -48,7 +48,13 @@ export default class Translate {
             .use(LanguageDetector)
             .init({
                 debug: GameHelper.isDevelopmentBuild(),
-                ns: ['pokemon', 'logbook', 'settings'],
+                ns: [
+                    'app',
+                    'logbook',
+                    'modules',
+                    'pokemon',
+                    'settings',
+                ],
                 fallbackLng: 'en',
                 backend: {
                     // Two backend sources - tries the TRANSLATION_URL first, falls back to copy taken at build time

--- a/src/modules/translation/Translation.ts
+++ b/src/modules/translation/Translation.ts
@@ -50,6 +50,7 @@ export default class Translate {
                 debug: GameHelper.isDevelopmentBuild(),
                 ns: [
                     'app',
+                    'constants',
                     'logbook',
                     'modules',
                     'pokemon',


### PR DESCRIPTION
## Links

**Issue** : https://github.com/pokeclicker/pokeclicker/issues/5491
**Pokeclicker Translations Pull Request** : https://github.com/pokeclicker/pokeclicker-translations/pull/128

<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

### Added

- New 3 translation files as namespace
- Unit tests for PokeballFilter new method

### Changed

- Every static resources for Pokeball Module has been changed to a translated one.
- Description is not a `getter` anymore, but a static method which compute translations keys and retrieve correct translation before sending it to the template
- New ID for all Pokeball Filter options
- New ID for Type1/Type2 settings in test filters tab

### Removal

- No more loading description method on PokeballFilters presets

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

Everything is explained in [this issue]().

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

### Environment
**OS** : Ubuntu `22.04`
**IDE** : Visual Studio Code Insider `1.90.0`
**Node/NPM** : `v20.15.0` / `10.7.0`
**Browser** : Firefox Nightly `127.0a1`

### Steps
- Fork the Pokeclicker game source code and the translation sources.
- Re-link submodule as the forked one
- Changed the `loadPath` of translations to local one
- Run following commands
```sh
npm ci # On both fork
npm start
```
- Loaded my personal save as work base
- Updated templates and added new keys to translate everything

### Sides effects

It's only a matter of front issues I've updated, so it seems there's no side effects on Poké Balls filters, even the id change. I assume it was used just for reference, because there was no use of this id anywhere.

The tooltip description removal was completed because the two usages were updated too.

The `App.translation` object has to be passed as argument to generate translation due to the code structure of the application. A tooltip template/component is missing, and I don't know the `knockout` enought to create a correct one (I'm a Vue developer on my side).

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->

Example of tooltip
![image](https://github.com/user-attachments/assets/434112a1-bc9a-4dcb-8a80-02a96b565d33)

Filter configuration
![image](https://github.com/user-attachments/assets/3563fa16-dd28-464d-a667-2a395e2e7861)

Help tab
![image](https://github.com/user-attachments/assets/2e494569-4355-4df4-a9d0-306aa9187d7f)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
- Translations
