### PR TITLE
Real Evo : nickname and category now transfered

### DIFF
--- a/src/scripts/party/evolutions/EvolutionHandler.ts
+++ b/src/scripts/party/evolutions/EvolutionHandler.ts
@@ -55,6 +55,8 @@ class EvolutionHandler {
             evolvedPartyPokemon.shiny = evolvedPartyPokemon.shiny || basePartyPokemon.shiny;
             evolvedPartyPokemon.attackBonusAmount = bonusAttack;
             evolvedPartyPokemon.vitaminsUsed = basePartyPokemon.vitaminsUsed;
+            evolvedPartyPokemon.nickname = basePartyPokemon.nickname;
+            evolvedPartyPokemon.category = basePartyPokemon.category;
             if (basePartyPokemon.heldItem()?.canUse(evolvedPartyPokemon)) {
                 evolvedPartyPokemon.heldItem = basePartyPokemon.heldItem;
             }


### PR DESCRIPTION
## Description
Evolving a Pokémon now does not clear its nickname and its category.

## Motivation and Context
An evolving Pokémon with Real Evolution challenge on would not keep its nickname nor its category.
I can see how it could help not to transfer categories, but I am sure it is better to have player change categories sometimes than having them set categories again everytime.

## How Has This Been Tested?
Started a Real Evo file, evolved some Pokémon with nicknames or categories set.
Ensured this does not change anything when challenge is disabled.

## Types of changes
- Bug fix, I guess ?
