### PR TITLE
Only create defeat dungeon quests from unlocked regions

### DIFF
--- a/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonQuest.ts
@@ -16,14 +16,23 @@ class DefeatDungeonQuest extends Quest implements QuestInterface {
         this.focus = App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(this.dungeon)];
     }
 
+    // Only add Defeat Dungeon Quest if the player has access to Viridian Forest.
+    public static canComplete() {
+        return TownList['Viridian Forest'].isUnlocked();
+    }
+
     public static generateData(): any[] {
         // Allow up to highest region
         const amount = SeededRand.intBetween(5, 20);
-        const region = SeededRand.intBetween(0, player.highestRegion());
+        let maxRegion = player.highestRegion();
+        // Check if any dungeon is unlocked in the highest region.
+        if (GameConstants.RegionDungeons[maxRegion].filter(dungeon => TownList[dungeon].isUnlocked()).length == 0) {
+            maxRegion -= 1;
+        }
+        const region = SeededRand.intBetween(0, maxRegion);
         // Only use unlocked dungeons
         const possibleDungeons = GameConstants.RegionDungeons[region].filter(dungeon => TownList[dungeon].isUnlocked());
-        // If no dungeons unlocked in this region, just use the first dungeon of the region
-        const dungeon = possibleDungeons.length ? SeededRand.fromArray(possibleDungeons) : GameConstants.RegionDungeons[region][0];
+        const dungeon = SeededRand.fromArray(possibleDungeons);
         const reward = this.calcReward(amount, dungeon);
         return [amount, reward, dungeon];
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->


## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
This PR makes sure that you only create defeat dungeon quests for unlocked dungeons by checking if a dungeon is unlocked for the highest region and if not, use the second highest region as the highest region. The dungeon quest also will not be unlocked before you can access viridian forest.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
I was quite perplexed when I just arrived at Johto and got a quest I couldn't have access to. It seems it just selected Sprout Tower dungeon 50 percent of the time. 
https://discord.com/channels/450412847017754644/1019758760589271071/threads/1275413432606265496

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I loaded the following save and kept reloading the quest list. 
[[v0.10.21] PokeClicker 2024-08-20 11_16_23.txt](https://github.com/user-attachments/files/16676558/v0.10.21.PokeClicker.2024-08-20.11_16_23.txt)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
