### PR TITLE
Profile Shadow Pokémon

### DIFF
--- a/src/components/profileModal.html
+++ b/src/components/profileModal.html
@@ -53,7 +53,7 @@
                             </div>
                         </label>
                     </div>
-                    <!-- ko if: SubRegions.getSubRegion(GameConstants.Region.hoenn, 'Orre').unlocked() -->
+                    <!-- ko if: SubRegions.isSubRegionUnlocked(GameConstants.Region.hoenn, GameConstants.HoennSubRegions.Orre) -->
                     <div class="form-group col-4">
                         <label>Shadow</label>
                         <label class="form-check-label toggler-wrapper style-1 float-right">

--- a/src/components/profileModal.html
+++ b/src/components/profileModal.html
@@ -9,19 +9,40 @@
             </div>
             <div class="modal-body text-left p-2">
                 <div class="form-row p-0" id="profileEdit">
-                    <div class="form-group col-6">
+                    <div class="form-group col-5">
                         <label>Name</label>
                         <input autocomplete="off" class="form-control" oninput="App.game.profile.name(this.value)" placeholder="name" data-bind="value: App.game.profile.name()"/>
                     </div>
-                    <div class="form-group col-6">
+                    <div class="form-group col-7">
                         <label>Pokémon</label>
-                        <select autocomplete="off" class="custom-select" onchange="App.game.profile.pokemon(+this.value), App.game.profile.pokemonShiny(false), App.game.profile.pokemonFemale(false), App.game.profile.pokemonShadow(false)">
-                            <!-- ko foreach: App.game.party.caughtPokemon.sort((a, b) => a.id - b.id) -->
-                            <option data-bind="attr: { value: $data.id, selected: App.game.profile.pokemon() === $data.id }, text: '#'+($data.id > 0 ? Math.floor($data.id) + '' : '???').padStart(3, 0)+' '+$data.displayName + ($data.shiny ? ' ✨' : '') + ($data.shadow !== GameConstants.ShadowStatus.None ? '⚫' : '')">Pokemon</option>
-                            <!-- /ko -->
-                        </select>
+                        <div class="dropdown">
+                            <button class="btn btn-dropdown custom-select text-left" type="button" data-toggle="dropdown" data-display="static">
+                                <div class="text-truncate btn-text" data-bind="with: App.game.party.getPokemon(App.game.profile.pokemon())">
+                                    <span data-bind="text: `#${($data.id > 0 ? Math.floor($data.id).toString() : '???').padStart(3, 0)} ${$data.displayName}`"></span>
+                                    <span data-bind="visible: $data.shiny">✨</span>
+                                    <span data-bind="visible: $data.shadow !== GameConstants.ShadowStatus.None">
+                                        <img style="width: 18px;" src="assets/images/status/shadow.svg"/>
+                                    </span>
+                                </div>
+                            </button>
+                            <div class="dropdown-menu px-2 w-100" style="max-height: 280px; overflow-y: auto;">
+                                <input type="text" class="form-control form-control-sm" placeholder="Search" data-bind="textInput: App.game.profile.pokemonSearch" />
+                                <div class="dropdown-divider"></div>
+                                <!-- ko if: DisplayObservables.modalState.profileModal === 'show' -->
+                                <div data-bind="foreach: App.game.profile.getCaughtPokemonList()">
+                                    <button class="dropdown-item small px-1" type="button" data-bind="click: () => { App.game.profile.pokemon($data.id); App.game.profile.pokemonShiny(false); App.game.profile.pokemonFemale(false); App.game.profile.pokemonShadow(false); }">
+                                        <span data-bind="text: `#${($data.id > 0 ? Math.floor($data.id).toString() : '???').padStart(3, 0)} ${$data.displayName}`"></span>
+                                        <span data-bind="visible: $data.shiny">✨</span>
+                                        <span data-bind="visible: $data.shadow !== GameConstants.ShadowStatus.None">
+                                            <img style="width: 16px;" src="assets/images/status/shadow.svg"/>
+                                        </span>
+                                    </button>
+                                </div>
+                                <!-- /ko -->
+                            </div>
+                        </div>
                     </div>
-                    
+
                     <div class="form-group col-4">
                         <label>Shiny</label>
                         <label class="form-check-label toggler-wrapper style-1 float-right">
@@ -37,9 +58,9 @@
                         <label>Shadow</label>
                         <label class="form-check-label toggler-wrapper style-1 float-right">
                             <input class="form-check-input" type="checkbox" id="profile-shadow-toggle"
