### PR TITLE
Fixed DefeatGymQuest using unlocked gyms

### DIFF
--- a/src/scripts/quests/questTypes/DefeatGymQuest.ts
+++ b/src/scripts/quests/questTypes/DefeatGymQuest.ts
@@ -29,8 +29,8 @@ class DefeatGymQuest extends Quest implements QuestInterface {
             maxRegion -= 1;
         }
         const region = SeededRand.intBetween(0, maxRegion);
-        // Only use cleared gyms.
-        const possibleGyms = GameConstants.RegionGyms[region].filter(gymTown => GymList[gymTown].flags.quest && GymList[gymTown].clears());
+        // Only use cleared and unlocked gyms.
+        const possibleGyms = GameConstants.RegionGyms[region].filter(gymTown => GymList[gymTown].flags.quest && GymList[gymTown].clears() && GymList[gymTown].isUnlocked());
         const gymTown = SeededRand.fromArray(possibleGyms);
         const reward = this.calcReward(amount, gymTown);
         return [amount, reward, gymTown];


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Fixed DefeatGymQuest using unlocked gyms.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
![QQ20241116-082611](https://github.com/user-attachments/assets/1d49e8dd-7d25-4edb-8360-a080b3e9ea22)
For example, the screenshot. DefeatGymQuest randomly generates a locked gym.

With the addition of the Alola questlines, cleared gyms may not necessarily be unlocked. So, we need to add the `isUnlocked()` judgment.



## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
See Screenshots.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![QQ20241116-083155](https://github.com/user-attachments/assets/31334e8a-7a5f-42c3-8193-c7b54370a066)



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
