### PR TITLE
Currency display updates

### DIFF
--- a/src/components/currencyContainer.html
+++ b/src/components/currencyContainer.html
@@ -14,7 +14,7 @@
             <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.battlePoint, tooltip: 'Battle Points<br /><br />Gained at the Battle Frontier.' } },
                 visible: TownList['Battle Frontier'].isUnlocked() || App.game.wallet.currencies[GameConstants.Currency.battlePoint]() > 0"></div>
             <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.contestToken, tooltip: 'Contest Tokens<br /><br />Gained by competing in Contests.' } },
-                visible: App.game.wallet.currencies[GameConstants.Currency.contestToken]() > 0"></div>
+                visible: TownList['National Park'].isUnlocked() || App.game.wallet.currencies[GameConstants.Currency.contestToken]() > 0"></div>
         </div>
     </div>
 </div>

--- a/src/components/currencyContainer.html
+++ b/src/components/currencyContainer.html
@@ -3,22 +3,18 @@
         <span>Currency</span>
     </div>
     <div id="currencyBody" class="card-body p-0 show">
-        <div class="currency-wrapper p-1" data-bind="css: { 'short-currencies': Settings.getSetting('currencyMainDisplayReduced').observableValue() }">
-            <div class="currency-line">
-                <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.money, tooltip: 'Pokédollars<br /><br />Gained by defeating Pokémon and trainers in battle.' } }"></div>
-                <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.dungeonToken, tooltip: 'Dungeon Tokens<br /><br />Gained by catching wild Pokémon.' } }"></div>
-                <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.questPoint, tooltip: 'Quest Points<br /><br />Gained by completing Quests.' } }"></div>
-            </div>
-
-            <!-- ko if: Settings.getSetting('currencyMainDisplayExtended').observableValue() -->
-            <div class="currency-line">
-                <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.farmPoint, tooltip: 'Farm Points<br /><br />Gained by harvesting berries on the Farm.' } }"></div>
-                <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.diamond, tooltip: 'Diamonds<br /><br />Gained by selling treasure found in the Underground.' } }"></div>
-                <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.battlePoint, tooltip: 'Battle Points<br /><br />Gained at the Battle Frontier.' } }"></div>
-                <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.contestToken, tooltip: 'Contest Tokens<br /><br />Gained by competing in Contests.' } },
-                    visible: App.game.wallet.currencies[GameConstants.Currency.contestToken]() > 0"></div>
-            </div>
-            <!-- /ko -->
+        <div class="currency-wrapper d-flex flex-wrap justify-content-around p-1" data-bind="css: { 'short-currencies': Settings.getSetting('currencyMainDisplayReduced').observableValue() }">
+            <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.money, tooltip: 'Pokédollars<br /><br />Gained by defeating Pokémon and trainers in battle.' } }"></div>
+            <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.dungeonToken, tooltip: 'Dungeon Tokens<br /><br />Gained by catching wild Pokémon.' } }"></div>
+            <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.questPoint, tooltip: 'Quest Points<br /><br />Gained by completing Quests.' } }"></div>
+            <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.farmPoint, tooltip: 'Farm Points<br /><br />Gained by harvesting berries on the Farm.' } },
+                visible: App.game.farming.canAccess() || App.game.wallet.currencies[GameConstants.Currency.farmPoint]() > 0"></div>
+            <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.diamond, tooltip: 'Diamonds<br /><br />Gained by selling treasure found in the Underground.' } },
+                visible: App.game.underground.canAccess() || App.game.wallet.currencies[GameConstants.Currency.diamond]() > 0"></div>
+            <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.battlePoint, tooltip: 'Battle Points<br /><br />Gained at the Battle Frontier.' } },
+                visible: TownList['Battle Frontier'].isUnlocked() || App.game.wallet.currencies[GameConstants.Currency.battlePoint]() > 0"></div>
+            <div data-bind="template: { name: 'currency-display-template', data: { currency: GameConstants.Currency.contestToken, tooltip: 'Contest Tokens<br /><br />Gained by competing in Contests.' } },
+                visible: App.game.wallet.currencies[GameConstants.Currency.contestToken]() > 0"></div>
         </div>
     </div>
 </div>

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -46,7 +46,6 @@
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showCurrencyGainedAnimation')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('showCurrencyLostAnimation')}"></tr>
                                 <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('currencyMainDisplayReduced')}"></tr>
-                                <tr data-bind="template: { name: 'BooleanSettingTemplate', data: Settings.getSetting('currencyMainDisplayExtended')}"></tr>
                             </tbody>
                             <thead>
                                 <tr><th colspan="2">Hatchery</th></tr>

--- a/src/components/templates/currencyContainerCurrencyTemplate.html
+++ b/src/components/templates/currencyContainerCurrencyTemplate.html
@@ -1,6 +1,6 @@
 <script type="text/html" id="currency-display-template">
-    <div class="currency-display d-flex flex-wrap mx-1 my-2 justify-content-center">
-        <img src="" class="mx-1" height="25px" data-bind="attr: { src: `assets/images/currency/${GameConstants.Currency[$data.currency]}.svg` },
+    <div class="d-flex flex-column mx-1 my-2 justify-content-center">
+        <img src="" height="25px" data-bind="attr: { src: `assets/images/currency/${GameConstants.Currency[$data.currency]}.svg` },
             tooltip: {
                 html: true,
                 title: $data.tooltip,

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -147,7 +147,6 @@ Settings.add(new BooleanSetting('autoRestartUndergroundMine', 'Auto restart sele
 Settings.add(new BooleanSetting('showUndergroundModule', 'Show Underground module on main screen', true));
 Settings.add(new BooleanSetting('enableUndergroundModuleMineControls', 'Enable Underground module mine controls', true));
 Settings.add(new BooleanSetting('currencyMainDisplayReduced', 'Shorten currency amount shown on main screen', false));
-Settings.add(new BooleanSetting('currencyMainDisplayExtended', 'Show Diamonds, Farm Points, Battle Points, and Contest Tokens on main screen', false));
 Settings.add(new BooleanSetting('confirmLeaveDungeon', 'Confirm before leaving dungeons', false));
 Settings.add(new BooleanSetting('confirmBeformeMulchingAllPlots', 'Confirm before mulching all plots', false));
 Settings.add(new BooleanSetting('breedingQueueClearConfirmation', 'Confirm before clearing the hatchery queue', true));

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -835,47 +835,6 @@ button.btn-circle {
   overflow: hidden;
 }
 
-// Currency module
-#middle-column {
-    .currency-wrapper {
-        .currency-line {
-            display: flex;
-            flex-wrap: nowrap;
-            justify-content: space-evenly;
-        }
-
-        &.short-currencies {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: space-evenly;
-
-            > .currency-line {
-                display: contents;
-            }
-
-            .currency-display {
-                flex-direction: column;
-            }
-        }
-    }
-}
-
-#left-column, #left-column-2, #right-column, #right-column-2 {
-    .currency-wrapper {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-evenly;
-
-        .currency-line {
-            display: contents;
-        }
-
-        .currency-display {
-            flex-direction: column;
-        }
-    }
-}
-
 .dropdown-toggle-no-arrow::after {
     content: none !important;
 }


### PR DESCRIPTION
## Description
- Removes the `Show Diamonds, Farm Points, Battle Points, and Contest Tokens on main screen` setting
- Farm Points, Diamonds, Battle Points, and Contest Tokens will be displayed upon unlocking their source locations or if the player has acquired any.

## How Has This Been Tested?
Checked the display with files of various progression and that each currency type appeared correctly after unlocking or being obtained
