### PR TITLE
Fix Chilan aura multipliers

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -967,7 +967,7 @@ class Farming implements Feature {
             3.3,
             BerryFirmness.Very_Soft,
             ['This Berry can be cored out and dried to make a whistle. Blowing through its hole makes an indescribable sound.'],
-            new Aura(AuraType.Egg, [0.9, 0.8, 0.7]),
+            new Aura(AuraType.Egg, [0.99, 0.98, 0.97]),
             ['Snorlax', 'Girafarig', 'Swablu', 'Munchlax', 'Audino', 'Skwovet']
         );
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
This is a fix to pr #5587. The aura multiplier on chilan has been changed from tanga's numbers to micle's numbers. The multipliers are now x0.99, x0.98, and x0.97 for the respective stages that berries give auras.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
I did this because the old numbers were wildly unbalanced and resulted in the eggstep gain being awful.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I loaded up a file and fully grew a farm of the berry and made sure the aura number was correct. I also loaded up another file with nothing on the farm to see how much the aura affected breeding so I had both files use the same hatchery helpers with the same filters autobattling cynthia to see how much damage each would gain over an hour.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Aura fix
