### PR TITLE
Map : Add an option to prior Pokérus to Shiny and add the state "Missing Pokérus And Missing Achievement"

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -94,11 +94,29 @@
                                 <!-- /ko -->
                                 <tr data-bind="template: { name: 'ColorChoiceSettingTemplate', data: Settings.getSetting('--uncaughtShinyPokemonAndMissingAchievement')}"></tr>
                                 <tr data-bind="template: { name: 'ColorChoiceSettingTemplate', data: Settings.getSetting('--uncaughtShinyPokemon')}"></tr>
-                                <tr data-bind="template: { name: 'ColorChoiceSettingTemplate', data: Settings.getSetting('--missingAchievement')}"></tr>
+                                <!-- ko if: Settings.getSetting('--missingResistantAndMissingAchievement').isUnlocked() -->
+                                <tr data-bind="template: { name: 'ColorChoiceSettingTemplate', data: Settings.getSetting('--missingResistantAndMissingAchievement')}"></tr>
+                                <!-- /ko -->
                                 <!-- ko if: Settings.getSetting('--missingResistant').isUnlocked() -->
                                 <tr data-bind="template: { name: 'ColorChoiceSettingTemplate', data: Settings.getSetting('--missingResistant')}"></tr>
                                 <!-- /ko -->
+                                <tr data-bind="template: { name: 'ColorChoiceSettingTemplate', data: Settings.getSetting('--missingAchievement')}"></tr>
                                 <tr data-bind="template: { name: 'ColorChoiceSettingTemplate', data: Settings.getSetting('--completed')}"></tr>
+                                <!-- ko if: Settings.getSetting('priorPokerus').isUnlocked() -->
+                                <tr data-bind="with: Settings.getSetting('priorPokerus')">
+                                    <td class="p-2">
+                                        <label class="m-0" data-bind="attr: { for: 'checkbox-' + $data.name }, text: `${$data.displayName}:`"></label>
+                                    </td>
+                                    <td class="p-2">
+                                        <input class="clickable" type="checkbox"
+                                            data-bind="checked: $data.observableValue(), attr: {name, id: 'checkbox-' + $data.name }"
+                                            onchange="(() => {
+                                                MapHelper.updatePriorPokerus(checked);
+                                                Settings.setSettingByName('priorPokerus', checked);
+                                            })()"/>
+                                    </td>
+                                </tr>
+                                <!-- /ko -->
                                 <tr>
                                     <td colspan="2">
                                         <button type="button" class="btn btn-primary" data-bind="click: () => {

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -170,9 +170,11 @@ Settings.add(new CssVariableSetting('uncaughtPokemon', 'Uncaught Pokemon', [], '
 Settings.add(new CssVariableSetting('uncaughtShadowPokemon', 'Uncaught Shadow Pokemon', [], '#a11131', new QuestLineStartedRequirement('Shadows in the Desert')));
 Settings.add(new CssVariableSetting('uncaughtShinyPokemonAndMissingAchievement', 'Uncaught Shiny Pokemon and Missing Achievement', [], '#c939fe'));
 Settings.add(new CssVariableSetting('uncaughtShinyPokemon', 'Uncaught Shiny Pokemon', [], '#ffee00'));
-Settings.add(new CssVariableSetting('missingAchievement', 'Missing Achievement', [], '#57e3ff'));
+Settings.add(new CssVariableSetting('missingResistantAndMissingAchievement', 'Missing Resistant and Missing Achievement', [], '#ff8000', new ClearDungeonRequirement(1, getDungeonIndex('Distortion World'))));
 Settings.add(new CssVariableSetting('missingResistant', 'Missing Resistant', [], '#ab1707', new ClearDungeonRequirement(1, getDungeonIndex('Distortion World'))));
+Settings.add(new CssVariableSetting('missingAchievement', 'Missing Achievement', [], '#57e3ff'));
 Settings.add(new CssVariableSetting('completed', 'Completed Location', [], '#ffffff'));
+Settings.add(new BooleanSetting('priorPokerus', 'Prior Pokérus to Shiny Status', false, new ClearDungeonRequirement(1, getDungeonIndex('Distortion World'))));
 
 // Other settings
 Settings.add(new BooleanSetting('disableAutoDownloadBackupSaveOnUpdate', 'Disable automatic backup save downloading when game updates', false));

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -110,6 +110,7 @@ class Game implements TmpGameType {
     }
 
     initialize() {
+        MapHelper.initialize();
         AchievementHandler.initialize(this.multiplier, this.challenges);
         FarmController.initialize();
         EffectEngineRunner.initialize(this.multiplier, GameHelper.enumStrings(GameConstants.BattleItemType).map((name) => ItemList[name]));

--- a/src/scripts/safari/SafariTownContent.ts
+++ b/src/scripts/safari/SafariTownContent.ts
@@ -31,6 +31,6 @@ class SafariTownContent extends TownContent {
                 pokemonStatusArray.push(areaStatus.missingResistant);
             }
         });
-        return Math.min(...pokemonStatusArray);
+        return MapHelper.getImportantState(pokemonStatusArray);
     }
 }

--- a/src/scripts/shop/BerryMasterShop.ts
+++ b/src/scripts/shop/BerryMasterShop.ts
@@ -36,7 +36,7 @@ class BerryMasterShop extends Shop {
                 itemStatusArray.push(areaStatus.missingResistant);
             }
         }
