### PR TITLE
Award BP + Money on completing "floors" of Battle Frontier, rather than on loss

### DIFF
--- a/src/modules/notifications/NotificationConstants.ts
+++ b/src/modules/notifications/NotificationConstants.ts
@@ -51,7 +51,7 @@ const NotificationConstants = {
             offline_earnings: new NotificationSetting('notification.offline_earnings', 'Offline earnings', true),
             achievement_complete: new NotificationSetting('notification.achievement_complete', 'Achievement complete', true, true),
             new_catch: new NotificationSetting('notification.new_catch', 'New Pokémon/shiny captured', true, true),
-            battle_frontier: new NotificationSetting('notification.battle_frontier', 'Battle Frontier', true, true),
+            battle_frontier: new NotificationSetting('notification.battle_frontier', 'Battle Frontier', true),
             pokerus: new NotificationSetting('notification.pokerus', 'Pokémon has become Resistant to Pokérus', true),
         },
         Hatchery: {

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2775,6 +2775,23 @@ class Update implements Saveable {
                 settingsData.showFarmModule = settingsData.showFarmModuleControls === false ? 'limited' : 'extended';
             }
             delete settingsData.showFarmModuleControls;
+
+            // Award missed BP+Money for the in-progress BF run
+            const bfCheckpoint = saveData.battleFrontier.checkpoint;
+            if (bfCheckpoint > 10) {
+                const lastRewardStage = Math.floor(bfCheckpoint / BattleFrontierRunner.STAGES_PER_FLOOR) * BattleFrontierRunner.STAGES_PER_FLOOR;
+                const battlePointsEarned = BattleFrontierRunner.calculateBattlePointsForStage(lastRewardStage);
+                const moneyEarned = BattleFrontierRunner.MONEY_TO_BATTLE_POINTS_RATIO * battlePointsEarned;
+                saveData.wallet.currencies[GameConstants.Currency.battlePoint] += battlePointsEarned;
+                saveData.wallet.currencies[GameConstants.Currency.money] += moneyEarned;
+
+                Notifier.notify({
+                    title: 'Battle Frontier Rewards Updated',
+                    message: `You have earned <img src="./assets/images/currency/battlePoint.svg" height="24px"/>&nbsp;${battlePointsEarned.toLocaleString('en-US')} and <img src="./assets/images/currency/money.svg" height="24px"/>&nbsp;${moneyEarned.toLocaleString('en-US')} for your in&nbsp;progress Battle Frontier run.`,
+                    type: NotificationConstants.NotificationOption.success,
+                    timeout: 5 * GameConstants.MINUTE,
+                });
+            }
         },
     };
 


### PR DESCRIPTION
Probably a long shot...

## Description
Battle Frontier now gives its rewards on completing a Floor of 10 stages, which is now also when the scenery changes
Partial floor completion does not provide rewards, finishing at stage 258 is no different than finishing at stage 251 (i.e. 250 stages completed)
The awarded amount is the delta between the current floor and the previous floor, total rewarded BP/Money for a run that goes to failure is unchanged other than missing the last 0-9 stages
Save update function rewards the would-be missed BP and Money based on the current checkpoint stage
You can now also turn off Battle Frontier notifications, because there's no reason for them to be forced on

## Motivation and Context
Make BF work more thematically - you get rewarded for winning, not for losing
Players who only need a small amount of BP to progress can do so without having to wait out their full run
Removes the gap between players who have a small breeding pool and those with a large one. The former group can *already* quit out effectively on command while still claiming their rewards*.

*If this PR is rejected, it's my opinion that this gap should be closed by making it impossible to lose early.


## How Has This Been Tested?
Run BF from the start to end, checking the rewards and notifications.
Checked that saves with checkpoints get awarded via the update function, and saves without checkpoints do not error on the update function



## Screenshots (optional):
Floor beaten notification:
![image](https://github.com/user-attachments/assets/f0ff98fe-4ada-4a4a-838c-1bc4c23e1c28)
Stage 2840 currently awards 80,656 BP, stage 2830 awards 80,089 BP, so the floor awards 567

Run ending notification, gives summary of total earnings:
![image](https://github.com/user-attachments/assets/b6e74b42-479e-41ab-8141-b19106a2213a)

