### PR TITLE
Move the sinnoh roamer NPC, add a hint for darkrai/cresselia

### DIFF
--- a/src/modules/pokemons/RoamingPokemonList.ts
+++ b/src/modules/pokemons/RoamingPokemonList.ts
@@ -116,8 +116,8 @@ RoamingPokemonList.add(Region.hoenn, 1, new RoamingPokemon('Bonsly', new QuestLi
 // Sinnoh
 RoamingPokemonList.add(Region.sinnoh, 0, new RoamingPokemon('Manaphy', new QuestLineCompletedRequirement('Recover the Precious Egg!')));
 RoamingPokemonList.add(Region.sinnoh, 0, new RoamingPokemon('Mesprit', new ClearDungeonRequirement(1, getDungeonIndex('Distortion World'))));
-RoamingPokemonList.add(Region.sinnoh, 0, new RoamingPokemon('Cresselia', new MultiRequirement([new ClearDungeonRequirement(1, getDungeonIndex('Fullmoon Island')), new MoonCyclePhaseRequirement([MoonCyclePhase.FullMoon, MoonCyclePhase.WaxingGibbous, MoonCyclePhase.WaningGibbous, MoonCyclePhase.FirstQuarter, MoonCyclePhase.ThirdQuarter])])));
-RoamingPokemonList.add(Region.sinnoh, 0, new RoamingPokemon('Darkrai', new MultiRequirement([new ClearDungeonRequirement(1, getDungeonIndex('Newmoon Island')), new MoonCyclePhaseRequirement([MoonCyclePhase.NewMoon, MoonCyclePhase.WaxingCrescent, MoonCyclePhase.WaningCrescent])])));
+RoamingPokemonList.add(Region.sinnoh, 0, new RoamingPokemon('Cresselia', new MultiRequirement([new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion), new MoonCyclePhaseRequirement([MoonCyclePhase.FullMoon, MoonCyclePhase.WaxingGibbous, MoonCyclePhase.WaningGibbous, MoonCyclePhase.FirstQuarter, MoonCyclePhase.ThirdQuarter])])));
+RoamingPokemonList.add(Region.sinnoh, 0, new RoamingPokemon('Darkrai', new MultiRequirement([new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion), new MoonCyclePhaseRequirement([MoonCyclePhase.NewMoon, MoonCyclePhase.WaxingCrescent, MoonCyclePhase.WaningCrescent])])));
 
 // Unova
 RoamingPokemonList.add(Region.unova, 0, new RoamingPokemon('Tornadus', new GymBadgeRequirement(BadgeEnums.Legend)));

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -7801,7 +7801,7 @@ dungeonList['Fullmoon Island'] = new Dungeon('Fullmoon Island',
         new DungeonBossPokemon('Clefable', 11000000, 100),
         new DungeonBossPokemon('Cresselia', 11000000, 100, {requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.NewMoon, MoonCyclePhase.WaxingCrescent, MoonCyclePhase.WaningCrescent])}),
     ],
-    96500, 230);
+    96500, 230, undefined, { requirement: new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion) });
 
 dungeonList['Newmoon Island'] = new Dungeon('Newmoon Island',
     ['Volbeat', 'Plusle', 'Sneasel', 'Luvdisc'],
@@ -7823,7 +7823,7 @@ dungeonList['Newmoon Island'] = new Dungeon('Newmoon Island',
         new DungeonBossPokemon('Absol', 9900000, 100),
         new DungeonBossPokemon('Darkrai', 11000000, 100, {requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.FullMoon, MoonCyclePhase.WaxingGibbous, MoonCyclePhase.WaningGibbous, MoonCyclePhase.FirstQuarter, MoonCyclePhase.ThirdQuarter])}),
     ],
-    96500, 230);
+    96500, 230, undefined, { requirement: new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion) });
 
 dungeonList['Flower Paradise'] = new Dungeon('Flower Paradise',
     ['Gloom', 'Bellsprout', 'Tangela', 'Skiploom', 'Jumpluff', 'Lombre', 'Seedot', 'Roselia'],

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -7799,7 +7799,7 @@ dungeonList['Fullmoon Island'] = new Dungeon('Fullmoon Island',
     [
         new DungeonBossPokemon('Lunatone', 11000000, 100),
         new DungeonBossPokemon('Clefable', 11000000, 100),
-        new DungeonBossPokemon('Cresselia', 11000000, 100, {requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.NewMoon, MoonCyclePhase.WaxingCrescent, MoonCyclePhase.WaningCrescent])}),
+        new DungeonBossPokemon('Cresselia', 11000000, 100, {hide: true, requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.NewMoon, MoonCyclePhase.WaxingCrescent, MoonCyclePhase.WaningCrescent])}),
     ],
     96500, 230, undefined, { requirement: new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion) });
 
