### PR TITLE
Held Item UI updates

### DIFF
--- a/src/components/heldItemModal.html
+++ b/src/components/heldItemModal.html
@@ -57,7 +57,7 @@
                   <div class="small px-1 pb-2 my-1" style="overflow-x: hidden;">
                     <!-- Region and Type selects -->
                     <div class="form-row px-1">
-                        <div class="form-group col-6 m-0 px-1 py-0">
+                        <div class="form-group col-4 m-0 px-1 py-0">
                             <!-- ko let: { heldItemRegionFilter: Settings.getSetting('heldItemRegionFilter') } -->
                             <label class="mb-1" for="held-item-region-filter">Region</label>
                             <select id="held-item-region-filter" autocomplete="off" class="custom-select custom-select-sm"
@@ -68,7 +68,7 @@
                             </select>
                             <!-- /ko -->
                         </div>
-                        <div class="form-group col-6 m-0 px-1 py-0">
+                        <div class="form-group col-4 m-0 px-1 py-0">
                             <!-- ko let: { heldItemTypeFilter: Settings.getSetting('heldItemTypeFilter') } -->
                             <label class="mb-1" for="held-item-type-filter">Type</label>
                             <select id="held-item-type-filter" name="heldItemTypeFilter" autocomplete="off" class="custom-select custom-select-sm"
@@ -79,17 +79,34 @@
                             </select>
                             <!-- /ko -->
                         </div>
+                        <div class="form-group col-4 m-0 px-1 py-0">
+                            <!-- ko let: { heldItemType2Filter: Settings.getSetting('heldItemType2Filter') } -->
+                            <label class="mb-1" for="held-item-type2-filter">Type 2</label>
+                            <select id="held-item-type2-filter" name="heldItemType2Filter" autocomplete="off" class="custom-select custom-select-sm"
+                                data-bind="options: heldItemType2Filter.options,
+                                    optionsValue: 'value',
+                                    optionsText: 'text',
+                                    value: heldItemType2Filter.observableValue">
+                            </select>
+                            <!-- /ko -->
+                        </div>
                     </div>
                     <!-- Hide/Show checkboxes -->
-                    <div class="form-check align-middle mt-1">
-                        <input type="checkbox" id="hide-holding-item-pokemon" class="form-check-input"
-                            data-bind="checked: Settings.getSetting('heldItemHideHoldingPokemon').observableValue" />
-                        <label for="hide-holding-item-pokemon" class="form-check-label">Hide Pokémon holding an item</label>
-                    </div>
-                    <div class="form-check align-middle mt-1">
-                        <input type="checkbox" id="show-this-item-pokemon" class="form-check-input"
-                            data-bind="checked: Settings.getSetting('heldItemHideHoldingThisItem').observableValue" />
-                        <label for="show-this-item-pokemon" class="form-check-label">Hide Pokémon holding <u>this</u> item</label>
+                    <div class="form-row mt-2">
+                        <div class="col-12 col-sm-6 text-center">
+                            <div class="form-check align-middle">
+                                <input type="checkbox" id="hide-holding-item-pokemon" class="form-check-input"
+                                    data-bind="checked: Settings.getSetting('heldItemHideHoldingPokemon').observableValue" />
+                                <label for="hide-holding-item-pokemon" class="form-check-label">Hide Pokémon holding an item</label>
+                            </div>
+                        </div>
+                        <div class="col-12 col-sm-6 text-center">
+                            <div class="form-check align-middle">
+                                <input type="checkbox" id="show-this-item-pokemon" class="form-check-input"
+                                    data-bind="checked: Settings.getSetting('heldItemHideHoldingThisItem').observableValue" />
+                                <label for="show-this-item-pokemon" class="form-check-label">Hide Pokémon holding <u>this</u> item</label>
+                            </div>
+                        </div>
                     </div>
                   </div>
                 </div>
@@ -102,14 +119,24 @@
                       </tr>
                   </thead>
                   <tbody data-bind="foreach: lazyLoad('lazyHeldItemList', $element, PartyController.getHeldItemSortedList, { reset: () => (DisplayObservables.modalState.heldItemModal === 'hidden') }), childrenComplete: () => { lazyLoadCallback('lazyHeldItemList'); }">
