### PR TITLE
More 0.10.22 fixes

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -234,21 +234,10 @@
                                 <tr><th colspan="2">Underground</th></tr>
                             </thead>
                             <tbody>
-                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.underground.hammer')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.underground.chisel')}"></tr>
+                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.underground.hammer')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.underground.bomb')}"></tr>
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.underground.survey')}"></tr>
-                                <tr>
-                                    <td class="p-2">
-                                        <knockout data-bind="text: App.translation.get('hotkey.underground.useRestore', 'settings', { defaultValue: 'Use Restore'})"></knockout><span>:</span>
-                                    </td>
-                                    <td class="p-0" data-bind="tooltip: {
-                                        title: 'Each number refers to a specific Restore',
-                                        trigger: 'hover',
-                                    }">
-                                        <kbd class="btn-block" style="padding: 10px 0;" ><code>Number Keys</code></kbd>
-                                    </td>
-                                </tr>
                             </tbody>
                             <thead>
                                 <tr><th colspan="2">Oak Items</th></tr>

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -473,7 +473,7 @@
                         </div>
 
                         <div class="card-body">
-                            <p>Helpers are characters you can hire to assist with mining tasks. They perform actions at certain timing intervals and become more efficient as they level up.</p>
+                            <p>Helpers are characters you can hire to assist with mining tasks. They perform actions at certain timing intervals and become more efficient as they level up. Each of them bring their own powerful tools, so their actions will not affect the durability of your tools.</p>
 
                             <h4>Helper Mechanics</h4>
                             <ul>

--- a/src/modules/SaveSelector.ts
+++ b/src/modules/SaveSelector.ts
@@ -5,6 +5,7 @@ import Profile from './profile/Profile';
 import { SortSaves } from './Sortable';
 import Settings from './settings/index';
 import GameHelper from './GameHelper';
