### PR TITLE
Allows the click on the chisel and hammer in the reduced underground module.

### DIFF
--- a/src/components/undergroundDisplay.html
+++ b/src/components/undergroundDisplay.html
@@ -35,9 +35,9 @@
                 <!-- ko foreach: [UndergroundToolType.Chisel, UndergroundToolType.Hammer, UndergroundToolType.Bomb, UndergroundToolType.Survey] -->
                 <!-- ko let: { tool: App.game.underground.tools.getTool($data) } -->
                 <div class="tool-ui" style="flex: 1; min-width: 50px;" data-bind="class: `${UndergroundToolType[$data]}-tool-ui`">
-                    <div class="p-0 mb-1 d-flex justify-content-center" data-bind="css: { 'clickable': [UndergroundToolType.Bomb, UndergroundToolType.Survey].includes($data) && Settings.getSetting('enableUndergroundModuleMineControls').observableValue() }, click: () => {
-                        if ([UndergroundToolType.Bomb, UndergroundToolType.Survey].includes($data) && Settings.getSetting('enableUndergroundModuleMineControls').observableValue()) {
-                            App.game.underground.tools.useTool($data, 0, 0);
+                    <div class="p-0 mb-1 d-flex justify-content-center" data-bind="css: { 'clickable': [UndergroundToolType.Chisel, UndergroundToolType.Hammer, UndergroundToolType.Bomb, UndergroundToolType.Survey].includes($data) && Settings.getSetting('enableUndergroundModuleMineControls').observableValue() }, click: () => {
+                        if ([UndergroundToolType.Chisel, UndergroundToolType.Hammer, UndergroundToolType.Bomb, UndergroundToolType.Survey].includes($data) && Settings.getSetting('enableUndergroundModuleMineControls').observableValue()) {
+                            App.game.underground.tools.useTool($data, null, null, 'Small_module');
                         }
                     }">
                         <div style="position: relative; width: 100%; max-width: 50px; aspect-ratio: 1; padding: 2px; border-radius: 10px;" data-bind="style: { background: `conic-gradient(var(--tool-color) ${tool.durability.toLocaleString('en-US', { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })}, transparent 0)`, opacity: tool.durability < tool.durabilityPerUse ? 0.3 : 1 }">

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -2705,3 +2705,8 @@ export enum ContestStyle {
     Clever,
     Tough,
 }
+
+export enum UndergroundViews {
+    Small = 'Small_module',
+    Large = 'Large_module',
+}

--- a/src/modules/underground/UndergroundController.ts
+++ b/src/modules/underground/UndergroundController.ts
@@ -22,6 +22,7 @@ import {
     SURVEY_RANGE_REDUCTION_LEVELS,
     UNDERGROUND_EXPERIENCE_CLEAR_LAYER,
     UNDERGROUND_EXPERIENCE_DIG_UP_ITEM,
+    UndergroundViews,
 } from '../GameConstants';
 import { UndergroundHelper } from './helper/UndergroundHelper';
 import NotificationOption from '../notifications/NotificationOption';
@@ -176,7 +177,7 @@ export class UndergroundController {
         this.lastMineClick = now;
 
         const coordinates = App.game.underground.mine.getCoordinateForGridIndex(index);
-        App.game.underground.tools.useTool(App.game.underground.tools.selectedToolType, coordinates.x, coordinates.y);
+        App.game.underground.tools.useTool(App.game.underground.tools.selectedToolType, coordinates.x, coordinates.y, UndergroundViews.Large);
     }
 
     public static handleCoordinatesMined(coordinates: Coordinate[], helper: UndergroundHelper = undefined) {

--- a/src/modules/underground/tools/UndergroundTools.ts
+++ b/src/modules/underground/tools/UndergroundTools.ts
@@ -5,7 +5,7 @@ import { UndergroundController } from '../UndergroundController';
 import { Coordinate } from '../mine/Mine';
 import Rand from '../../utilities/Rand';
 import OakItemType from '../../enums/OakItemType';
-import { clipNumber } from '../../GameConstants';
+import { clipNumber, UndergroundViews } from '../../GameConstants';
 import GameHelper from '../../GameHelper';
 
 export default class UndergroundTools {
@@ -100,8 +100,22 @@ export default class UndergroundTools {
         return Rand.fromArray(this.tools.filter(value => value.id !== UndergroundToolType.Survey));
     }
 
-    public useTool(toolType: UndergroundToolType, x: number, y: number): void {
+    public randomIntFromInterval(min: number, max: number) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    public useTool(toolType: UndergroundToolType, x: number | null, y: number | null, from: UndergroundViews): void {
         const tool = this.getTool(toolType);
+
+        if (from === UndergroundViews.Small) {
+            if (tool.id === 0 || tool.id === 1) {
+                x = this.randomIntFromInterval(0, 24);
+                y = this.randomIntFromInterval(0, 11);
+            } else if (tool.id === 2 || tool.id === 3) {
+                x = 0;
+                y = 0;
+            }
+        }
 
         if (!tool ||
             !App.game.underground.mine ||
@@ -117,6 +131,8 @@ export default class UndergroundTools {
                 GameHelper.incrementObservable(App.game.statistics.undergroundToolsUsed[tool.id]);
                 UndergroundController.handleCoordinatesMined(coordinatesMined);
                 tool.reduceDurabilityByUse();
+            } else if (!success && from === UndergroundViews.Small) {
+                this.useTool(toolType, null, null, UndergroundViews.Small);
             }
         }
     }


### PR DESCRIPTION
## Description
Allows you to click on the chisel  and hammer in the reduced underground module.

Chisel and hammer dig coordinates are randomly generated by clicking on the reduced module. If the excavation zone has already been explored, the function is restarted until excavation is possible.


## Motivation and Context
I found it strange to be able to use the bomb and the clue but not the other 2 tools. Plus, it's more practical to simply click from the reduced module than to open the large one.


## How Has This Been Tested?
I've used the chisel and hammer from the reduced module to completely empty several mines without any problems.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
- New feature
