### PR TITLE
Modulify Battle.ts and related classes

### DIFF
--- a/src/modules/TemporaryScriptTypes.ts
+++ b/src/modules/TemporaryScriptTypes.ts
@@ -29,6 +29,11 @@ import type { EvoData } from './pokemons/evolutions/Base';
 import type { PokemonNameType } from './pokemons/PokemonNameType';
 import type CaughtStatus from './enums/CaughtStatus';
 import type { SpecialEventTitleType } from './specialEvents/SpecialEventTitleType';
+import type PokemonType from './enums/PokemonType';
+import type WeatherType from './weather/WeatherType';
+import type { MultiplierDecreaser } from './items/types';
+import type BagItem from './interfaces/BagItem';
+import type BattlePokemon from './battles/BattlePokemon';
 
 /*
     These types are only temporary while we are converting things to modules. As things are converted, 
@@ -83,7 +88,6 @@ import type { SpecialEventTitleType } from './specialEvents/SpecialEventTitleTyp
 export type TmpUpdateType = any;
 export type TmpBreedingType = any;
 export type TmpPokeballsType = any;
-export type TmpPartyType = any;
 export type TmpGemsType = any;
 export type TmpFarmingType = any;
 export type TmpRedeemableCodesType = any;
@@ -97,8 +101,7 @@ export type TmpPurifyChamberType = any;
 export type TmpWeatherAppType = any;
 export type TmpZMovesType = any;
 export type TmpPokemonContestType = any;
-export type TmpBattlePokemonType = any;
-export type TmpMultiplierDecreaserType = any;
+export type TmpHeldItemType = any;
 
 export type TmpGameType = {
     gameState: GameConstants.GameState;
@@ -194,29 +197,10 @@ export type TmpPlayerType = {
     itemMultipliers: Record<string, number>;
     gainItem: (itemName: string, amount: number) => void;
     loseItem: (itemName: string, amount: number) => void;
-    lowerItemMultipliers: (multiplierDecreaser: TmpMultiplierDecreaserType, amount?: number) => void;
+    lowerItemMultipliers: (multiplierDecreaser: MultiplierDecreaser, amount?: number) => void;
     hasMegaStone: (megaStone: GameConstants.MegaStoneType) => boolean;
     gainMegaStone: (megaStone: GameConstants.MegaStoneType, notify?: boolean) => void;
     toJSON: () => Record<string, any>;
-};
-
-export type TmpBattleType = {
-    enemyPokemon: KnockoutObservable<TmpBattlePokemonType | null>;
-    counter: number;
-    catching: KnockoutObservable<boolean>;
-    catchRateActual: KnockoutObservable<number>;
-    pokeball: KnockoutObservable<GameConstants.Pokeball>;
-    lastPokemonAttack: number;
-    lastClickAttack: number;
-    route: number;
-    tick: () => void;
-    pokemonAttack: () => void;
-    clickAttack: () => void;
-    defeatPokemon: () => void;
-    generateNewEnemy: () => void;
-    catchPokemon: (enemyPokemon: TmpBattlePokemonType, route: number, region: GameConstants.Region) => void;
-    gainItem: () => void;
-    pokemonAttackTooltip: KnockoutComputed<string>;
 };
 
 export type TmpMapHelperType = {
@@ -289,13 +273,90 @@ export type TmpPokemonLocationsType = {
 };
 
 export type TmpPokemonFactoryType = {
+    generateWildPokemon(route: number, region: GameConstants.Region, subRegion: SubRegion): BattlePokemon;
+    routeDungeonTokens(route: number, region: GameConstants.Region): number;
     generateShiny(chance: number, skipBonus?: boolean): boolean;
     generateGenderById(id: number): GameConstants.BattlePokemonGender;
+};
+
+export type TmpPartyPokemonType = {
+    id: number;
+    name: PokemonNameType;
+    evolutions: EvoData[],
+    baseAttack: number,
+    eggCycles: number,
+    level: number,
+    attack: number,
+    attackBonusAmount: number,
+    attackBonusPercent: number,
+    breeding: boolean,
+    pokerus: GameConstants.Pokerus,
+    effortPoints: number,
+    shiny: boolean,
+    category: Array<number>,
+    nickname: string,
+    displayName: string,
+    shadow: GameConstants.ShadowStatus,
+    showShadowImage: boolean,
+    vitaminsUsed: Record<GameConstants.VitaminType, KnockoutObservable<number>>;
+    heldItem: KnockoutObservable<TmpHeldItemType>;
+    defaultFemaleSprite: KnockoutObservable<boolean>;
+    hideShinyImage: KnockoutObservable<boolean>;
+    canUseStone(stoneType: GameConstants.StoneType): boolean;
+    addCategory(id: number): void;
+    removeCategory(id: number): void;
+    resetCategory(): void;
+};
+
+export type TmpPartyType = {
+    caughtPokemon: ReadonlyArray<TmpPartyPokemonType>;
+    activePartyPokemon: ReadonlyArray<TmpPartyPokemonType>;
+    gainPokemonByName: (name: PokemonNameType, shiny?: boolean, suppressNewCatchNotification?: boolean, gender?: GameConstants.BattlePokemonGender, shadow?: GameConstants.ShadowStatus) => void;
+    gainPokemonById: (id: number, shiny?: boolean, suppressNewCatchNotification?: boolean, gender?: GameConstants.BattlePokemonGender, shadow?: GameConstants.ShadowStatus) => void;
+    gainExp: (exp: number, level?: number, trainer?: boolean) => void;
+    calculatePokemonAttack: (
+        type1: PokemonType,
+        type2: PokemonType,
+        ignoreRegionMultiplier?: boolean,
+        region?: GameConstants.Region,
+        includeBreeding?: boolean,
+        useBaseAttack?: boolean,
+        overrideWeather?: WeatherType,
+        ignoreLevel?: boolean,
+        includeTempBonuses?: boolean,
+        subregion?: GameConstants.SubRegions
+    ) => number;
+    calculateOnePokemonAttack: (
+        pokemon: TmpPartyPokemonType,
+        type1: PokemonType,
+        type2: PokemonType,
+        region?: GameConstants.Region,
+        ignoreRegionMultiplier?: boolean,
+        includeBreeding?: boolean,
+        useBaseAttack?: boolean,
+        overrideWeather?: WeatherType,
+        ignoreLevel?: boolean,
+        includeTempBonuses?: boolean,
+    ) => number;
+    getRegionAttackMultiplier: (highestRegion?: GameConstants.Region) => number
+    calculateEffortPoints: (pokemon: TmpPartyPokemonType, shiny: boolean, shadow: GameConstants.ShadowStatus, number: number, ignore?: boolean) => number;
+    getPokemon: (id: number) => TmpPartyPokemonType | undefined;
+    getPokemonByName: (name: PokemonNameType) => TmpPartyPokemonType | undefined;
+    partyPokemonActiveInSubRegion: (region: GameConstants.Region, subregion: GameConstants.SubRegions) => Array<TmpPartyPokemonType>;
+    alreadyCaughtPokemonByName: (name: PokemonNameType, shiny?: boolean) => boolean;
+    alreadyCaughtPokemon: (id: number, shiny?: boolean, shadow?: boolean, purified?: boolean) => boolean;
+    calculateClickAttack: (useItem?: boolean) => number;
 };
 
 export type TmpPartyControllerType = {
     getCaughtStatusByName: (name: PokemonNameType) => CaughtStatus;
     getPokerusStatusByName: (name: PokemonNameType) => GameConstants.Pokerus;
+};
+
+export type TmpBagHandlerType = {
+    displayName(item: BagItem): string;
+    image(item: BagItem): string;
+    gainItem(item: BagItem, amount?: number): void;
 };
 
 export type TmpSpecialEventsType = {

--- a/src/modules/battles/Battle.ts
+++ b/src/modules/battles/Battle.ts
@@ -1,16 +1,27 @@
-/// <reference path="../declarations/TemporaryScriptTypes.d.ts" />
-///<reference path="pokemons/PokemonFactory.ts"/>
-/// <reference path="../declarations/GameHelper.d.ts" />
+import * as GameConstants from '../GameConstants';
+import GameHelper from '../GameHelper';
+import * as PokemonHelper from '../pokemons/PokemonHelper';
+import { pokemonMap } from '../pokemons/PokemonList';
+import PokemonType from '../enums/PokemonType';
+import { createLogContent } from '../logbook/helpers';
+import { LogBookTypes } from '../logbook/LogBookTypes';
+import { MultiplierDecreaser } from '../items/types';
+import Routes from '../routes/Routes';
+import OakItemType from '../enums/OakItemType';
+import Rand from '../utilities/Rand';
+import Amount from '../wallet/Amount';
+import type BattlePokemon from './BattlePokemon';
+import type { Observable as KnockoutObservable, PureComputed } from 'knockout';
 
 /**
  * Handles all logic related to battling
  */
