### PR TITLE
Added an NPC that explains Unown

### DIFF
--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -877,6 +877,13 @@ const BillGrandpaChristmas = new NPC('Bill\'s Grandpa', [
     ]),
 });
 
+const UnownFigure = new NPC('Unown Figure', [
+    'I am the lead scientist specializing in all things related to Unown. If you have any questions, don\'t hesitate to ask. Our study has revealed three key patterns regarding the appearance of Unown:',
+    '1. <b>Increased Frequency with Clears</b>: The deeper one ventures into the dungeon, the more Unown emerge. Our most daring researchers have observed up to three Unown at a time.',
+    '2. <b> Daily Variations </b>: Different types of Unown seem to appear each day, following what appears to be a specific sequence.',
+    '3. <b> Limited Variety in the Region </b>: Not all versions of Unown are found here. Although 28 forms exist, some have only been encountered in other regions.'
+], { image: 'assets/images/npcs/Scientist (male).png' });
+
 //Kanto Towns
 TownList['Pallet Town'] = new Town(
     'Pallet Town',
@@ -1410,7 +1417,7 @@ TownList['Tanoby Ruins'] = new DungeonTown(
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 39)],
     [TanobyRuinsShop],
     {
-        npcs: [TanobyProfIvy],
+        npcs: [TanobyProfIvy, UnownFigure],
     }
 );
 TownList['Pinkan Mountain'] = new DungeonTown(
@@ -1546,6 +1553,7 @@ const VioletPrimo = new NPC('Primo', [
     'Choose who you select carefully! Once you remove a Held Item from your Pokémon, the item will break!',
     'All righty, be seeing you!',
 ]);
+
 
 const AzaleaElder = new NPC('Elder Li', [
     'You want to know about Celebi? It hasn\'t been seen in a long time.',
@@ -2040,7 +2048,11 @@ TownList['Ruins of Alph'] = new DungeonTown(
     'Ruins of Alph',
     GameConstants.Region.johto,
     GameConstants.JohtoSubRegions.Johto,
-    [new RouteKillRequirement(10, GameConstants.Region.johto, 32)]
+    [new RouteKillRequirement(10, GameConstants.Region.johto, 32)],
+    undefined,
+    {
+        npcs: [UnownFigure]
+    }
 );
 TownList['Union Cave'] = new DungeonTown(
     'Union Cave',
@@ -4754,7 +4766,11 @@ TownList['Solaceon Ruins'] = new DungeonTown(
     'Solaceon Ruins',
     GameConstants.Region.sinnoh,
     GameConstants.SinnohSubRegions.Sinnoh,
-    [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 209)]
+    [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 209)],
+    undefined,
+    {
+        npcs: [UnownFigure]
+    }
 );
 TownList['Iron Island'] = new DungeonTown(
     'Iron Island',

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -880,8 +880,8 @@ const BillGrandpaChristmas = new NPC('Bill\'s Grandpa', [
 const UnownFigure = new NPC('Unown Figure', [
     'I am the lead scientist specializing in all things related to Unown. If you have any questions, don\'t hesitate to ask. Our study has revealed three key patterns regarding the appearance of Unown:',
     '1. <b>Increased Frequency with Clears</b>: The deeper one ventures into the dungeon, the more Unown emerge. Our most daring researchers have observed up to three Unown at a time.',
-    '2. <b> Daily Variations </b>: Different types of Unown seem to appear each day, following what appears to be a specific sequence.',
-    '3. <b> Limited Variety in the Region </b>: Not all versions of Unown are found here. Although 28 forms exist, some have only been encountered in other regions.',
+    '2. <b>Daily Variations</b>: Different types of Unown seem to appear each day, following what appears to be a specific sequence.',
+    '3. <b>Limited Variety in the Region</b>: Not all versions of Unown are found here. Although 28 forms exist, some have only been encountered in other regions.',
 ], { image: 'assets/images/npcs/Scientist (male).png' });
 
 //Kanto Towns

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -881,7 +881,7 @@ const UnownFigure = new NPC('Unown Figure', [
     'I am the lead scientist specializing in all things related to Unown. If you have any questions, don\'t hesitate to ask. Our study has revealed three key patterns regarding the appearance of Unown:',
     '1. <b>Increased Frequency with Clears</b>: The deeper one ventures into the dungeon, the more Unown emerge. Our most daring researchers have observed up to three Unown at a time.',
     '2. <b> Daily Variations </b>: Different types of Unown seem to appear each day, following what appears to be a specific sequence.',
-    '3. <b> Limited Variety in the Region </b>: Not all versions of Unown are found here. Although 28 forms exist, some have only been encountered in other regions.'
+    '3. <b> Limited Variety in the Region </b>: Not all versions of Unown are found here. Although 28 forms exist, some have only been encountered in other regions.',
 ], { image: 'assets/images/npcs/Scientist (male).png' });
 
 //Kanto Towns
@@ -2051,7 +2051,7 @@ TownList['Ruins of Alph'] = new DungeonTown(
     [new RouteKillRequirement(10, GameConstants.Region.johto, 32)],
     undefined,
     {
-        npcs: [UnownFigure]
+        npcs: [UnownFigure],
     }
 );
 TownList['Union Cave'] = new DungeonTown(
@@ -4769,7 +4769,7 @@ TownList['Solaceon Ruins'] = new DungeonTown(
     [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 209)],
     undefined,
     {
-        npcs: [UnownFigure]
+        npcs: [UnownFigure],
     }
 );
 TownList['Iron Island'] = new DungeonTown(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Added an NPC to all (currently available) Unown dungeons. He explains the boss amount, the variety per day and that not all unowns can be caught in that region.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
People asking, no NPC explaining it yet


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Loaded the game, checked if NPC is at every location


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://github.com/user-attachments/assets/14af3c1c-1354-416c-91a8-9305fc223890)




## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- new NPC
