### PR TITLE
Fix dungeon guides failing to progress DeafeatDungeonBossQuest

### DIFF
--- a/src/scripts/dungeons/DungeonGuides.ts
+++ b/src/scripts/dungeons/DungeonGuides.ts
@@ -122,6 +122,8 @@ class DungeonGuides {
     }
 
     public static endDungeon(): void {
+        // runEarly as deferred updates can fail to happen before the dungeon is started again, e.g. DefeatDungeonBossQuest
+        ko.tasks.runEarly();
         this.hired()?.end();
     }
 

--- a/src/scripts/quests/questTypes/DefeatDungeonBossQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatDungeonBossQuest.ts
@@ -19,7 +19,7 @@ class DefeatDungeonBossQuest extends Quest implements QuestInterface {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         ko.when(
-            () =>  DungeonRunner.defeatedBoss() === this.dungeonBoss && DungeonRunner.dungeon?.name === this.dungeon,
+            () => DungeonRunner.defeatedBoss() === this.dungeonBoss && DungeonRunner.dungeon?.name === this.dungeon,
             () => this.focus(1)
         );
     }


### PR DESCRIPTION
## Description
Due to deferred updates, dungeon guides clear a boss and start the next dungeon (clearing the `defeatedBoss` variable) before the observable has chance to update. Make the dungeon guides force an update of observables when they finish a dungeon to avoid this and any other potential similar issues.

## How Has This Been Tested?
Tested against a synthetic save file on the "Defeat Lovrina"  stage of Gale of Darkness

## Types of changes
- Bug fix