+import GameLoadState from './utilities/GameLoadState';
 
 export default class SaveSelector {
     static MAX_SAVES = 9;
@@ -68,6 +69,11 @@ export default class SaveSelector {
 
     static LoadSaveOnKeydown(e: JQuery.KeyDownEvent) {
         if (GameHelper.focusedOnEditableElement()) {
+            return;
+        }
+
+        if (GameLoadState.getLoadState() !== GameLoadState.states.none) {
+            $(document).off(e);
             return;
         }
 

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -83,7 +83,7 @@ ItemList.Rich_Mulch  = new MulchItem(MulchType.Rich_Mulch, 100, 'Rich Mulch', 'I
 ItemList.Surprise_Mulch  = new MulchItem(MulchType.Surprise_Mulch, 150, 'Surprise Mulch', 'Increases Berry mutation rate.');
 ItemList.Amaze_Mulch = new MulchItem(MulchType.Amaze_Mulch, 200, 'Amaze Mulch', 'A weaker combination of Boost, Rich and Surprise mulch.');
 ItemList.Freeze_Mulch = new MulchItem(MulchType.Freeze_Mulch, 350, 'Freeze Mulch', 'Stops Berry growth and auras. Mutations will still occur while berries are frozen.');
-ItemList.Gooey_Mulch = new MulchItem(MulchType.Gooey_Mulch, 100, 'Gooey Mulch', 'Helps attract rarer species. Gooed Pokémon are less likely to flee.');
+ItemList.Gooey_Mulch = new MulchItem(MulchType.Gooey_Mulch, 100, 'Gooey Mulch', 'Helps attract rarer species. Gooed Pokémon are more likely to be caught.');
 
 ItemList.Pokeball   = new PokeballItem(Pokeball.Pokeball, 100, undefined, { multiplier: 1 }, 'Poké Ball');
 ItemList.Greatball  = new PokeballItem(Pokeball.Greatball, 500, undefined, undefined, 'Great Ball');

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -377,7 +377,7 @@ ItemList['Grotle (Acorn)']  = new PokemonItem('Grotle (Acorn)');
 ItemList.Combee               = new PokemonItem('Combee', 6750);
 ItemList['Burmy (Plant)']     = new PokemonItem('Burmy (Plant)', 6750);
 ItemList.Cherubi              = new PokemonItem('Cherubi', 6750);
-ItemList.Spiritomb            = new PokemonItem('Spiritomb', 432, Currency.diamond);
+ItemList.Spiritomb            = new PokemonItem('Spiritomb', 20000, Currency.diamond);
 // Unova
 ItemList.Zorua                = new PokemonItem('Zorua', 50625);
 ItemList['Meloetta (Pirouette)'] = new PokemonItem('Meloetta (Pirouette)', 200000);

--- a/src/modules/notifications/NotificationConstants.ts
+++ b/src/modules/notifications/NotificationConstants.ts
@@ -78,6 +78,7 @@ const NotificationConstants = {
             underground_dig_deeper: new NotificationSetting('notifcation.underground_dig_deeper', 'You dig deeper...', true),
             underground_item_found: new NotificationSetting('notification.underground_item_found', 'Item found while mining', true),
             helper: new NotificationSetting('notification.underground_helper', 'Underground Helper Hired/Fired', true),
+            battery_full: new NotificationSetting('notification.battery_full', 'Underground Battery is ready to be discharged', true),
         },
         Farming: {
             berry_discovered: new NotificationSetting('notification.berry_discovered', 'New Berry discovered', true),

--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -170,7 +170,7 @@ export default class Profile implements Saveable {
         if (json.trainer !== undefined) this.trainer(json.trainer);
         if (json.pokemon !== undefined) this.pokemon(json.pokemon);
         if (json.pokemonShiny !== undefined) this.pokemonShiny(json.pokemonShiny);
-        if (json.pokemonShadow !== undefined) this.pokemonShadow(json.pokemonShiny);
+        if (json.pokemonShadow !== undefined) this.pokemonShadow(json.pokemonShadow);
         if (json.pokemonFemale !== undefined) this.pokemonFemale(json.pokemonFemale);
         if (json.background !== undefined) this.background(json.background);
         if (json.textColor) this.textColor(json.textColor);
@@ -182,7 +182,7 @@ export default class Profile implements Saveable {
             trainer: this.trainer(),
             pokemon: this.pokemon(),
             pokemonShiny: this.pokemonShiny(),
-            pokemonShadow: this.pokemonShiny(),
+            pokemonShadow: this.pokemonShadow(),
             pokemonFemale: this.pokemonFemale(),
             background: this.background(),
             textColor: this.textColor(),

--- a/src/modules/underground/UndergroundBattery.ts
+++ b/src/modules/underground/UndergroundBattery.ts
@@ -156,7 +156,12 @@ export class UndergroundBattery {
     }
 
     private async handleDischargingPattern() {
-        while (this._activeDischargePattern && this._activeDischargeFrame < this._activeDischargePattern.pattern.length) {
+        while (
+            this._activeDischargePattern &&
+            this._activeDischargeFrame < this._activeDischargePattern.pattern.length &&
+            App.game.underground.mine.timeUntilDiscovery <= 0 &&
+            !App.game.underground.mine.completed
+        ) {
             const patternFrame = this._activeDischargePattern.pattern[this._activeDischargeFrame];
 
             if ((patternFrame?.length || 0) > 0) {
@@ -177,6 +182,7 @@ export class UndergroundBattery {
                 setTimeout(resolve, 15);
             });
         }
+        this._activeDischargePattern = null;
     }
 
     get charges() {

--- a/src/modules/underground/UndergroundBattery.ts
+++ b/src/modules/underground/UndergroundBattery.ts
@@ -122,6 +122,10 @@ export class UndergroundBattery {
 
         GameHelper.incrementObservable(this._charges, 1);
         this._batteryCooldown(UNDERGROUND_BATTERY_COOLDOWN_SECONDS);
+
+        if (this._charges() >= UNDERGROUND_BATTERY_MAX_CHARGES) {
+            UndergroundController.notifyBatteryFull();
+        }
     }
 
     public discharge() {

--- a/src/modules/underground/UndergroundController.ts
+++ b/src/modules/underground/UndergroundController.ts
@@ -315,4 +315,13 @@ export class UndergroundController {
             timeout: 3000,
         });
     }
+
+    public static notifyBatteryFull() {
+        Notifier.notify({
+            message: 'Your Underground Battery has been fully charged and is ready to be discharged.',
+            type: NotificationOption.info,
+            setting: NotificationConstants.NotificationSetting.Underground.battery_full,
+            timeout: 10000,
+        });
+    }
 }

--- a/src/modules/underground/UndergroundController.ts
+++ b/src/modules/underground/UndergroundController.ts
@@ -282,7 +282,7 @@ export class UndergroundController {
     }
 
     public static notifyItemFound(item: UndergroundItem, amount: number, helper?: UndergroundHelper) {
-        const { itemName } = item;
+        const { name: itemName } = item;
 
         Notifier.notify({
             message: `${helper ? `${helper.name}` : 'You'} found ${GameHelper.anOrA(itemName)} ${humanifyString(itemName)}.`,

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -1412,7 +1412,7 @@ TemporaryBattleList['Barry 3'] = new TemporaryBattle(
         new GymPokemon('Prinplup', 2329444, 27, new StarterRequirement(GameConstants.Region.sinnoh, GameConstants.Starter.Fire)),
         new GymPokemon('Grotle', 2329444, 27, new StarterRequirement(GameConstants.Region.sinnoh, GameConstants.Starter.Water)),
     ],
-    'Waaah! It goes to show my surefire winning strategy doesn\'t work',
+    'Waaah! It goes to show my surefire winning strategy doesn\'t work.',
     [new GymBadgeRequirement(BadgeEnums.Relic)],
     undefined,
     {

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3214,7 +3214,7 @@ const Chobin2 = new NPC('Chobin', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Gale of Darkness', 18), new QuestLineStepCompletedRequirement('Gale of Darkness', 20, GameConstants.AchievementOption.less)]),
 });
 const SearchLibra = new NPC('Search the S. S. Libra', [
-    '<i>You rummage around in the wreckage of the S. S. Libra, and find evidence of a recent battle. It looks like something very strong beat up a lot of weaker Pokémon</i>',
+    '<i>You rummage around in the wreckage of the S. S. Libra, and find evidence of a recent battle. It looks like something very strong beat up a lot of weaker Pokémon.</i>',
     '<i>Deep in the wreckage, you find a box that was left behind on accident.</i>',
 ], {requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Gale of Darkness', 20), new QuestLineStepCompletedRequirement('Gale of Darkness', 22, GameConstants.AchievementOption.less)]),
 });
@@ -6322,7 +6322,7 @@ const KalosStoneSalesman2 = new NPC('Stone Salesman', [
 
 const Baraz1 = new NPC('Baraz', [
     'Hello, $playername$! My name is Baraz, and my people have a complicated history with Hoopa.',
-    'I have come to this region to search of a Prison Bottle, in which the spirit of a powerful Hoopa is bound.',
+    'I have come to this region to search for a Prison Bottle, in which the spirit of a powerful Hoopa is bound.',
     'Can you help with my search? My search indicates it is nearby, maybe one of the local Psychic Pokémon has it?',
 ], {
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Clash of Ages', 0), new QuestLineStepCompletedRequirement('Clash of Ages', 2, GameConstants.AchievementOption.less)]),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
* Increase Spiritomb cost from 108 diamonds to 5000 diamonds
* Fixed various typos
* Fixed capitalisation on digged up items in the notification
* Updated Gooey Mulch description
* Added helper explanation that they don't affect player tool durability
* Prevented Underground Battery Discharge from affecting a completed mine, or a mine that is being searched for
* Removed the Num hotkeys from the settings modal for UG
* Added a full UG Battery notification


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
