### PR TITLE
Remove unused Pokeballs defaults

### DIFF
--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -5,14 +5,6 @@ class Pokeballs implements Feature {
     name = 'Pokeballs';
     saveKey = 'pokeballs';
 
-    defaults = {
-        alreadyCaughtSelection: GameConstants.Pokeball.None,
-        alreadyCaughtContagiousSelection: GameConstants.Pokeball.None,
-        alreadyCaughtShinySelection: GameConstants.Pokeball.Pokeball,
-        notCaughtSelection: GameConstants.Pokeball.Pokeball,
-        notCaughtShinySelection: GameConstants.Pokeball.Pokeball,
-    };
-
     public pokeballs: Pokeball[];
 
     public selectedSelection: KnockoutObservable<KnockoutObservable<GameConstants.Pokeball>>;

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -5,6 +5,8 @@ class Pokeballs implements Feature {
     name = 'Pokeballs';
     saveKey = 'pokeballs';
 
+    defaults = {};
+
     public pokeballs: Pokeball[];
 
     public selectedSelection: KnockoutObservable<KnockoutObservable<GameConstants.Pokeball>>;


### PR DESCRIPTION
Removed `Pokeballs.ts` defaults that were previously used for filter defaults before that was spun off into `PokeballFilters`.

## Motivation and Context
Reducing code clutter.