### PR TITLE
Adjust Alcremie Spin Numbers to be only dependent on caught number

### DIFF
--- a/src/components/battleCafeModal.html
+++ b/src/components/battleCafeModal.html
@@ -97,7 +97,7 @@
                 <div class="card">
                     <div class="card-header py-2 font-weight-bold">Spin!</div>
                     <div class="card-body col-lg-6 align-self-center p-2">
-                        <div>Remaining Spin Attempts: <span data-bind="text: BattleCafeController.spinsLeft()"></span></div>
+                        <div data-bind="if: BattleCafeController.spinsLeft() > -1">Remaining Spin Attempts: <span data-bind="text: BattleCafeController.spinsLeft()"></span></div>
                         <img style="width: 60px;" src="assets/images/profile/trainer-1.png" data-bind="
                             attr: { src: `assets/images/profile/trainer-${App.game.profile.trainer() || 0}.png` },
                             class: BattleCafeController.isSpinning() ? 'player-animated' + (BattleCafeController.clockwise() ? '' : '-counter') : ''" />

--- a/src/scripts/towns/BattleCafe.ts
+++ b/src/scripts/towns/BattleCafe.ts
@@ -41,20 +41,11 @@ class BattleCafeController {
     static clockwise = ko.observable<boolean>(false);
 
     static spinsPerDay() : number {
-        // Give additional spins for each sweet type completed, shiny, and resistant
-        let spins = this.baseDailySpins;
-        const sweetStatus = GameHelper.enumStrings(GameConstants.AlcremieSweet)
-            .map((s) => ({
-                caught: BattleCafeController.getCaughtStatus(GameConstants.AlcremieSweet[s])(),
-                pokerus: BattleCafeController.getPokerusStatus(GameConstants.AlcremieSweet[s])(),
-            }));
-        // Caught
-        spins += sweetStatus.filter((s) => s.caught >= CaughtStatus.Caught).length;
-        // Caught Shiny
-        spins += sweetStatus.filter((s) => s.caught == CaughtStatus.CaughtShiny).length;
-        // Resistant
-        spins += sweetStatus.filter((s) => s.pokerus == GameConstants.Pokerus.Resistant).length;
-        return spins;
+        // Give additional spins for each Alcremie obtained, or infinite if all Alcremie are obtained
+        const allCaughtStatuses = Object.values(BattleCafeController.evolutions).flatMap(group => Object.values(group)).map(pokemon => pokemon.getCaughtStatus());
+        const caughtCount = allCaughtStatuses.filter(status => status != CaughtStatus.NotCaught).length;
+
+        return caughtCount === allCaughtStatuses.length ? -1 : this.baseDailySpins + caughtCount;
     }
 
     public static spin(clockwise: boolean) {
@@ -124,7 +115,7 @@ class BattleCafeController {
             });
             return false;
         }
-        if (BattleCafeController.spinsLeft() < 1) {
+        if (BattleCafeController.spinsLeft() < 1 && BattleCafeController.spinsLeft() > -1) {
             Notifier.notify({
                 message: 'No spins left today.',
                 type: NotificationConstants.NotificationOption.danger,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Number of spins per day is now dependent on the amount of alcremie you own. 3 base + 1 for each Alcremie. Owning all Alcremie gives infinite spins. 


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Closes #5584


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Went in with files that had all, none and some amount between alcremie. Simulated day change and got the expected Spin number. Can spin indefinitely if owning all Alcremie, can't spin with 0 spins remaining. 


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UX improvement
