### PR TITLE
Fix broken reward images in active mines

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2835,8 +2835,9 @@ class Update implements Saveable {
             // Remove easier-to-fix locale misformatting from underground grid item tiles
             saveData.underground?.mine.grid.map(t => t.reward).filter(r => r).forEach(r => {
                 if (!r.backgroundPosition.match(/^\d+% \d+%$/)) {
-                    r.backgroundPosition = r.backgroundPosition.replace(/^(\d+)\s% (\d+)\s%$/, '$1% $2%');
-                    r.backgroundPosition = r.backgroundPosition.replace(/^%\s(\d+) %\s(\d+)$/, '$1% $2%');
+                    r.backgroundPosition = r.backgroundPosition.replaceAll(',', '.');
+                    r.backgroundPosition = r.backgroundPosition.replace(/^([\d.]+)\s% ([\d.]+)\s%$/, '$1% $2%');
+                    r.backgroundPosition = r.backgroundPosition.replace(/^%\s([\d.]+) %\s([\d.]+)$/, '$1% $2%');
                 }
             });
         },

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2830,6 +2830,16 @@ class Update implements Saveable {
                 playerData._townName = 'Pokémon HQ Lab';
             }
         },
+
+        '0.10.23': ({ playerData, saveData, settingsData }) => {
+            // Remove easier-to-fix locale misformatting from underground grid item tiles
+            saveData.underground?.mine.grid.map(t => t.reward).filter(r => r).forEach(r => {
+                if (!r.backgroundPosition.match(/^\d+% \d+%$/)) {
+                    r.backgroundPosition = r.backgroundPosition.replace(/^(\d+)\s% (\d+)\s%$/, '$1% $2%');
+                    r.backgroundPosition = r.backgroundPosition.replace(/^%\s(\d+) %\s(\d+)$/, '$1% $2%');
+                }
+            });
+        },
     };
 
     constructor() {


### PR DESCRIPTION
#5656 already fixed reward images broken by localeString in newly-loaded mines, this fixes images in mines already open at the time of updating. This won't work for every locale but catches the most common breakage.

## How Has This Been Tested?
Confirmed this fixes the save with which which the bug was identified.