### PR TITLE
Remove Convert Save functionality & rename Save -> Save / Enter Code

### DIFF
--- a/src/components/gameMenu.html
+++ b/src/components/gameMenu.html
@@ -39,7 +39,7 @@
             <a class="dropdown-item" href="#badgeCaseModal" data-toggle="modal">Badge Case</a>
         </li>
         <li>
-            <a class="dropdown-item" href="#saveModal" data-toggle="modal">Save / Redeem Code</a>
+            <a class="dropdown-item" href="#saveModal" data-toggle="modal">Save / Enter Code</a>
         </li>
         <li>
             <a class="dropdown-item" href="#settingsModal" data-toggle="modal">Settings</a>

--- a/src/components/gameMenu.html
+++ b/src/components/gameMenu.html
@@ -39,7 +39,7 @@
             <a class="dropdown-item" href="#badgeCaseModal" data-toggle="modal">Badge Case</a>
         </li>
         <li>
-            <a class="dropdown-item" href="#saveModal" data-toggle="modal">Save</a>
+            <a class="dropdown-item" href="#saveModal" data-toggle="modal">Save / Redeem Code</a>
         </li>
         <li>
             <a class="dropdown-item" href="#settingsModal" data-toggle="modal">Settings</a>

--- a/src/components/saveModal.html
+++ b/src/components/saveModal.html
@@ -9,49 +9,33 @@
                 </button>
             </div>
 
-            <div class="modal-body p-0">
-                <ul class="nav nav-tabs nav-fill">
-                    <li class="nav-item"><a class="nav-link active" href="#saveTab" data-toggle="tab">Save</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#saveConvert" data-toggle="tab">Convert Original Save</a></li>
-                </ul>
-                <div class="tab-content p-3">
-                    <div id="saveTab" class="tab-pane fade in active show">
-                        <div>
-                            <form class="form-inline input-group">
-                                <input class="outline-dark form-control" placeholder="Enter code..." id="redeemable-code-input" type="text" />
-                                <div class="input-group-append">
-                                    <button class="btn btn-info" name="name" value="value" type="submit" onclick="RedeemableCodeController.enterCode(); return false;">Claim!</button>
-                                </div>
-                            </form>
-                            <hr>
-                            <!-- ko if: App.game.discord.enabled -->
-                            <button class="btn btn-primary btn-block" onClick="App.game.discord.login()" data-bind="visible: !App.game.discord.ID()">Link Discord</button>
-                            <button class="btn btn-warning btn-block" onClick="App.game.discord.logout()" data-bind="visible: App.game.discord.ID()">Unlink Discord</button>
-                            <i class="text-warning"><strong>Note:</strong> This is <strong>not</strong> used for cloud saves;<br/>it just allows you to enter codes received from the Discord bot.</i>
-                            <hr>
-                            <!-- /ko -->
-
-                            <button class="btn btn-primary btn-block" onClick="Save.download()">Download Save</button>
-                            <i>If this does not work, you can copy the contents of the save and paste it into a '.txt' file</i>
-                            <button class="btn btn-primary btn-block" onclick="Save.copySaveToClipboard()">Copy to Clipboard</button>
-                            <hr>
-
-                            <input type="file" id="import-save" accept=".txt" style="display:none;"
-                                    onchange=Save.loadFromFile(this.files[0])>
-                            <label for="import-save" class="btn btn-primary btn-block">Import Save</label>
-                            <hr>
-                            <h5 class="text-danger">You will not be able to recover your savefile!</h5>
-                            <button class="btn btn-danger btn-block" onClick="Save.delete()">DELETE SAVE</button>
+            <div class="modal-body">
+                <div id="saveTab">
+                    <form class="form-inline input-group">
+                        <input class="outline-dark form-control" placeholder="Enter code..." id="redeemable-code-input" type="text" />
+                        <div class="input-group-append">
+                            <button class="btn btn-info" name="name" value="value" type="submit" onclick="RedeemableCodeController.enterCode(); return false;">Claim!</button>
                         </div>
-                    </div>
+                    </form>
+                    <hr>
+                    <!-- ko if: App.game.discord.enabled -->
+                    <button class="btn btn-primary btn-block" onClick="App.game.discord.login()" data-bind="visible: !App.game.discord.ID()">Link Discord</button>
+                    <button class="btn btn-warning btn-block" onClick="App.game.discord.logout()" data-bind="visible: App.game.discord.ID()">Unlink Discord</button>
+                    <i class="text-warning"><strong>Note:</strong> This is <strong>not</strong> used for cloud saves;<br/>it just allows you to enter codes received from the Discord bot.</i>
+                    <hr>
+                    <!-- /ko -->
 