@@ -7807,7 +7807,7 @@ dungeonList['Newmoon Island'] = new Dungeon('Newmoon Island',
     ['Volbeat', 'Plusle', 'Sneasel', 'Luvdisc'],
     {
         common: [
-            {loot: 'Lucky_egg', weight: 2},
+            {loot: 'Lucky_egg', weight: 2},S
             {loot: 'Nanab'},
         ],
         rare: [{loot: 'Black Shard'}],
@@ -7821,7 +7821,7 @@ dungeonList['Newmoon Island'] = new Dungeon('Newmoon Island',
     [
         new DungeonBossPokemon('Lunatone', 9900000, 100),
         new DungeonBossPokemon('Absol', 9900000, 100),
-        new DungeonBossPokemon('Darkrai', 11000000, 100, {requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.FullMoon, MoonCyclePhase.WaxingGibbous, MoonCyclePhase.WaningGibbous, MoonCyclePhase.FirstQuarter, MoonCyclePhase.ThirdQuarter])}),
+        new DungeonBossPokemon('Darkrai', 11000000, 100, {hide: true, requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.FullMoon, MoonCyclePhase.WaxingGibbous, MoonCyclePhase.WaningGibbous, MoonCyclePhase.FirstQuarter, MoonCyclePhase.ThirdQuarter])}),
     ],
     96500, 230, undefined, { requirement: new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion) });
 

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -4179,11 +4179,6 @@ const CanalaveRiley = new NPC('Riley', [
     'My partner Lucario evolved from a Riolu during daytime when I used a Soothe Bell.',
 ], {image: 'assets/images/npcs/Riley.png'});
 
-const CanalaveYoungBoy = new NPC('Young Boy', [
-    'Oh, hello! Say, have you ever heard of Cresselia? Once when I was really little I had a really bad dream I couldn’t wake up from, but then a kind trainer went to an island near here and got help from Cresselia to cure me!',
-    'Maybe if you can prove yourself by conquering that island, you could find Cresselia roaming around the region...',
-]);
-
 const CanalaveSinnohMyth = new NPC('Sinnoh\'s Myth', [
     '<i>Three Pokémon there were.</i>',
     '<i>Into the lakes they dove.</i>',
@@ -4195,6 +4190,11 @@ const CanalaveSinnohMyth = new NPC('Sinnoh\'s Myth', [
     '<i>Bearing with them the power to make vast lands, they rise again.</i>',
 ],{
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Zero\'s Ambition', 0), new QuestLineStepCompletedRequirement('Zero\'s Ambition', 2, GameConstants.AchievementOption.less)])});
+
+const NewFullMoonIslandResearcher = new RoamerNPC('Dream Researcher', [
+    'Oh, hello there! Have you heard the legend of Cresselia and Darkrai? It\’s said that one of them is roaming the region while the other retreats to its home island. It\'s speculated to have something to do with the moon phase.',
+    'There have been increased sightings of roaming Pokémon on {ROUTE_NAME}.',
+], GameConstants.Region.sinnoh, RoamingPokemonList.findGroup(GameConstants.Region.sinnoh, GameConstants.SinnohSubRegions.Sinnoh), 'assets/images/npcs/Scientist (female).png');
 
 const VerityMesprit = new NPC('Mesprit', [
     '<i>You are the trainer looking for the Distortion World, right?</i>',
@@ -4261,10 +4261,6 @@ const FightAreaZero2 = new NPC('Zero', [
     image: 'assets/images/npcs/Zero.png',
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Zero\'s Ambition', 1), new QuestLineStepCompletedRequirement('Zero\'s Ambition', 2, GameConstants.AchievementOption.less)]),
 });
-
-const SurvivalAreaSinnohRoamerNPC = new RoamerNPC('Hiker Kevin', [
-    'I spotted a bunch of roaming Pokémon on {ROUTE_NAME}!',
-], GameConstants.Region.sinnoh, RoamingPokemonList.findGroup(GameConstants.Region.sinnoh, GameConstants.SinnohSubRegions.Sinnoh), 'assets/images/npcs/Hiker.png');
 
 const SendoffSpringLakeTrio = new NPC('Lake Trio', [
     '<i>You are finally here.</i>',
@@ -4618,7 +4614,7 @@ TownList['Canalave City'] = new Town(
     [CanalaveCityShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Canalave City'])],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 218)],
-        npcs: [CanalaveRiley, CanalaveYoungBoy, CanalaveSinnohMyth, ManaphyHastings3, ManaphyHastings4],
+        npcs: [CanalaveRiley, CanalaveSinnohMyth, ManaphyHastings3, ManaphyHastings4],
     }
 );
 TownList['Great Marsh'] = new Town(
@@ -4681,7 +4677,6 @@ TownList['Survival Area'] = new Town(
     [TemporaryBattleList['Barry 7'], SurvivalAreaShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Survival Area'])],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 225)],
-        npcs: [SurvivalAreaSinnohRoamerNPC],
     }
 );
 TownList['Resort Area'] = new Town(
@@ -4870,13 +4865,21 @@ TownList['Fullmoon Island'] = new DungeonTown(
     'Fullmoon Island',
     GameConstants.Region.sinnoh,
     GameConstants.SinnohSubRegions.Sinnoh,
-    [new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion)]
+    [new GymBadgeRequirement(BadgeEnums.Mine)],
+    [],
+    {
+        npcs: [NewFullMoonIslandResearcher],
+    }
 );
 TownList['Newmoon Island'] = new DungeonTown(
     'Newmoon Island',
     GameConstants.Region.sinnoh,
     GameConstants.SinnohSubRegions.Sinnoh,
-    [new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion)]
+    [new GymBadgeRequirement(BadgeEnums.Mine)],
+    [],
+    {
+        npcs: [NewFullMoonIslandResearcher],
+    }
 );
 TownList['Flower Paradise'] = new DungeonTown(
     'Flower Paradise',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Moved the roamer NPC for sinnoh onto both fullmoon island and newmoon island. Made both Cresselia and Darkrai roam upon completing the region. Locked the dungeons of the two islands until becoming champ


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
People were confused how the Darkrai/Cresselia thing works. 
The Roamer NPC was post champ even tho you could unlock roamers in sinnoh much earlier. 


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Loaded a file, looked at the islands and saw that the NPC was there and the dungeons were locked.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- new NPC
