### PR TITLE
Clarify Amulet Coin quest text

### DIFF
--- a/src/scripts/quests/questTypes/UseOakItemQuest.ts
+++ b/src/scripts/quests/questTypes/UseOakItemQuest.ts
@@ -49,7 +49,7 @@ class UseOakItemQuest extends Quest implements QuestInterface {
         if (this.item == OakItemType.Magic_Ball) {
             desc.push(`capture ${this.amount.toLocaleString('en-US')} wild Pokémon.`);
         } else if (this.item == OakItemType.Amulet_Coin) {
-            desc.push(`earn Pokédollars ${this.amount.toLocaleString('en-US')} times.`);
+            desc.push(`earn bonus Pokédollars ${this.amount.toLocaleString('en-US')} times.`);
         } else if (this.item == OakItemType.Exp_Share) {
             desc.push(`defeat ${this.amount.toLocaleString('en-US')} Pokémon.`);
         } else {


### PR DESCRIPTION
Changed the Amulet Coin `UseOakItemQuest` text to specify that it only activates when earning bonus money. Slightly less confusing!