-                    <div id="saveConvert" class="tab-pane fade">
-                        <p>You can paste your old PokéClicker save file here, to keep shinies:</p>
-                        <textarea id="convertTextArea" class="saveTextArea"></textarea>
-                        <button class="btn btn-success btn-block" onclick="Save.convert()">
-                            Convert
-                        </button>
-                    </div>
+                    <button class="btn btn-primary btn-block" onClick="Save.download()">Download Save</button>
+                    <i>If this does not work, you can copy the contents of the save and paste it into a '.txt' file</i>
+                    <button class="btn btn-primary btn-block" onclick="Save.copySaveToClipboard()">Copy to Clipboard</button>
+                    <hr>
+
+                    <input type="file" id="import-save" accept=".txt" style="display:none;"
+                            onchange=Save.loadFromFile(this.files[0])>
+                    <label for="import-save" class="btn btn-primary btn-block">Import Save</label>
+                    <hr>
+                    <h5 class="text-danger">You will not be able to recover your savefile!</h5>
+                    <button class="btn btn-danger btn-block" onClick="Save.delete()">DELETE SAVE</button>
                 </div>
             </div>
 

--- a/src/modules/TemporaryScriptTypes.ts
+++ b/src/modules/TemporaryScriptTypes.ts
@@ -31,7 +31,7 @@ import type CaughtStatus from './enums/CaughtStatus';
 import type SpecialEvents from './specialEvents/SpecialEvents';
 
 /*
-    These types are only temporary while we are converting things to modules. As things are converted, 
+    These types are only temporary while we are converting things to modules. As things are converted,
     we should import their types here for use, instead of these cheap imitations.
 
     When a file is converted to a module, the types for any /scripts dependencies should be added here
@@ -75,7 +75,7 @@ import type SpecialEvents from './specialEvents/SpecialEvents';
         }
         Example2 satisfies TmpExample2Type;
 
-    If a class has both static and instance properties, it needs separate types for each. 
+    If a class has both static and instance properties, it needs separate types for each.
 
 */
 
@@ -172,8 +172,6 @@ export type TmpSaveType = {
     initializeEffects: (saved?: Array<string>) => Record<string, KnockoutObservable<number>>;
     initializeEffectTimer: () => Record<string, KnockoutObservable<string>>;
     loadFromFile: (file) => void;
-    convert: () => void;
-    convertShinies: (list: Array<any>) => void;
 };
 
 export type TmpPlayerType = {

--- a/src/scripts/Save.ts
+++ b/src/scripts/Save.ts
@@ -217,46 +217,6 @@ class Save {
             }
         }, 1000);
     }
-
-    public static convert() {
-        const base64 = $('#convertTextArea').val().toString();
-        try {
-            const json = atob(base64);
-            const p = JSON.parse(json);
-            Save.convertShinies(p.caughtPokemonList);
-            $('#saveModal').modal('hide');
-        } catch (e) {
-            Notifier.notify({
-                message: 'Invalid save data.',
-                type: NotificationConstants.NotificationOption.danger,
-            });
-        }
-    }
-
-    public static convertShinies(list: Array<any>) {
-        const converted = [];
-        list = list.filter(p => p.shiny);
-        for (const pokemon of list) {
-            const id = +pokemon.id;
-            const partyPokemon = App.game.party.getPokemon(id);
-            if (partyPokemon) {
-                converted.push(pokemon.name);
-                partyPokemon.shiny = true;
-            }
-        }
-        if (converted.length > 0) {
-            Notifier.notify({
-                message: `You have gained the following shiny Pokémon:</br>${converted.join(',</br>')}`,
-                type: NotificationConstants.NotificationOption.success,
-                timeout: 1e4,
-            });
-        } else {
-            Notifier.notify({
-                message: 'No new shiny Pokémon to import.',
-                type: NotificationConstants.NotificationOption.info,
-            });
-        }
-    }
 }
 
 Save satisfies TmpSaveType;

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2649,7 +2649,7 @@ const Television2 = new NPC('Watch More Television', [
 
 const TicketClaim = new NPC('Contest Attendant', [
     'Thank you for reserving your Eon Ticket!',
-    'To claim the ticket, all you have to do is go to your Start Menu, select "Save", and enter the following code in the "Enter Code..." box:',
+    'To claim the ticket, all you have to do is go to your Start Menu, select "Save / Enter Code", and enter the following code in the "Enter Code..." box:',
     'EON-TICKET',
 ],  {requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('The Eon Duo', 1), new QuestLineStepCompletedRequirement('The Eon Duo', 3, GameConstants.AchievementOption.less)]),
 });

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -208,6 +208,8 @@ body:hover {
 
   .dropdown-item {
     font-family: pokemonFont, "Helvetica Neue", sans-serif;
+    white-space: nowrap !important;
+    padding: 0.25rem 1rem;
   }
 
   .dropdown-toggle {


### PR DESCRIPTION
Removes the "Convert Save" functionality for files from the original PokeClicker, it's been long enough and it just confuses players now.

Also renames the "Save" start menu item to "Save / Redeem Code"
