### PR TITLE
Added icons for underground helpers to harmonize with other types of helpers.

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -235,6 +235,7 @@
                         <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
                             <h5 class="card-header">
                                 <knockout data-bind="text: $data.name">Name</knockout>
+                                <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                             </h5>
                             <div class="card-body p-0">
                                 <table class="table table-striped table-hover table-bordered table-sm m-0">
@@ -614,7 +615,10 @@
                     <div class="row p-0">
                         <!-- ko foreach: App.game.underground.helpers.hired() -->
                         <div class="col p-0">
-                            <div>
+                            <div class="footer-container">
+                                <knockout class="pr-2 pt-1" data-bind="foreach: App.game.underground.helpers.hired()">
+                                    <img class="pixelated mx-1" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                                </knockout>
                                 <span data-bind="text: $data.name"></span>
                                 <!-- ko ifnot: $data.selectedEnergyRestore < 0 -->
                                 <span data-bind="text: ` using ${GameConstants.camelCaseToString(GameConstants.EnergyRestoreSize[$data.selectedEnergyRestore])} (${player.itemList[GameConstants.EnergyRestoreSize[$data.selectedEnergyRestore]]().toLocaleString('en-US')})`"></span>

--- a/src/components/undergroundDisplay.html
+++ b/src/components/undergroundDisplay.html
@@ -89,7 +89,12 @@
             <!-- ko foreach: App.game.underground.helpers.hired() -->
             <div class="row">
                 <div class="col p-2">
-                    <div data-bind="text: $data.name"></div>
+                    <div class="row udergroundDisplay-HelperName-row">
+                        <knockout class="udergroundDisplay-HelperIcon pr-2 pt-1" data-bind="foreach: App.game.underground.helpers.hired()">
+                            <img class="pixelated mx-1" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                        </knockout>
+                        <div class="udergroundDisplay-HelperName" data-bind="text: $data.name"></div>
+                    </div>
                     <!-- ko ifnot: $data.selectedEnergyRestore < 0 -->
                     <div data-bind="text: `${GameConstants.camelCaseToString(GameConstants.EnergyRestoreSize[$data.selectedEnergyRestore])} (${player.itemList[GameConstants.EnergyRestoreSize[$data.selectedEnergyRestore]]().toLocaleString('en-US')})`"></div>
                     <!-- /ko -->

--- a/src/modules/underground/helper/UndergroundHelper.ts
+++ b/src/modules/underground/helper/UndergroundHelper.ts
@@ -28,8 +28,10 @@ import UndergroundToolType from '../tools/UndergroundToolType';
 import { UndergroundController } from '../UndergroundController';
 import Rand from '../../utilities/Rand';
 import UndergroundTool from '../tools/UndergroundTool';
+import SeededRand from '../../utilities/SeededRand';
 
 export class UndergroundHelper {
+    public trainerSprite = 0;
     private _experience: Observable<number> = ko.observable<number>(0);
     private _hired: Observable<boolean> = ko.observable<boolean>(false);
     private _timeSinceWork: Observable<number> = ko.observable<number>(0);
@@ -61,6 +63,7 @@ export class UndergroundHelper {
         private _favoriteMine: MineType,
         private _unlockRequirement?: Requirement | MultiRequirement | OneFromManyRequirement,
     ) {
+        this.trainerSprite = SeededRand.intBetween(0, 118);
     }
 
     public isUnlocked(): boolean {
@@ -158,7 +161,7 @@ export class UndergroundHelper {
         this._hired(true);
         this._timeSinceWork(0);
         Notifier.notify({
-            title: `[UNDERGROUND HELPER] ${this._name}`,
+            title: `[UNDERGROUND HELPER] <img src="assets/images/profile/trainer-${this.trainerSprite}.png" height="24px" class="pixelated"/> ${this._name}`,
             message: 'Thanks for hiring me,\nI won\'t let you down!',
             type: NotificationConstants.NotificationOption.success,
             timeout: 30 * SECOND,
@@ -170,9 +173,9 @@ export class UndergroundHelper {
         this._hired(false);
         this._timeSinceWork(0);
         Notifier.notify({
-            title: `[UNDERGROUND HELPER] ${this._name}`,
-            message: 'Happy to work for you! Let me know when you\'re hiring again!',
-            type: NotificationConstants.NotificationOption.success,
+            title: `[UNDERGROUND HELPER] <img src="assets/images/profile/trainer-${this.trainerSprite}.png" height="24px" class="pixelated"/> ${this._name}`,
+            message: 'Thanks for the work.\nLet me know when you\'re hiring again!',
+            type: NotificationConstants.NotificationOption.info,
             timeout: 30 * SECOND,
             setting: NotificationConstants.NotificationSetting.Underground.helper,
         });

--- a/src/styles/underground.less
+++ b/src/styles/underground.less
@@ -244,3 +244,22 @@
         --tool-color: #FFC300;
     }
 }
+
+.footer-container {
+    margin-bottom: 4px;
+}
+
+.udergroundDisplay-HelperName-row {
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.udergroundDisplay-HelperIcon {
+    margin-left: auto;
+    margin-top: -7px;
+}
+
+.udergroundDisplay-HelperName {
+    margin-right: auto;
+}


### PR DESCRIPTION
## Description

Added icons in the list of underground helpers and next to their names in the various underground displays and alert messages.


## Motivation and Context
I did this to harmonize with the rest of the helpers.


## How Has This Been Tested?
I browsed the menus to see if the images were loaded correctly. Hired and licensed all helpers to check alert messages.


## Screenshots (optional):
![helpers_before](https://github.com/user-attachments/assets/6b43e6f8-6c8e-4674-9664-51b082f76158)
![helpers_after](https://github.com/user-attachments/assets/ebebd006-49a1-45e0-b84f-a880e79aee0e)

## Types of changes
- UI improvement
