### PR TITLE
Click Attack breakdown

### DIFF
--- a/src/components/statisticsModal.html
+++ b/src/components/statisticsModal.html
@@ -7,10 +7,12 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
+            <!-- ko if: DisplayObservables.modalState.statisticsModal === 'show' -->
             <div class="modal-body p-0">
                 <ul class="nav nav-tabs nav-fill">
                     <li class="nav-item"><a class="nav-link active" href="#statisticsModalStatsPane" data-toggle="tab">Stats</a></li>
                     <li class="nav-item"><a class="nav-link" href="#statisticsModalMultipliersPane" data-toggle="tab">Multipliers</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#statisticsModalClickAttackPane" data-toggle="tab">Click Attack</a></li>
                 </ul>
                 <div class="tab-content">
                     <!-- Stats Pane -->
@@ -66,8 +68,93 @@
                             <!-- /ko -->
                         </table>
                     </div>
+
+                    <!-- Click Attack Pane -->
+                    <div class="tab-pane text-left p-3" id="statisticsModalClickAttackPane" data-bind="with: App.game.party.clickAttackBreakdown">
+                        <h5>Base Click Attack</h5>
+                        <table class="table table-bordered table-sm">
+                            <tbody>
+                                <tr>
+                                    <td class="w-50">Unique Pokémon</td>
+                                    <td class="text-center w-50">
+                                        <code data-bind="text: $data.caughtPokemon.toLocaleString('en-US')"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Shiny Pokémon</td>
+                                    <td class="text-center">
+                                        <code data-bind="text: $data.shinyPokemon.toLocaleString('en-US')"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Resistant Pokémon</td>
+                                    <td class="text-center">
+                                        <code data-bind="text: $data.resistantPokemon.toLocaleString('en-US')"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Purified Pokémon</td>
+                                    <td class="text-center">
+                                        <code data-bind="text: $data.purifiedPokemon.toLocaleString('en-US')"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Achievement Bonus</td>
+                                    <td class="text-center">
+                                        <code data-bind="text: AchievementHandler.achievementBonus()"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="2" class="text-center">
+                                        <code data-bind="html: `(1 + ${$data.caughtPokemon} + ${$data.shinyPokemon} + ${$data.resistantPokemon} + ${$data.purifiedPokemon})<sup>1.4</sup> * (1 + ${AchievementHandler.achievementBonus()})`"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="text-right">=</td>
+                                    <td class="text-center">
+                                        <span data-bind="text: $data.baseClickAttack.toLocaleString('en-US')"></span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <h5>Modifiers</h5>
+                        <table class="table table-bordered table-sm mb-0">
+                            <tbody>
+                                <tr>
+                                    <td class="w-50">xClick</td>
+                                    <td class="text-center w-50">
+                                        <code data-bind="text: `×${$data.xClickModifier}`"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Rocky Helmet</td>
+                                    <td class="text-center">
+                                        <code data-bind="text: `×${$data.rockyHelmetModifier}`"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Black Flute</td>
+                                    <td class="text-center">
+                                        <code data-bind="text: `×${$data.blackFluteModifier}`"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="2" class="text-center">
+                                        <code data-bind="text: `${$data.baseClickAttack} * ${$data.xClickModifier} * ${$data.rockyHelmetModifier} * ${$data.blackFluteModifier}`"></code>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="text-right">=</td>
+                                    <td class="text-center">
+                                        <span data-bind="text: App.game.party.calculateClickAttack().toLocaleString('en-US')"></span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
+            <!-- /ko -->
         </div>
     </div>
 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -262,7 +262,12 @@
                                         <knockout data-bind="template: { name: 'pokemonAttackTemplate', data: { 'pokemon': Battle.enemyPokemon() } }"></knockout>
                                     </td>
                                     <td width="50%" data-bind="css: { 'text-muted': App.game.challenges.list.disableClickAttack.active() }">
-                                        <span style="display: inline;">Click Attack:
+                                        <span style="display: inline;" data-bind="tooltip: {
+                                            title: 'See the Click Attack tab in the Start → Statistics menu for details.',
+                                            placement: 'bottom',
+                                            trigger: 'hover'
+                                        }">
+                                            Click Attack:
                                             <span data-bind="text: App.game.party.calculateClickAttack().toLocaleString('en-US')"></span>
                                         </span>
                                     </td>

--- a/src/scripts/party/ClickAttackBreakdown.ts
+++ b/src/scripts/party/ClickAttackBreakdown.ts
@@ -1,0 +1,10 @@
+type ClickAttackBreakdown = {
+    caughtPokemon: number,
+    shinyPokemon: number,
+    resistantPokemon: number,
+    purifiedPokemon: number,
+    xClickModifier: number,
+    blackFluteModifier: number,
+    rockyHelmetModifier: number,
+    baseClickAttack: number,
+};

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -313,6 +313,32 @@ class Party implements Feature {
         return Math.floor(clickAttack * bonus);
     }
 
+    public clickAttackBreakdown = ko.pureComputed((): ClickAttackBreakdown => {
+        let numShiny = 0, numResistant = 0, numPurified = 0;
+        this.activePartyPokemon.forEach((p) => {
+            if (p.shiny) {
+                numShiny += 1;
+            }
+            if (p.pokerus >= GameConstants.Pokerus.Resistant) {
+                numResistant += 1;
+            }
+            if (p.shadow >= GameConstants.ShadowStatus.Purified) {
+                numPurified += 1;
+            }
+        });
+
+        return {
+            caughtPokemon: this.activePartyPokemon.length,
+            shinyPokemon: numShiny,
+            resistantPokemon: numResistant,
+            purifiedPokemon: numPurified,
+            xClickModifier: EffectEngineRunner.isActive(ItemList.xClick.name)() ? (ItemList.xClick as BattleItem).multiplyBy : 1,
+            blackFluteModifier: FluteEffectRunner.getFluteMultiplier(GameConstants.FluteItemType.Black_Flute),
+            rockyHelmetModifier: App.game.oakItems.calculateBonus(OakItemType.Rocky_Helmet),
+            baseClickAttack: Math.floor(App.game.party.calculateBaseClickAttack() * (1 + AchievementHandler.achievementBonus())),
+        };
+    });
+
     canAccess(): boolean {
         return true;
     }


### PR DESCRIPTION
## Description
Adds a new tab to the Statistics modal that gives a breakdown of the players click attack and how it's calculated.

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/eedfe19c-0384-4a65-9e3f-c01c525ad03a)

## Types of changes
- New feature
- UI improvement
