### PR TITLE
Changed Wacan's Aura Name from Growth to Ripen

### DIFF
--- a/src/modules/enums/AuraType.ts
+++ b/src/modules/enums/AuraType.ts
@@ -1,5 +1,5 @@
 enum AuraType {
-    Growth,
+    Ripen,
     Replant,
     Mutation,
     Harvest,

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -691,7 +691,7 @@ class Farming implements Feature {
                 'Energy from lightning strikes is drawn into the plant, making the Berries grow big and rich.',
                 'The same energy promotes the growth of nearby Berries.',
             ],
-            new Aura(AuraType.Growth, [1.1, 1.2, 1.3]),
+            new Aura(AuraType.Ripen, [1.1, 1.2, 1.3]),
             ['Pikachu', 'Plusle', 'Minun', 'Pachirisu', 'Emolga', 'Dedenne', 'Togedemaru', 'Morpeko (Hangry)', 'Pawmi']
         );
 

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -31,7 +31,7 @@ class Plot implements Saveable {
     formattedMulchTimeLeft: KnockoutComputed<string>;
     formattedAuras: KnockoutComputed<string>;
 
-    auraGrowth: KnockoutComputed<number>;
+    auraRipen: KnockoutComputed<number>;
     auraHarvest: KnockoutComputed<number>;
     auraMutation: KnockoutComputed<number>;
     auraReplant: KnockoutComputed<number>;
@@ -130,8 +130,8 @@ class Plot implements Saveable {
             return GameConstants.formatTime(this.mulchTimeLeft);
         });
 
-        this.auraGrowth = ko.pureComputed(() => {
-            return this.multiplyNeighbourAura(AuraType.Growth);
+        this.auraRipen = ko.pureComputed(() => {
+            return this.multiplyNeighbourAura(AuraType.Ripen);
         });
         this.auraHarvest = ko.pureComputed(() => {
             return this.multiplyNeighbourAura(AuraType.Harvest);
@@ -154,8 +154,8 @@ class Plot implements Saveable {
 
         this.formattedAuras = ko.pureComputed(() => {
             const auraStr = [];
-            if (this.auraGrowth() !== 1) {
-                auraStr.push(`Growth: ×${this.auraGrowth().toFixed(2)}`);
+            if (this.auraRipen() !== 1) {
+                auraStr.push(`Ripen: ×${this.auraRipen().toFixed(2)}`);
             }
 
             if (this.auraHarvest() !== 1) {
@@ -478,7 +478,7 @@ class Plot implements Saveable {
         }[this.mulch] ?? 1;
 
         if (this.stage() !== PlotStage.Berry) {
-            multiplier *= this.auraGrowth();
+            multiplier *= this.auraRipen();
         } else {
             multiplier *= this.auraDecay();
             // Handle Death Aura


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Following on the replacement from skill issue #5592, this should help distinguish Wacan's aura only affecting ripening rate vs the word "grow" that's used both in Sprayduck and the replaced Mulch that affect both ripening and withering rates.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Having a double Growth would be as bad as the current double Boost addressed in skill issue #5592 so this change was needed to further differentiate what each "concept" refers to in the Farm. I'm open for suggestions, of course.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Opened the Farm. Made sure Growth -> Ripen.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![ripen-aura](https://github.com/user-attachments/assets/9c6d347b-de16-4261-b36a-5451b12d83ed)


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Text edit