-class Battle {
-    static enemyPokemon: KnockoutObservable<BattlePokemon> = ko.observable(null);
+export default class Battle {
+    static enemyPokemon: KnockoutObservable<BattlePokemon | null> = ko.observable(null);
 
     static counter = 0;
     static catching: KnockoutObservable<boolean> = ko.observable(false);
-    static catchRateActual: KnockoutObservable<number> = ko.observable(null);
+    static catchRateActual: KnockoutObservable<number | null> = ko.observable(0);
     static pokeball: KnockoutObservable<GameConstants.Pokeball> = ko.observable(GameConstants.Pokeball.Pokeball);
     static lastPokemonAttack = Date.now();
     static lastClickAttack = Date.now();
@@ -88,7 +99,7 @@ class Battle {
                         this.generateNewEnemy();
                     }
                 },
-                App.game.pokeballs.calculateCatchTime(pokeBall)
+                App.game.pokeballs.calculateCatchTime(pokeBall),
             )
             ;
 
@@ -120,7 +131,7 @@ class Battle {
                     : createLogContent.encounterShiny({
                         location: Routes.getRoute(player.region, player.route).routeName,
                         pokemon: enemyPokemon.name,
-                    })
+                    }),
             );
         } else if (!App.game.party.alreadyCaughtPokemon(enemyPokemon.id) && enemyPokemon.health()) {
             App.game.logbook.newLog(
@@ -128,7 +139,7 @@ class Battle {
                 createLogContent.encounterWild({
                     location: Routes.getRoute(player.region, player.route).routeName,
                     pokemon: enemyPokemon.name,
-                })
+                }),
             );
         }
     }
