### PR TITLE
Add an indicator and hint tooltip for locked rare hold items

### DIFF
--- a/src/components/pokemonStatisticsModal.html
+++ b/src/components/pokemonStatisticsModal.html
@@ -102,9 +102,21 @@
                 <!-- /ko -->
                 <!-- ko if: BagHandler.displayName(pokemonMap[$data].heldItem) -->
                 <tr>
-                  <td class="text-left align-middle">Rare Hold Item</td>
-                  <td class="text-left tight text-wrap"><code
-                      data-bind="text: BagHandler.displayName(pokemonMap[$data].heldItem)"></code></td>
+                  <td class="text-left align-middle" data-bind="tooltip: {
+                    title: 'Item this Pokémon has a chance to drop upon being defeated.',
+                    placement: 'bottom',
+                    trigger: 'hover'
+                  }">Rare Hold Item</td>
+                  <td class="text-left tight text-wrap">
+                    <code data-bind="text: BagHandler.displayName(pokemonMap[$data].heldItem)"></code>
+                    <!-- ko ifnot: pokemonMap[$data].heldItem.requirement?.isCompleted() ?? true -->
+                    <span class="small" data-bind="tooltip: {
+                        title: pokemonMap[$data].heldItem.requirement.hint(),
+                        placement: 'bottom',
+                        trigger: 'hover'
+                    }">🔒</span>
+                    <!-- /ko -->
+                  </td>
                 </tr>
                 <!-- /ko -->
                 <tr>


### PR DESCRIPTION
## Description
Adds a lock icon and hint tooltip in the dex entry for pokemon with rare hold items that the player does not meet the requirements for yet

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/637a064b-dcaa-41c7-8872-97684b8551f6)

## Types of changes
- UI improvement
