### PR TITLE
Adding icon in dungeon loot modal for items which ignore the debuff

### DIFF
--- a/src/components/dungeonInfoModal.html
+++ b/src/components/dungeonInfoModal.html
@@ -30,6 +30,13 @@
                                                 placement: 'bottom',
                                                 trigger: 'hover'
                                             }, visible: item.requirement && !item.requirement.isCompleted()" />
+                                            <knockout class="h4 text-success no-emoji-font mr-2 mb-0 align-self-center lock" data-bind="
+                                                visible: DungeonRunner.isDungeonDebuffed(player.town.dungeon) && item.ignoreDebuff && (item.requirement?.isCompleted() ?? true),
+                                                tooltip: {
+                                                    title: 'The odds for this item are preserved despite the dungeon being debuffed.',
+                                                    trigger: 'hover',
+                                                }">⚠
+                                            </knockout>
                                         </div>
                                     <!-- /ko -->
                                 <!-- /ko -->

--- a/src/components/dungeonInfoModal.html
+++ b/src/components/dungeonInfoModal.html
@@ -30,7 +30,7 @@
                                                 placement: 'bottom',
                                                 trigger: 'hover'
                                             }, visible: item.requirement && !item.requirement.isCompleted()" />
-                                            <knockout class="h4 text-success no-emoji-font mr-2 mb-0 align-self-center lock" data-bind="
+                                            <knockout class="h4 text-success no-emoji-font mr-2 mb-0 align-self-center" data-bind="
                                                 visible: DungeonRunner.isDungeonDebuffed(player.town.dungeon) && item.ignoreDebuff && (item.requirement?.isCompleted() ?? true),
                                                 tooltip: {
                                                     title: 'The odds for this item are preserved despite the dungeon being debuffed.',

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -46,8 +46,9 @@
 
                 <div class="title-right" data-bind="if: isDungeon && QuestLineHelper.isQuestLineCompleted('Tutorial Quests')">
                     <div class="d-flex ml-auto">
-                        <knockout class="h4 text-danger no-emoji-font mr-2 mb-0 align-self-center" data-bind="
+                        <knockout class="h4 no-emoji-font mr-2 mb-0 align-self-center" data-bind="
                             visible: DungeonRunner.isDungeonDebuffed(player.town.dungeon),
+                            class: Object.values(player.town.dungeon.lootTable).flat().find(l => l.ignoreDebuff && (l.requirement?.isCompleted() ?? true)) ? 'text-warning' : 'text-danger',
                             tooltip: {
                                 title: 'This dungeon is debuffed and will be significantly less likely to drop Epic, Legendary, and Mythic loot.',
                                 trigger: 'hover',


### PR DESCRIPTION
## Description
Same ⚠️ icon but green next to items like Zen or scents.

## Motivation and Context
Makes more clear that some items are immune to the dungeon debuff, and which.

## How Has This Been Tested?
Checked a few places : Orre dungeons, Ilex Forest, Relic Castle.

## Types of changes
- UI improvement