@@ -159,12 +170,12 @@ class Battle {
                 LogBookTypes.ESCAPED,
                 App.game.party.alreadyCaughtPokemon(enemyPokemon.id, true)
                     ? createLogContent.escapedShinyDupe({ pokemon: enemyPokemon.name })
-                    : createLogContent.escapedShiny({ pokemon: enemyPokemon.name })
+                    : createLogContent.escapedShiny({ pokemon: enemyPokemon.name }),
             );
         } else if (!App.game.party.alreadyCaughtPokemon(enemyPokemon.id)) { // Failed to catch, Uncaught
             App.game.logbook.newLog(
                 LogBookTypes.ESCAPED,
-                createLogContent.escapedWild({ pokemon: enemyPokemon.name})
+                createLogContent.escapedWild({ pokemon: enemyPokemon.name }),
             );
         }
         this.catching(false);
@@ -215,15 +226,14 @@ class Battle {
         }
     }
 
-    public static pokemonAttackTooltip: KnockoutComputed<string> = ko.pureComputed(() => {
+    // eslint-disable-next-line @typescript-eslint/member-ordering
+    public static pokemonAttackTooltip: PureComputed<string> = ko.pureComputed(() => {
         if (Battle.enemyPokemon()) {
             const pokemonAttack = App.game.party.calculatePokemonAttack(Battle.enemyPokemon().type1, Battle.enemyPokemon().type2);
             return `${pokemonAttack.toLocaleString('en-US')} against ${pokemonMap[Battle.enemyPokemon().name].type.map(t => PokemonType[t]).join('&nbsp;/&nbsp;')}`;
         } else {
             return '';
         }
-    }).extend({rateLimit: 1000});
+    }).extend({ rateLimit: 1000 });
 
 }
-
-Battle satisfies TmpBattleType;

--- a/src/modules/battles/BattlePokemon.ts
+++ b/src/modules/battles/BattlePokemon.ts
@@ -1,11 +1,24 @@
-/// <reference path="../../declarations/GameHelper.d.ts" />
+import * as GameConstants from '../GameConstants';
+import GameHelper from '../GameHelper';
+import * as PokemonHelper from '../pokemons/PokemonHelper';
+import { createLogContent } from '../logbook/helpers';
+import { LogBookTypes } from '../logbook/LogBookTypes';
+import Notifier from '../notifications/Notifier';
+import NotificationConstants from '../notifications/NotificationConstants';
+import PokemonType from '../enums/PokemonType';
+import Amount from '../wallet/Amount';
+import type { PokemonNameType } from '../pokemons/PokemonNameType';
+import type EnemyPokemonInterface from '../pokemons/EnemyPokemonInterface';
+import type EncounterType from '../enums/EncounterType';
+import type BagItem from '../interfaces/BagItem';
+import type { Observable as KnockoutObservable, Computed as KnockoutComputed } from 'knockout';
 
