### PR TITLE
Fixed Pokémon Hatched in BF not Hatching at Level 1

### DIFF
--- a/src/scripts/battleFrontier/BattleFrontierBattle.ts
+++ b/src/scripts/battleFrontier/BattleFrontierBattle.ts
@@ -37,9 +37,9 @@ class BattleFrontierBattle extends Battle {
      * Award the player with exp, gems and go to the next pokemon
      */
     public static defeatPokemon() {
+        this.enemyPokemon().defeat(true);
         // This needs to stay as none so the stage number isn't adjusted
         App.game.breeding.progressEggsBattle(BattleFrontierRunner.stage(), GameConstants.Region.none);
-        this.enemyPokemon().defeat(true);
         // Next pokemon
         GameHelper.incrementObservable(this.pokemonIndex);
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Battle Frontier was hatching eggs before the defeat calculation was made so it made all hatched eggs get this experience instead of the Pokémon hatching at level 1 like everywhere else. This fixes the order of operations so it's consistent with the rest of the game.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Everywhere else Pokémon being defeated (and experience awarded) happens **before** hatching so I'm making it consistent with other places. Also, I asked the person who wrote the code and they told me it was an oversight.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Went to Battle Frontier. Hatched some eggs. They hatch at level 1 now.

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
