### PR TITLE
Fix html related bugs for Key items

### DIFF
--- a/src/components/getKeyItem.html
+++ b/src/components/getKeyItem.html
@@ -10,14 +10,14 @@
             <div class="modal-body">
                 <h5><strong>Congratulations!</strong></h5>
                 <span>You have gained a</span><br>
-                <img class="key-item" src="" data-bind="attr:{ title: App.game.keyItems.itemList[KeyItemController.latestGainedItem()].displayName,  src: 'assets/images/keyitems/' + KeyItemType[KeyItemController.latestGainedItem()] + '.png'}"/><br>
+                <img class="key-item" src="" data-bind="attr:{ title: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).displayName,  src: 'assets/images/keyitems/' + KeyItemType[KeyItemController.latestGainedItem()] + '.png'}"/><br>
                 <span>
-                    <strong data-bind="text: App.game.keyItems.itemList[KeyItemController.latestGainedItem()].displayName">Name</strong>
+                    <strong data-bind="text: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).displayName">Name</strong>
                 </span><br>
-                <span data-bind="html:  App.game.keyItems.itemList[KeyItemController.latestGainedItem()].description">Description</span>
+                <span data-bind="html:  App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).description">Description</span>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: App.game.keyItems.itemList[KeyItemController.latestGainedItem()].unlockRewardOnClose">Close</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).unlockRewardOnClose">Close</button>
             </div>
         </div>
     </div>

--- a/src/components/getKeyItem.html
+++ b/src/components/getKeyItem.html
@@ -7,18 +7,20 @@
                     <h5 class="modal-title" id="keyItemModalLabel">New key item!</h5>
                 </div>
             </div>
+            <!-- ko with: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()) -->
             <div class="modal-body">
                 <h5><strong>Congratulations!</strong></h5>
                 <span>You have gained a</span><br>
-                <img class="key-item" src="" data-bind="attr:{ title: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).displayName,  src: 'assets/images/keyitems/' + KeyItemType[KeyItemController.latestGainedItem()] + '.png'}"/><br>
+                <img class="key-item" src="" data-bind="attr:{ title: $data.displayName,  src: 'assets/images/keyitems/' + KeyItemType[KeyItemController.latestGainedItem()] + '.png'}"/><br>
                 <span>
-                    <strong data-bind="text: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).displayName">Name</strong>
+                    <strong data-bind="text: $data.displayName">Name</strong>
                 </span><br>
-                <span data-bind="html:  App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).description">Description</span>
+                <span data-bind="html: $data.description">Description</span>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.latestGainedItem()).unlockRewardOnClose">Close</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal" data-bind="click: $data.unlockRewardOnClose">Close</button>
             </div>
+            <!-- /ko -->
         </div>
     </div>
 </div>

--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -310,13 +310,13 @@
                             <div class="oak-item-info">
                                 <div class="row justify-content-sm-center">
                                     <div class="col-xs-10">
-                                        <b><span data-bind="text: App.game.keyItems.itemList[KeyItemController.inspectedItem()].displayName"></span></b>
+                                        <b><span data-bind="text: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.inspectedItem()).displayName"></span></b>
                                     </div>
                                 </div>
                                 <div class="row justify-content-sm-center">
                                     <div class="col-xs-10">
                                         <knockout data-bind="if: App.game.keyItems.hasKeyItem(KeyItemController.inspectedItem())">
-                                            <p data-bind="html: App.game.keyItems.itemList[KeyItemController.inspectedItem()].description"></p>
+                                            <p data-bind="html: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.inspectedItem()).description"></p>
                                         </knockout>
                                         <knockout data-bind="ifnot: App.game.keyItems.hasKeyItem(KeyItemController.inspectedItem())">
                                             <p>?????</p>

--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -308,21 +308,23 @@
                             </div>
 
                             <div class="oak-item-info">
+                                <!-- ko with: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.inspectedItem()) -->
                                 <div class="row justify-content-sm-center">
                                     <div class="col-xs-10">
-                                        <b><span data-bind="text: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.inspectedItem()).displayName"></span></b>
+                                        <b><span data-bind="text: $data.displayName"></span></b>
                                     </div>
                                 </div>
                                 <div class="row justify-content-sm-center">
                                     <div class="col-xs-10">
                                         <knockout data-bind="if: App.game.keyItems.hasKeyItem(KeyItemController.inspectedItem())">
-                                            <p data-bind="html: App.game.keyItems.itemList.find(k=> k.id == KeyItemController.inspectedItem()).description"></p>
+                                            <p data-bind="html: $data.description"></p>
                                         </knockout>
                                         <knockout data-bind="ifnot: App.game.keyItems.hasKeyItem(KeyItemController.inspectedItem())">
                                             <p>?????</p>
                                         </knockout>
                                     </div>
                                 </div>
+                                <!-- /ko -->
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Description
The htmls related to key items still used enums to go through the key items itemList

## Motivation and Context
Finished #5565

## How Has This Been Tested?
- Bought new key item, worked ✔️ 
- Hovered over new key item, worked ✔️ 
- Switched around key items _and_ hovered over them, worked ✔️ 


## Screenshots:
![image](https://github.com/user-attachments/assets/1163c3f8-9644-4bb9-9aba-df60d8eae1e5)


## Types of changes
- Bug fix