### PR TITLE
Add requirements for wanderers

### DIFF
--- a/src/components/templates/wanderingPokemonDisplay.html
+++ b/src/components/templates/wanderingPokemonDisplay.html
@@ -11,9 +11,9 @@
     <img class="dungeon-pokemon-preview" src="" data-bind="attr:{ src: PokemonHelper.getImage(pokemonMap[$data].id, App.game.party.getPokemonByName($data)?.shiny ?? false, undefined, GameConstants.ShadowStatus.None) },
     css: { 'dungeon-pokemon-locked': !App.game.party.alreadyCaughtPokemonByName($data) }" onerror="this.src='assets/images/pokemon/0.png';"/>
     <sup class="shiny" data-bind="visible: App.game.party.alreadyCaughtPokemonByName($data, true)">✨</sup>
-    <img class="lock" src="assets/images/breeding/lock.svg" data-bind="hidden: pokemonMap[$data].nativeRegion <= player.highestRegion(),
+    <img class="lock" src="assets/images/breeding/lock.svg" data-bind="hidden: FarmController.isAvailableWanderer($data),
     tooltip: {
-      title: `Reach ${GameConstants.camelCaseToString(GameConstants.Region[pokemonMap[$data].nativeRegion])} to attract this Pokémon!`,
+      title: FarmController.wandererDexTooltip($data),
         placement: 'top',
         trigger: 'hover'
     }">

--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -102,6 +102,7 @@ import CustomRequirement from './requirements/CustomRequirement';
 import DefeatedRequirement from './requirements/DefeatedRequirement';
 import DevelopmentRequirement from './requirements/DevelopmentRequirement';
 import DiamondRequirement from './requirements/DiamondRequirement';
+import InEnvironmentRequirement from './requirements/InEnvironmentRequirement';
 import FarmHandRequirement from './requirements/FarmHandRequirement';
 import FarmPlotsUnlockedRequirement from './requirements/FarmPlotsUnlockedRequirement';
 import FarmPointsRequirement from './requirements/FarmPointsRequirement';
@@ -316,6 +317,7 @@ Object.assign(<any>window, {
     DefeatedRequirement,
     DevelopmentRequirement,
     DiamondRequirement,
+    InEnvironmentRequirement,
     FarmHandRequirement,
     FarmPlotsUnlockedRequirement,
     FarmPointsRequirement,

--- a/src/scripts/farming/Berry.ts
+++ b/src/scripts/farming/Berry.ts
@@ -31,7 +31,7 @@ class Berry {
         [BerryColor.Red]: ['Ledyba', 'Flabébé (Red)', 'Oricorio (Baile)'],
         [BerryColor.Purple]: ['Illumise', 'Oricorio (Sensu)'],
         [BerryColor.Pink]: ['Spewpa', 'Oricorio (Pa\'u)'],
-        [BerryColor.Green]: ['Burmy (Plant)'],
+        [BerryColor.Green]: ['Burmy (Plant)', 'Burmy (Sand)', 'Burmy (Trash)'],
         [BerryColor.Yellow]: ['Combee', 'Flabébé (Yellow)', 'Oricorio (Pom-Pom)'],
         [BerryColor.Blue]: ['Volbeat', 'Flabébé (Blue)'],
         [BerryColor.Silver]: ['Flabébé (White)'],

--- a/src/scripts/farming/FarmController.ts
+++ b/src/scripts/farming/FarmController.ts
@@ -1,6 +1,5 @@
 /// <reference path="../../declarations/GameConstants.d.ts" />
 /// <reference path="../../declarations/enums/MulchType.d.ts"/>
-/// <reference path="../../declarations/requirements/InEnvironmentRequirement.d.ts"/>
 
 class FarmController {
 

--- a/src/scripts/farming/FarmController.ts
+++ b/src/scripts/farming/FarmController.ts
@@ -1,4 +1,6 @@
+/// <reference path="../../declarations/GameConstants.d.ts" />
 /// <reference path="../../declarations/enums/MulchType.d.ts"/>
+/// <reference path="../../declarations/requirements/InEnvironmentRequirement.d.ts"/>
 
 class FarmController {
 
@@ -317,6 +319,31 @@ class FarmController {
             return 'walkDown';
         }
     }
+
+    public static wandererDexTooltip(p: any) {
+        if (pokemonMap[p].nativeRegion > player.highestRegion()) {
+            return `Reach ${GameConstants.camelCaseToString(GameConstants.Region[pokemonMap[p].nativeRegion])} to attract this Pokémon!`;
+        }
+        if (FarmController.wandererRequirement[p]) {
+            return FarmController.wandererRequirement[p].hint();
+        }
+        return '';
+    }
+
+    public static isAvailableWanderer(p: any): boolean {
+        let availability = pokemonMap[p].nativeRegion <= player.highestRegion();
+        if (availability === true && FarmController.wandererRequirement[p]) {
+            availability = FarmController.wandererRequirement[p].isCompleted();
+        }
+        return availability;
+    }
+
+    // use this mindfully, we don't want to lock pokemon behind the same requirements their other obtain methods have
+    public static wandererRequirement: Partial<Record<PokemonNameType, Requirement>> = {
+        'Burmy (Plant)' : new InEnvironmentRequirement('PlantCloak'),
+        'Burmy (Sand)' : new InEnvironmentRequirement('SandyCloak'),
+        'Burmy (Trash)' : new InEnvironmentRequirement('TrashCloak'),
+    };
 
     public static shortcutVisible: KnockoutComputed<boolean> = ko.pureComputed(() => {
         return App.game.farming.canAccess() && !Settings.getSetting('showFarmModule').observableValue();

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -376,7 +376,7 @@ class PokemonFactory {
         const availablePokemon = [];
         const weights = [];
         berry.wander.forEach((p, i) => {
-            if (pokemonMap[p].nativeRegion <= player.highestRegion()) {
+            if (FarmController.isAvailableWanderer(p)) {
                 availablePokemon.push(p);
                 weights.push(mulch === MulchType.Gooey_Mulch && i >= Berry.baseWander.length ? 2 : 1);
             }


### PR DESCRIPTION
## Description
Wanderers can now have requirements. I'd appreciate if we used this sparingly, and not copy-paste requirements from wanderer pokemon's other obtain methods, to keep some variety.

## Motivation and Context
I wanted to include the burmies in a fun way

## How Has This Been Tested?
Locked the wanderers and then unlocked them.

## Types of changes
Pokemon distribution