-class BattlePokemon implements EnemyPokemonInterface {
+export default class BattlePokemon implements EnemyPokemonInterface {
 
     health: KnockoutObservable<number>;
     maxHealth: KnockoutObservable<number>;
     healthPercentage: KnockoutObservable<number>;
-    _displayName: KnockoutObservable<string>;
+    _displayName: KnockoutComputed<string>;
 
     /**
      * In case you want to manually create a Pokémon instead of generating it from the route number
@@ -24,6 +37,7 @@ class BattlePokemon implements EnemyPokemonInterface {
      * @param shadow is shadow or purified
      */
 
+    /* eslint-disable @typescript-eslint/default-param-last */
     constructor(
         public name: PokemonNameType,
         public id: number,
@@ -40,13 +54,14 @@ class BattlePokemon implements EnemyPokemonInterface {
         public shadow: GameConstants.ShadowStatus,
         public encounterType: EncounterType,
         public heldItem?: BagItem,
-        public ep: number = GameConstants.BASE_EP_YIELD
+        public ep: number = GameConstants.BASE_EP_YIELD,
     ) {
         this.health = ko.observable(maxHealth);
         this.maxHealth = ko.observable(maxHealth);
         this.healthPercentage = ko.observable(100);
         this._displayName = PokemonHelper.displayName(name);
     }
+    /* eslint-enable @typescript-eslint/default-param-last */
 
     public isAlive(): boolean {
         return this.health() > 0;
@@ -79,7 +94,7 @@ class BattlePokemon implements EnemyPokemonInterface {
             });
             App.game.logbook.newLog(
                 LogBookTypes.FOUND,
-                createLogContent.enemyDrop({ pokemon: this.name, item: name })
+                createLogContent.enemyDrop({ pokemon: this.name, item: name }),
             );
         }
         App.game.party.gainExp(this.exp, this.level, trainer);

--- a/src/modules/battles/Trainer.ts
+++ b/src/modules/battles/Trainer.ts
@@ -1,12 +1,13 @@
+import type GymPokemon from '../gym/GymPokemon';
 
-class Trainer {
+export default class Trainer {
     public name: string;
 
     constructor(
         public trainerClass: string,
         private team: GymPokemon[],
         name?: string,
-        public subTrainerClass?: string
+        public subTrainerClass?: string,
     ) {
         this.name = name ? `${trainerClass} ${name}` : trainerClass;
     }

--- a/src/modules/globals.ts
+++ b/src/modules/globals.ts
@@ -17,4 +17,5 @@ declare global {
     const PokemonFactory: TempTypes.TmpPokemonFactoryType;
     const PartyController: TempTypes.TmpPartyControllerType;
     const TemporaryBattleList: TempTypes.TmpTemporaryBattleListType;
+    const BagHandler: TempTypes.TmpBagHandlerType;
 }

--- a/src/modules/gym/GymPokemon.ts
+++ b/src/modules/gym/GymPokemon.ts
@@ -1,4 +1,8 @@
-class GymPokemon {
+import * as GameConstants from '../GameConstants';
+import Requirement from '../requirements/Requirement';
+import type { PokemonNameType } from '../pokemons/PokemonNameType';
+
+export default class GymPokemon {
     name: PokemonNameType;
     maxHealth: number;
     level: number;

--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -27,14 +27,16 @@ export default class Profile implements Saveable {
 
     public pokemonSearch = ko.observable('');
     public getCaughtPokemonList = ko.pureComputed(() => {
-        let caughtPokemon = App.game.party.caughtPokemon;
-        if (this.pokemonSearch() != '') {
+        let caughtPokemon = [...App.game.party.caughtPokemon];
+        if (/^\d+$/.test(this.pokemonSearch())) {
+            // Search by ID
+            caughtPokemon = caughtPokemon.filter((pokemon) => +this.pokemonSearch() == Math.floor(pokemon.id));
+        } else if (this.pokemonSearch() != '') {
+            // Search by name
             const regex = GameHelper.safelyBuildRegex(this.pokemonSearch());
-            caughtPokemon = caughtPokemon.filter((pokemon) => {
-                return regex.test(pokemon.id) || regex.test(pokemon.name) || regex.test(pokemon.displayName);
-            });
+            caughtPokemon = caughtPokemon.filter((pokemon) => regex.test(pokemon.name) || regex.test(pokemon.displayName));
         }
-        return caughtPokemon.sort((a, b) => a.id - b.id);
+        return caughtPokemon;
     });
 
     constructor(

--- a/src/modules/temporaryWindowInjection.ts
+++ b/src/modules/temporaryWindowInjection.ts
@@ -27,6 +27,10 @@ import WeatherForecastStatus from './enums/WeatherForecastStatus';
 import SafariEnvironments from './enums/SafariEnvironments';
 import FarmingTool from './enums/FarmingTool';
 // end enums
+import Battle from './battles/Battle';
+import BattlePokemon from './battles/BattlePokemon';
+import Trainer from './battles/Trainer';
+import GymPokemon from './gym/GymPokemon';
 import BooleanSetting from './settings/BooleanSetting';
 import RangeSetting from './settings/RangeSetting';
 import Setting from './settings/Setting';
@@ -241,6 +245,10 @@ Object.assign(<any>window, {
     WeatherForecastStatus,
     SafariEnvironments,
     FarmingTool,
+    Battle,
+    BattlePokemon,
+    Trainer,
+    GymPokemon,
     BooleanSetting,
     RangeSetting,
     Setting,

--- a/src/modules/types/DamageCalculator.ts
+++ b/src/modules/types/DamageCalculator.ts
@@ -3,7 +3,7 @@ import { Region } from '../GameConstants';
 import WeatherType from '../weather/WeatherType';
 import { getPokemonByName } from '../pokemons/PokemonHelper';
 import GameHelper from '../GameHelper';
-import type { PokemonNameType } from '../pokemons/PokemonNameType';
+import type { TmpPartyPokemonType } from '../TemporaryScriptTypes';
 
 export default class DamageCalculator {
     public static type1 = ko.observable(PokemonType.None).extend({ numeric: 0 });
@@ -67,7 +67,7 @@ export default class DamageCalculator {
     }
 
     // TODO replace temporary type with PartyPokemon type once that class is ported
-    public static getOneTypeDetail(pokemon: { name: PokemonNameType, displayName: string }): TypeDetail {
+    public static getOneTypeDetail(pokemon: TmpPartyPokemonType): TypeDetail {
         const ignoreRegionMultiplier = DamageCalculator.region() == Region.none;
         const dataPokemon = getPokemonByName(pokemon.name);
         return {
@@ -86,7 +86,6 @@ export default class DamageCalculator {
                 DamageCalculator.weather(),
                 DamageCalculator.ignoreLevel(),
             	true,
-                DamageCalculator.subregion(),
             ),
             displayName: pokemon.displayName,
         };

--- a/src/scripts/battleFrontier/BattleFrontierBattle.ts
+++ b/src/scripts/battleFrontier/BattleFrontierBattle.ts
@@ -1,6 +1,3 @@
-/// <reference path="../../declarations/GameHelper.d.ts" />
-/// <reference path="../Battle.ts" />
-
 class BattleFrontierBattle extends Battle {
     static alternateAttack = false;
     static pokemonIndex: KnockoutObservable<number> = ko.observable(0);

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -8,7 +8,6 @@
 ///<reference path="../../declarations/requirements/ObtainedPokemonRequirement.d.ts"/>
 ///<reference path="../../declarations/utilities/SeededDateRand.d.ts"/>
 ///<reference path="./DungeonTrainer.ts"/>
-///<reference path="../gym/GymPokemon.ts"/>
 
 interface EnemyOptions {
     weight?: number,

--- a/src/scripts/dungeons/DungeonBattle.ts
+++ b/src/scripts/dungeons/DungeonBattle.ts
@@ -1,5 +1,4 @@
 /// <reference path="../../declarations/GameHelper.d.ts" />
-/// <reference path="../Battle.ts" />
 
 class DungeonBattle extends Battle {
 

--- a/src/scripts/dungeons/DungeonTrainer.ts
+++ b/src/scripts/dungeons/DungeonTrainer.ts
@@ -1,5 +1,3 @@
-///<reference path="../trainers/Trainer.ts"/>
-
 class DungeonTrainer extends Trainer {
 
     constructor(

--- a/src/scripts/gym/Gym.ts
+++ b/src/scripts/gym/Gym.ts
@@ -1,5 +1,4 @@
 /// <reference path="../../declarations/TemporaryScriptTypes.d.ts" />
-///<reference path="GymPokemon.ts"/>
 ///<reference path="../pokemons/PokemonFactory.ts"/>
 ///<reference path="../../declarations/requirements/OneFromManyRequirement.d.ts"/>
 ///<reference path="../../declarations/enums/Badges.d.ts"/>

--- a/src/scripts/gym/GymBattle.ts
+++ b/src/scripts/gym/GymBattle.ts
@@ -1,4 +1,3 @@
-///<reference path="../Battle.ts"/>
 class GymBattle extends Battle {
 
     static gym: Gym;

--- a/src/scripts/items/BagHandler.ts
+++ b/src/scripts/items/BagHandler.ts
@@ -137,3 +137,6 @@ class BagHandler {
     //#endregion
 
 }
+
+
+BagHandler satisfies TmpBagHandlerType;

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../declarations/DataStore/common/Feature.d.ts" />
 ///<reference path="../../declarations/enums/CaughtStatus.d.ts"/>
 
-class Party implements Feature {
+class Party implements Feature, TmpPartyType {
     name = 'Pokemon Party';
     saveKey = 'party';
 
@@ -71,6 +71,9 @@ class Party implements Feature {
         if (newCatch) {
             // Create new party pokemon
             this._caughtPokemon.push(PokemonFactory.generatePartyPokemon(id, shiny, gender, shadow));
+
+            // Keep caughtPokemon array sorted by ID
+            this._caughtPokemon.sort((a, b) => a.id - b.id);
         }
 
         // Update existing party pokemon
@@ -185,7 +188,7 @@ class Party implements Feature {
         ignoreRegionMultiplier = false,
         includeBreeding = false,
         useBaseAttack = false,
-        overrideWeather: WeatherType,
+        overrideWeather?: WeatherType,
         ignoreLevel = false,
         includeTempBonuses = true
     ): number {
@@ -323,11 +326,12 @@ class Party implements Feature {
         }
 
         const caughtPokemonSave = json.caughtPokemon;
-        for (let i = 0; i < caughtPokemonSave.length; i++) {
-            const partyPokemon = PokemonFactory.generatePartyPokemon(caughtPokemonSave[i].id);
-            partyPokemon.fromJSON(caughtPokemonSave[i]);
-            this._caughtPokemon.push(partyPokemon);
-        }
+        const caughtPokemon = caughtPokemonSave.map(caughtPoke => {
+            const partyPokemon = PokemonFactory.generatePartyPokemon(caughtPoke.id);
+            partyPokemon.fromJSON(caughtPoke);
+            return partyPokemon;
+        });
+        this._caughtPokemon(caughtPokemon);
     }
 
     initialize(): void {

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -19,7 +19,7 @@ enum PartyPokemonSaveKeys {
     showShadowImage,
 }
 
-class PartyPokemon implements Saveable {
+class PartyPokemon implements Saveable, TmpPartyPokemonType {
     saveKey: string;
     public exp = 0;
     public evs: KnockoutComputed<number>;

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -1,5 +1,4 @@
 ///<reference path="../../declarations/globals.d.ts"/>
-///<reference path="BattlePokemon.ts"/>
 
 class PokemonFactory {
 

--- a/src/scripts/temporaryBattle/TemporaryBattle.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattle.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../declarations/TemporaryScriptTypes.d.ts" />
-
 type TemporaryBattleOptionalArgument = {
     rewardFunction?: () => void,
     firstTimeRewardFunction?: () => void,

--- a/src/scripts/temporaryBattle/TemporaryBattleBattle.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleBattle.ts
@@ -1,4 +1,3 @@
-///<reference path="../Battle.ts"/>
 class TemporaryBattleBattle extends Battle {
 
     static index: KnockoutObservable<number> = ko.observable(0);


### PR DESCRIPTION
Convert Battle.ts and related classes to modules.

## Description
Mostly a lot of type work. The only logic change is some cleanup to Profile.ts as it was sneakily sorting the internal `Party._caughtPokemon` array. Profile now minds its own business and Party now keeps the array sorted just in case something depends on that.

## Motivation and Context
Ongoing module conversion.

## How Has This Been Tested?
Confirmed the game loaded properly and the various kinds of battles seemed to run normally. The profile modal search likewise works as intended without affecting the caught pokemon array.