### PR TITLE
Fix diamonds being deleted when updating old save files to v0.10.22

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2779,7 +2779,7 @@ class Update implements Saveable {
             };
 
             const totalReimburse = Object.entries(saveData.underground.upgrades).map(([key, value]) => {
-                return upgradeCostMap[key]?.slice(0, value).reduce((acc, cur) => acc + cur, 0);
+                return upgradeCostMap[key]?.slice(0, value).reduce((acc, cur) => acc + cur, 0) ?? 0;
             }).reduce((acc, cur) => acc + cur, 0);
             saveData.underground.upgrades = {};
             saveData.wallet.currencies[GameConstants.Currency.diamond] += totalReimburse;


### PR DESCRIPTION
## Description
Returning undefined in the map (due to old underground upgrade names) causes it to be added to the numerical values, causing `NaN`

## How Has This Been Tested?
Ran against a save which had this bug

## Types of changes
- Bug fix
