### PR TITLE
Show Temp battle Pokemon Locations for locked pokemon

### DIFF
--- a/src/scripts/pokemons/PokemonLocations.ts
+++ b/src/scripts/pokemons/PokemonLocations.ts
@@ -437,7 +437,7 @@ class PokemonLocations {
             });
 
             if (tempBattle[1].optionalArgs?.isTrainerBattle === false) {
-                tempBattle[1].getPokemonList().forEach(p => {
+                tempBattle[1].getPokemonList(true).forEach(p => {
                     cacheLine[p.name].push(tempBattle[0]);
                 });
             }

--- a/src/scripts/temporaryBattle/TemporaryBattle.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattle.ts
@@ -72,7 +72,7 @@ class TemporaryBattle extends TownContent implements TmpTemporaryBattleType {
         this.completeRequirements = completeRequirements;
     }
 
-    public getPokemonList() {
-        return this.pokemons.filter((p) => p.requirements.every((r => r.isCompleted())));
+    public getPokemonList(fullList = false) {
+        return !fullList ? this.pokemons.filter((p) => p.requirements.every((r => r.isCompleted()))) : this.pokemons;
     }
 }


### PR DESCRIPTION
## Description
PokemonLocations now uses the full pokemon list from tempbattles

## Motivation and Context
Was browsing the wiki and realized Solgaleo and Lunala never showed up as obtainable through a temp battle even though they are

## How Has This Been Tested?
Used the PokemonLocation function on Solgaleo and Lunala. Unsure if this breaks anything else

## Screenshots:
![image](https://github.com/user-attachments/assets/7d97cba2-1fd6-4d05-a640-314a59dcadaa)

## Types of changes
- Bug fix