-        return Math.min(...itemStatusArray);
+        return MapHelper.getImportantState(itemStatusArray);
     }
 
 }

--- a/src/scripts/shop/GemMasterShop.ts
+++ b/src/scripts/shop/GemMasterShop.ts
@@ -34,6 +34,6 @@ class GemMasterShop extends Shop {
                 itemStatusArray.push(areaStatus.missingResistant);
             }
         }
-        return Math.min(...itemStatusArray);
+        return MapHelper.getImportantState(itemStatusArray);
     }
 }

--- a/src/scripts/shop/GenericTraderShop.ts
+++ b/src/scripts/shop/GenericTraderShop.ts
@@ -43,7 +43,7 @@ class GenericTraderShop extends Shop {
             }
         }
 
-        return Math.min(...itemStatusArray);
+        return MapHelper.getImportantState(itemStatusArray);
     }
 
     public isVisible(): boolean {

--- a/src/scripts/shop/ShardTraderShop.ts
+++ b/src/scripts/shop/ShardTraderShop.ts
@@ -34,7 +34,7 @@ class ShardTraderShop extends Shop {
                 itemStatusArray.push(areaStatus.missingResistant);
             }
         }
-        return Math.min(...itemStatusArray);
+        return MapHelper.getImportantState(itemStatusArray);
     }
 
     public isVisible(): boolean {

--- a/src/scripts/shop/Shop.ts
+++ b/src/scripts/shop/Shop.ts
@@ -41,7 +41,7 @@ class Shop extends TownContent {
                 }
             }
         });
-        return Math.min(...itemStatusArray);
+        return MapHelper.getImportantState(itemStatusArray);
     }
 
     get displayName() {

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -26,11 +26,11 @@ const priorityStatus = new Map([
     [areaStatus.missingResistantAndMissingAchievement, 7],
     [areaStatus.missingResistant, 8],
     [areaStatus.missingAchievement, 9],
-    [areaStatus.completed, 10]
+    [areaStatus.completed, 10],
 ]);
 
 class MapHelper {
-    
+
     public static initialize() {
         this.updatePriorPokerus(Settings.getSetting('priorPokerus').observableValue());
     }
@@ -40,13 +40,13 @@ class MapHelper {
             priorityStatus.set(status, newPriority);
         }
     }
-    
+
     public static getImportantState(states) {
-        return states.reduce((lowest, current) => 
+        return states.reduce((lowest, current) =>
             priorityStatus.get(current) < priorityStatus.get(lowest) ? current : lowest
         );
     }
-    
+
     public static updatePriorPokerus(priorPokerus) {
         if (priorPokerus) {
             this.updatePriority(areaStatus.missingResistantAndMissingAchievement, 5);

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -588,14 +588,18 @@ td.tight {
 
 .bg-uncaughtShinyPokemonAndMissingAchievement {
     background-color: var(--uncaughtShinyPokemonAndMissingAchievement);
-  }
-
-.bg-missingAchievement {
-    background-color: var(--missingAchievement);
 }
 
 .bg-missingResistant {
-    background-color: var(--missingResistant);
+  background-color: var(--missingResistant);
+}
+
+.bg-missingResistantAndMissingAchievement {
+    background-color: var(--missingResistantAndMissingAchievement);
+}
+
+.bg-missingAchievement {
+    background-color: var(--missingAchievement);
 }
 
 .bg-completed {

--- a/src/styles/map.less
+++ b/src/styles/map.less
@@ -45,13 +45,18 @@
     opacity: 0.6;
   }
 
-  .missingAchievement {
-    fill: var(--missingAchievement);
+  .missingResistant {
+    fill: var(--missingResistant);
     opacity: 0.6;
   }
 
-  .missingResistant {
-    fill: var(--missingResistant);
+  .missingResistantAndMissingAchievement {
+    fill: var(--missingResistantAndMissingAchievement);
+    opacity: 0.6;
+  }
+
+  .missingAchievement {
+    fill: var(--missingAchievement);
     opacity: 0.6;
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

Modification of the states (css) of a location. Added the state 'Missing Pokérus and Missing Achievement' to the states. The important point of this PR is the fact of being able to prioritize Pokérus over Shiny. By default, if you wanted to see the 'pokérus' state of a location, you had to first capture all the shinys of the location in question. Here, you can switch between the two: you can stay by default or see the pokérus first and only show the shiny once the pokérus is completed.

For it to work correctly and for there to be a real duality between Pokérus and Shiny, I had to add the state 'Missing Pokérus and Missing Achievement' to have a perfect balance.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

This Shiny/Pokérus duality was inspired by my frustration at having to capture all the shinys in a location before being able to see the Pokérus state. With this option, I no longer have to capture all the shinys (which could take a long time) before being able to tackle the pokérus.

I had confirmation from @EatPant2nd that some players are requesting it like me, so I programmed it to cover this problem.

Thanks to them for helping me! Little info: they are my admiration in the game, without them, I will not move forward, so thank you Pant!

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I tested with different statuses of roads/dungeons/cities/safaris/etc... to check that everything is fine in both cases.

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://github.com/user-attachments/assets/d8590df2-e2b4-4af9-9f2c-f059ee87845d)
![image](https://github.com/user-attachments/assets/7fd95be3-0e61-4e40-a6c9-352f900aefa0)

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement : possibility of targeting the pokérus before the shinies