-                    <tr class="clickable" data-bind="click: () => $data.giveHeldItem(HeldItem.heldItemSelected())">
-                      <td class="text-left align-middle"><knockout data-bind="text: $data.displayName"></knockout><sup data-bind="visible: $data.shiny">✨</sup></td>
-                      <td class="text-left tight align-middle" data-bind="if: $data.heldItem(),
-                        tooltip: { title: $data.heldItem()?.description ?? '', trigger: 'hover', placement: 'bottom' }">
-                            <img width="20" data-bind="attr: { src: $data.heldItem().image }" />
-                            <knockout data-bind="text: $data.heldItem().displayName"></knockout>
+                      <tr class="clickable" data-bind="click: () => $data.giveHeldItem(HeldItem.heldItemSelected())">
+                        <td class="text-left">
+                          <knockout data-bind="text: $data.displayName"></knockout>
+                          <knockout data-bind="visible: $data.shiny">✨</knockout>
+                          <img width="28" data-bind="visible: $data.pokerus, attr: { src: `assets/images/breeding/pokerus/${GameConstants.Pokerus[$data.pokerus]}.png`}" />
+                          <img height="16" class="ml-1" src="assets/images/status/shadow.svg" data-bind="visible: $data.shadow === GameConstants.ShadowStatus.Shadow" />
+                          <img height="16" class="ml-1" src="assets/images/status/purified.svg" data-bind="visible: $data.shadow === GameConstants.ShadowStatus.Purified" />
                         </td>
-                    </tr>
+                        <td class="text-left tight align-middle" data-bind="if: $data.heldItem(),
+                          tooltip: {
+                            title: $data.heldItem()?.description ?? '',
+                            trigger: 'hover',
+                            placement: 'bottom'
+                        }">
+                          <img width="20" data-bind="attr: { src: $data.heldItem().image }" />
+                          <knockout data-bind="text: $data.heldItem().displayName"></knockout>
+                        </td>
+                      </tr>
                   </tbody>
                 </table>
             </div>

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -270,7 +270,16 @@ Settings.add(new BooleanSetting('heldItemSortDirection', 'reverse', false, undef
 Settings.add(new Setting<string>('heldItemDropdownPokemonOrItem', 'Pokémon or Item', [new SettingOption('Pokémon', 'pokemon'), new SettingOption('Item', 'item')], 'pokemon', undefined, false));
 Settings.add(new SearchSetting('heldItemSearchFilter', 'Search', '', undefined, false));
 Settings.add(new Setting<number>('heldItemRegionFilter', 'Region', [new SettingOption('All', -2), ...regionOptionsNoneLast], -2, undefined, false));
-Settings.add(new Setting<number>('heldItemTypeFilter', 'Type', [new SettingOption('All', -2), ...Settings.enumToNumberSettingOptionArray(PokemonType, (t) => t !== 'None')], -2, undefined, false));
+Settings.add(new Setting<number>('heldItemTypeFilter', 'Type', [
+    new SettingOption('All', -2),
+    ...Settings.enumToNumberSettingOptionArray(PokemonType, (t) => t !== 'None'),
+    new SettingOption('None', PokemonType.None),
+], -2, undefined, false));
+Settings.add(new Setting<number>('heldItemType2Filter', 'Type 2', [
+    new SettingOption('All', -2),
+    ...Settings.enumToNumberSettingOptionArray(PokemonType, (t) => t !== 'None'),
+    new SettingOption('None', PokemonType.None),
+], -2, undefined, false));
 Settings.add(new BooleanSetting('heldItemHideHoldingPokemon', 'Hide Pokémon holding an item', false, undefined, false));
 Settings.add(new BooleanSetting('heldItemHideHoldingThisItem', 'Hide Pokémon holding this item', false, undefined, false));
 

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -215,10 +215,20 @@ class PartyController {
                     return false;
                 }
             }
-            const type = Settings.getSetting('heldItemTypeFilter').observableValue();
-            if (type > -2 && !pokemonMap[pokemon.name].type.includes(type)) {
-                return false;
+            const type1 = Settings.getSetting('heldItemTypeFilter').observableValue();
+            const type2 = Settings.getSetting('heldItemType2Filter').observableValue();
+            if (type1 !== -2 || type2 !== -2) {
+                const { type: types } = pokemonMap[pokemon.name];
+                if ([type1, type2].includes(PokemonType.None)) {
+                    const type = (type1 == PokemonType.None) ? type2 : type1;
+                    if (!BreedingController.isPureType(pokemon, type === -2 ? null : type)) {
+                        return false;
+                    }
+                } else if ((type1 !== -2 && !types.includes(type1)) || (type2 !== -2 && !types.includes(type2))) {
+                    return false;
+                }
             }
+
             if (Settings.getSetting('heldItemHideHoldingPokemon').observableValue() && pokemon.heldItem()) {
                 return false;
             }


### PR DESCRIPTION
## Description
- Added a second Type filter
- Added "None" pokemon type to the two type filters
- Added pokerus & shadow/purified indicators next to pokemon name alongside the shiny indicator

Closes #5679, #5668 

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/1db40d07-84b0-44b2-90aa-7ac2d4d20619)

## Types of changes
- UI improvement