-                                data-bind="checked: App.game.profile.pokemonShadow, enable: App.game.party.getPokemon(App.game.profile.pokemon()).shadow > GameConstants.ShadowStatus.None">
-                            <div class="toggler-slider" data-bind="tooltip: { title: !App.game.party.alreadyCaughtPokemon(App.game.profile.pokemon(), true) ? `Shadow ${PokemonHelper.getPokemonById(App.game.profile.pokemon()).name} is not unlocked yet` : '', trigger: 'hover' }">
-                                <div class="toggler-knob" data-bind="css: { 'checkbox-disabled': App.game.party.getPokemon(App.game.profile.pokemon()).shadow === GameConstants.ShadowStatus.None }"></div>
+                                data-bind="checked: App.game.profile.pokemonShadow, enable: App.game.party.alreadyCaughtPokemon(App.game.profile.pokemon(), false, true)">
+                            <div class="toggler-slider" data-bind="tooltip: { title: !App.game.party.alreadyCaughtPokemon(App.game.profile.pokemon(), false, true) ? `Shadow ${PokemonHelper.getPokemonById(App.game.profile.pokemon()).name} is not unlocked yet or does not exist` : '', trigger: 'hover' }">
+                                <div class="toggler-knob" data-bind="css: { 'checkbox-disabled': !App.game.party.alreadyCaughtPokemon(App.game.profile.pokemon(), false, true) }"></div>
                             </div>
                         </label>
                     </div>

--- a/src/components/profileModal.html
+++ b/src/components/profileModal.html
@@ -15,14 +15,14 @@
                     </div>
                     <div class="form-group col-6">
                         <label>Pokémon</label>
-                        <select autocomplete="off" class="custom-select" onchange="App.game.profile.pokemon(+this.value), App.game.profile.pokemonShiny(false), App.game.profile.pokemonFemale(false)">
+                        <select autocomplete="off" class="custom-select" onchange="App.game.profile.pokemon(+this.value), App.game.profile.pokemonShiny(false), App.game.profile.pokemonFemale(false), App.game.profile.pokemonShadow(false)">
                             <!-- ko foreach: App.game.party.caughtPokemon.sort((a, b) => a.id - b.id) -->
-                            <option data-bind="attr: { value: $data.id, selected: App.game.profile.pokemon() === $data.id }, text: '#'+($data.id > 0 ? Math.floor($data.id) + '' : '???').padStart(3, 0)+' '+$data.displayName + ($data.shiny ? ' ✨' : '')">Pokemon</option>
+                            <option data-bind="attr: { value: $data.id, selected: App.game.profile.pokemon() === $data.id }, text: '#'+($data.id > 0 ? Math.floor($data.id) + '' : '???').padStart(3, 0)+' '+$data.displayName + ($data.shiny ? ' ✨' : '') + ($data.shadow !== GameConstants.ShadowStatus.None ? '⚫' : '')">Pokemon</option>
                             <!-- /ko -->
                         </select>
                     </div>
                     
-                    <div class="form-group col-6">
+                    <div class="form-group col-4">
                         <label>Shiny</label>
                         <label class="form-check-label toggler-wrapper style-1 float-right">
                             <input class="form-check-input" type="checkbox" id="profile-shiny-toggle"
@@ -32,8 +32,20 @@
                             </div>
                         </label>
                     </div>
+                    <!-- ko if: SubRegions.getSubRegion(GameConstants.Region.hoenn, 'Orre').unlocked() -->
+                    <div class="form-group col-4">
+                        <label>Shadow</label>
+                        <label class="form-check-label toggler-wrapper style-1 float-right">
+                            <input class="form-check-input" type="checkbox" id="profile-shadow-toggle"
+                                data-bind="checked: App.game.profile.pokemonShadow, enable: App.game.party.getPokemon(App.game.profile.pokemon()).shadow > GameConstants.ShadowStatus.None">
+                            <div class="toggler-slider" data-bind="tooltip: { title: !App.game.party.alreadyCaughtPokemon(App.game.profile.pokemon(), true) ? `Shadow ${PokemonHelper.getPokemonById(App.game.profile.pokemon()).name} is not unlocked yet` : '', trigger: 'hover' }">
+                                <div class="toggler-knob" data-bind="css: { 'checkbox-disabled': App.game.party.getPokemon(App.game.profile.pokemon()).shadow === GameConstants.ShadowStatus.None }"></div>
+                            </div>
+                        </label>
+                    </div>
+                    <!-- /ko -->
                     <!-- ko if: PokemonHelper.getPokemonById(App.game.profile.pokemon()).gender.visualDifference -->
-                    <div class="form-group col-6">
+                    <div class="form-group col-4">
                         <label>Gender</label>
                         <label class="form-check-label toggler-wrapper style-1 float-right"
                             data-bind="css: { 'gender-toggle': PokemonHelper.getPokemonById(App.game.profile.pokemon()).gender.visualDifference }">

