### PR TITLE
Gym badge hints use button text for Elite trainers

### DIFF
--- a/src/modules/TemporaryScriptTypes.ts
+++ b/src/modules/TemporaryScriptTypes.ts
@@ -253,6 +253,13 @@ export type TmpGymRunnerType = {
     gymObservable: () => TmpGymType;
 };
 
+export type TmpGymListType = {
+    [gymName: string]: {
+        badgeReward: any;
+        buttonText: string;
+    }
+};
+
 export type TmpAchievementHandlerType = {
     achievementList: Achievement[];
     navigateIndex: KnockoutObservable<number>;

--- a/src/modules/globals.ts
+++ b/src/modules/globals.ts
@@ -17,4 +17,5 @@ declare global {
     const PokemonFactory: TempTypes.TmpPokemonFactoryType;
     const PartyController: TempTypes.TmpPartyControllerType;
     const TemporaryBattleList: TempTypes.TmpTemporaryBattleListType;
+    const GymList: TempTypes.TmpGymListType;
 }

--- a/src/modules/requirements/GymBadgeRequirement.ts
+++ b/src/modules/requirements/GymBadgeRequirement.ts
@@ -14,6 +14,8 @@ export default class GymBadgeRequirement extends Requirement {
     }
 
     public hint(): string {
-        return `Requires the ${GameConstants.camelCaseToString(BadgeEnums[this.badge])} badge.`;
+        return BadgeEnums[this.badge].startsWith('Elite') ?
+        `Requires having beaten ${Object.values(GymList).find(obj => obj.badgeReward === this.badge).buttonText}.` :
+        `Requires the ${GameConstants.camelCaseToString(BadgeEnums[this.badge])} badge.`;
     }
 }

--- a/src/scripts/gym/GymList.ts
+++ b/src/scripts/gym/GymList.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../declarations/TemporaryScriptTypes.d.ts" />
 
 const GymList: { [townName: string]: Gym } = {};
 
@@ -2638,3 +2639,5 @@ GymList['AI Turo'] = new Gym(
     [new RouteKillRequirement(10, GameConstants.Region.paldea, 2)],
     undefined, undefined, { displayName: 'AI Turo' }
 );
+
+GymList satisfies TmpGymListType;


### PR DESCRIPTION
## Description
Badge hints now change for "Elite" trainers and use their button text instead of the badge name

## Motivation and Context
Closes #5477
Closes #5604

## How Has This Been Tested?
In the console. See screenshot

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/18945cd4-6a3e-425f-8c56-087355690141)

## Types of changes
- UI improvement
