### PR TITLE
Fix tutorial softlock

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -82,34 +82,33 @@ class QuestLineHelper {
                     exitOnEsc: false,
                     showButtons: false,
                 });
-                const caughtSelector: HTMLElement = document.querySelector('tr[data-name="Caught"] img.pokeball-small.clickable.pokeball-selected');
-                caughtSelector.addEventListener('click', () => {
-                    Information.hide();
-                    $('#pokeballSelectorModal').one('shown.bs.modal', null, () => {
-                        // Need to set a timeout, otherwise it messes up the modal layout
-                        setTimeout(() => {
-                            Information.show({
-                                steps: [
-                                    {
-                                        element: document.querySelector('#pokeballSelectorModal .modal-body'),
-                                        intro: 'Select the <img title="Poké Ball" src="assets/images/pokeball/Pokeball.svg" height="25px"> Poké Ball to use this type of ball to capture already caught Pokémon, which will give you <img title="Dungeon Tokens\nGained by capturing Pokémon" src="assets/images/currency/dungeonToken.svg" height="25px"> Dungeon Tokens when captured.',
-                                    },
-                                ],
-                                // Needed for IntroJs on modals
-                                overlayOpacity: 0,
-                            });
-                        }, 100);
 
-                        // Hide the IntroJS overlay once the user selects the Pokeball
-                        const selectPokeball = document.querySelectorAll('#pokeballSelectorModal .clickable')[1];
-                        selectPokeball.addEventListener('click', () => {
-                            Information.hide();
-                        }, {
-                            once: true,
+                $('#pokeballSelectorModal').one('show.bs.modal', () => {
+                    Information.hide();
+                });
+
+                $('#pokeballSelectorModal').one('shown.bs.modal', () => {
+                    // Need to set a timeout, otherwise it messes up the modal layout
+                    setTimeout(() => {
+                        Information.show({
+                            steps: [
+                                {
+                                    element: document.querySelector('#pokeballSelectorModal .modal-body'),
+                                    intro: 'Select the <img title="Poké Ball" src="assets/images/pokeball/Pokeball.svg" height="25px"> Poké Ball to use this type of ball to capture already caught Pokémon, which will give you <img title="Dungeon Tokens\nGained by capturing Pokémon" src="assets/images/currency/dungeonToken.svg" height="25px"> Dungeon Tokens when captured.',
+                                },
+                            ],
+                            // Needed for IntroJs on modals
+                            overlayOpacity: 0,
                         });
+                    }, 100);
+
+                    // Hide the IntroJS overlay once the user selects the Pokeball
+                    const selectPokeball = document.querySelectorAll('#pokeballSelectorModal .clickable')[1];
+                    selectPokeball.addEventListener('click', () => {
+                        Information.hide();
+                    }, {
+                        once: true,
                     });
-                }, {
-                    once: true,
                 });
             });
         };

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -103,11 +103,8 @@ class QuestLineHelper {
                     }, 100);
 
                     // Hide the IntroJS overlay once the user selects the Pokeball
-                    const selectPokeball = document.querySelectorAll('#pokeballSelectorModal .clickable')[1];
-                    selectPokeball.addEventListener('click', () => {
+                    $('#pokeballSelectorModal .clickable').one('click', () => {
                         Information.hide();
-                    }, {
-                        once: true,
                     });
                 });
             });


### PR DESCRIPTION
## Description
During the tutorial after talking to the Old Man the game will prompt the player to click the Caught filter and select a pokeball. Clicking anything other than "Caught" will softlock the game until reloaded. This fixes this issue by triggering the next information prompt upon clicking any filter.

## Motivation and Context
🐛 

## How Has This Been Tested?
Clicked any filter other than "Caught" when prompted and verified the information prompt correctly continued
Test save: [tutorial.txt](https://github.com/user-attachments/files/19268160/tutorial.txt)

## Types of changes
- Bug fix