--- a/src/modules/SaveSelector.ts
+++ b/src/modules/SaveSelector.ts
@@ -98,6 +98,7 @@ export default class SaveSelector {
                 saveData.profile?.trainer,
                 saveData.profile?.pokemon ?? saveData.party.caughtPokemon[0]?.id,
                 saveData.profile?.pokemonShiny ?? saveData.party.caughtPokemon[0]?.shiny,
+                saveData.profile?.pokemonShadow ?? false,
                 saveData.profile?.pokemonFemale ?? false,
                 saveData.profile?.background,
                 saveData.profile?.textColor,

--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -19,6 +19,7 @@ export default class Profile implements Saveable {
     public trainer: KnockoutObservable<number>;
     public pokemon: KnockoutObservable<number>;
     public pokemonShiny: KnockoutObservable<boolean>;
+    public pokemonShadow: KnockoutObservable<boolean>;
     public pokemonFemale: KnockoutObservable<boolean>;
     public background: KnockoutObservable<number>;
     public textColor: KnockoutObservable<string>;
@@ -35,6 +36,7 @@ export default class Profile implements Saveable {
         this.trainer.subscribe((t) => document.documentElement.style.setProperty('--trainer-image', `url('../assets/images/profile/trainer-${t}.png')`));
         this.pokemon = ko.observable(pokemon).extend({ numeric: 2 });
         this.pokemonShiny = ko.observable(false).extend({ boolean: null });
+        this.pokemonShadow = ko.observable(false).extend({ boolean: null });
         this.pokemonFemale = ko.observable(false).extend({ boolean: null });
         this.background = ko.observable(background).extend({ numeric: 0 });
         this.textColor = ko.observable(textColor);
@@ -45,6 +47,7 @@ export default class Profile implements Saveable {
         trainer = Rand.floor(Profile.MAX_TRAINER),
         pokemon = Rand.intBetween(1, 151),
         pokemonShiny = false,
+        pokemonShadow = false,
         pokemonFemale = false,
         background = Rand.floor(Profile.MAX_BACKGROUND),
         textColor = 'whitesmoke',
@@ -94,7 +97,7 @@ export default class Profile implements Saveable {
         const trainerTime: HTMLElement = node.querySelector('.trainer-time');
         trainerTime.innerText = GameConstants.formatTimeFullLetters(seconds);
         const trainerPokemonImage: HTMLImageElement = node.querySelector('.trainer-pokemon-image');
-        trainerPokemonImage.src = `assets/images/${pokemonShiny ? 'shiny' : ''}pokemon/${pokemon}${pokemonFemale ? '-f' : ''}.png`;
+        trainerPokemonImage.src = `assets/images/${pokemonShiny ? 'shiny' : ''}${pokemonShadow ? 'shadow' : ''}pokemon/${pokemon}${pokemonFemale ? '-f' : ''}.png`;
         const trainerVersion: HTMLElement = node.querySelector('.trainer-version');
         trainerVersion.innerText = `v${version}`;
         const badgeContainer = node.querySelector('.challenge-badges');
@@ -127,6 +130,7 @@ export default class Profile implements Saveable {
             this.trainer(),
             this.pokemon(),
             this.pokemonShiny(),
+            this.pokemonShadow(),
             this.pokemonFemale(),
             this.background(),
             this.textColor(),
@@ -153,6 +157,7 @@ export default class Profile implements Saveable {
         if (json.trainer !== undefined) this.trainer(json.trainer);
         if (json.pokemon !== undefined) this.pokemon(json.pokemon);
         if (json.pokemonShiny !== undefined) this.pokemonShiny(json.pokemonShiny);
+        if (json.pokemonShadow !== undefined) this.pokemonShadow(json.pokemonShiny);
         if (json.pokemonFemale !== undefined) this.pokemonFemale(json.pokemonFemale);
         if (json.background !== undefined) this.background(json.background);
         if (json.textColor) this.textColor(json.textColor);
@@ -164,6 +169,7 @@ export default class Profile implements Saveable {
             trainer: this.trainer(),
             pokemon: this.pokemon(),
             pokemonShiny: this.pokemonShiny(),
+            pokemonShadow: this.pokemonShiny(),
             pokemonFemale: this.pokemonFemale(),
             background: this.background(),
             textColor: this.textColor(),

--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -6,6 +6,7 @@ import { Saveable } from '../DataStore/common/Saveable';
 import * as GameConstants from '../GameConstants';
 import Notifier from '../notifications/Notifier';
 import Rand from '../utilities/Rand';
+import GameHelper from '../GameHelper';
 
 export default class Profile implements Saveable {
     public static MAX_TRAINER = 160;
@@ -23,6 +24,18 @@ export default class Profile implements Saveable {
     public pokemonFemale: KnockoutObservable<boolean>;
     public background: KnockoutObservable<number>;
     public textColor: KnockoutObservable<string>;
+
+    public pokemonSearch = ko.observable('');
+    public getCaughtPokemonList = ko.pureComputed(() => {
+        let caughtPokemon = App.game.party.caughtPokemon;
+        if (this.pokemonSearch() != '') {
+            const regex = GameHelper.safelyBuildRegex(this.pokemonSearch());
+            caughtPokemon = caughtPokemon.filter((pokemon) => {
+                return regex.test(pokemon.id) || regex.test(pokemon.name) || regex.test(pokemon.displayName);
+            });
+        }
+        return caughtPokemon.sort((a, b) => a.id - b.id);
+    });
 
     constructor(
         name = 'Trainer',


### PR DESCRIPTION
## Description
Added the ability to display the Pokémon as shadow on Profile, when available. The toggle does not display until the player unlocks Orre.

## Motivation and Context
Motivated by neat sprites that deserve some more love.

## How Has This Been Tested?
Played around with the toggle on different files, for different Pokémon.

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/5437b9e5-459e-4115-9239-9a8a2b0dc83e)


## Types of changes
- New feature
