### PR TITLE
Fix typo in Peonia message

### DIFF
--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -9107,7 +9107,7 @@ const GigantamaxLeon2 = new NPC ('Leon', [
     requirement:  new MultiRequirement([new QuestLineStepCompletedRequirement('The Lair of Giants', 35), new QuestLineStepCompletedRequirement('The Lair of Giants', 37, GameConstants.AchievementOption.less )]),
 });
 const Peonia4 = new NPC ('Peonia', [
-    'Was it really was Eternatus again? Given that the purple glow has vanished, I guess you\'ve already taken care of it. Congrats!',
+    'So it really was Eternatus again? Given that the purple glow has vanished, I guess you\'ve already taken care of it. Congrats!',
     'Actually, I just saw some purple and red Pokémon fly into the caves. Maybe that was Eternatus? I think this place might let it return to its Eternamax form. Maybe you can catch it!',
     'At any rate, I\'m real thankful for all your help. There\'s so many more people coming here now there\'s more Gigantamax Pokémon to find.  It\'s been a lot of fun!',
 ], {


### PR DESCRIPTION
Fixed a typo in Peonia's NPC message after finishing the Gigantamax questline.

## Description

Updated a typoed text.

This issue here on the Discord: https://discord.com/channels/450412847017754644/1210005245145522186

## Motivation and Context

Fixing text to be correct.

## How Has This Been Tested?

No testing, but it's a text fix so I don't think this needs to be "tested" tested.

## Types of changes

Bug fix (text).
