### PR TITLE
Hatchery Helper / Farm Hand / Dungeon Guide UI updates

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -454,6 +454,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                     </div>
 
                     <div class="tab-pane fade" id="breeding-helpers">
+                        <!-- ko if: HatcheryHelpers.list.some(f => f.isUnlocked()) -->
                         <div class="bg-primary text-left rounded-0 px-3 py-2 mb-1" data-bind="visible: HatcheryHelpers.list.some(f => !f.isUnlocked())">
                             <h5 class="m-0 text-light">Available Helpers</h5>
                         </div>
@@ -585,7 +586,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                 </div>
                             </div>
                         </div>
-
+                        <!-- /ko -->
                         <!-- ko if: HatcheryHelpers.list.some(f => !f.isUnlocked()) -->
                         <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2">
                             <h5 class="m-0 text-light">Locked Helpers</h5>

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -455,9 +455,6 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
 
                     <div class="tab-pane fade" id="breeding-helpers">
                         <!-- ko if: HatcheryHelpers.list.some(f => f.isUnlocked()) -->
-                        <div class="bg-primary text-left rounded-0 px-3 py-2 mb-1" data-bind="visible: HatcheryHelpers.list.some(f => !f.isUnlocked())">
-                            <h5 class="m-0 text-light">Available Helpers</h5>
-                        </div>
                         <div class="row m-0 justify-content-center" data-bind="foreach: App.game.breeding.hatcheryHelpers.available()" style="max-width: 100%;">
                             <div class="card text-left col-md-3 col-sm-6 col-xs-12 p-0">
                                 <h5 class="card-header">
@@ -588,7 +585,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                         </div>
                         <!-- /ko -->
                         <!-- ko if: HatcheryHelpers.list.some(f => !f.isUnlocked()) -->
-                        <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2">
+                        <div class="bg-primary text-left rounded-0 px-3 py-2 mt-3">
                             <h5 class="m-0 text-light">Locked Helpers</h5>
                         </div>
                         <div class="row m-0 justify-content-center" data-bind="foreach: HatcheryHelpers.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -454,6 +454,9 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                     </div>
 
                     <div class="tab-pane fade" id="breeding-helpers">
+                        <div class="bg-primary text-left rounded-0 px-3 py-2 mb-1">
+                            <h5 class="m-0 text-light">Available Helpers</h5>
+                        </div>
                         <div class="row m-0 justify-content-center" data-bind="foreach: App.game.breeding.hatcheryHelpers.available()" style="max-width: 100%;">
                             <div class="card text-left col-md-3 col-sm-6 col-xs-12 p-0">
                                 <h5 class="card-header">
@@ -582,6 +585,48 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                 </div>
                             </div>
                         </div>
+
+                        <!-- ko with: HatcheryHelpers.list.filter(f => !f.isUnlocked()), as: 'lockedHelpers' -->
+                        <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2">
+                            <h5 class="m-0 text-light">Locked Helpers</h5>
+                        </div>
+                        <div class="row m-0 justify-content-center" data-bind="foreach: lockedHelpers" style="max-width: 100%;">
+                            <div class="card text-left col-md-3 col-sm-6 col-xs-12 p-0 mt-1">
+                                <h5 class="card-header">
+                                    <knockout data-bind="text: $data.name">Name</knockout>
+                                    <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                                </h5>
+                                <div class="card-body p-0">
+                                    <table class="table table-bordered table-sm m-0 h-100" style="overflow: visible;">
+                                        <tbody>
+                                            <tr>
+                                                <td class="text-left align-middle">Cost / Hatch:</td>
+                                                <td class="text-right" data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.cost.amount, 'currency': $data.cost.currency, 'reducedThreshold': 1e10}}"></td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-left">Step Efficiency:</td>
+                                                <td class="text-right">
+                                                    <knockout data-bind="text: `${$data.stepEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-left text-nowrap">Attack Efficiency:</td>
+                                                <td class="text-right">
+                                                    <knockout data-bind="text: `${$data.attackEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="2" class="text-center table-secondary">Unlock Requirement</td>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="2" class="text-center p-2 h-100 align-middle" data-bind="text: $data.unlockRequirement.hint()"></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /ko -->
                     </div>
 
 

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -48,7 +48,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                 </div>
             </div>
             <div class="modal-body p-0">
-                <div class="tab-content p-3 h-100">
+                <div class="tab-content p-2 h-100">
                     <!-- ko let: { categoryModeEnabled: PokemonCategories.categoryAssignEnabled, categoryModeSelected: PokemonCategories.categoryAssignSelected } -->
                     <div class="tab-pane fade in active show" id="breeding-pokemon">
                         <div class="row">
@@ -456,10 +456,10 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                     <div class="tab-pane fade" id="breeding-helpers">
                         <!-- ko if: HatcheryHelpers.list.some(f => f.isUnlocked()) -->
                         <div class="row m-0 justify-content-center" data-bind="foreach: App.game.breeding.hatcheryHelpers.available()" style="max-width: 100%;">
-                            <div class="card text-left col-md-3 col-sm-6 col-xs-12 p-0">
-                                <h5 class="card-header">
-                                    <knockout data-bind="text: $data.name">Name</knockout>
-                                    <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                            <div class="card text-left col-lg-3 col-md-6 col-xs-12 border-0 p-1">
+                                <h5 class="card-header d-flex align-items-center py-2">
+                                    <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                    <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                                 </h5>
                                 <div class="card-body p-0">
                                     <table class="table table-striped table-hover table-bordered table-sm m-0" style="overflow: visible;">
@@ -585,14 +585,14 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                         </div>
                         <!-- /ko -->
                         <!-- ko if: HatcheryHelpers.list.some(f => !f.isUnlocked()) -->
-                        <div class="bg-primary text-left rounded-0 px-3 py-2 mt-3">
+                        <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2 mb-1 mx-1">
                             <h5 class="m-0 text-light">Locked Helpers</h5>
                         </div>
                         <div class="row m-0 justify-content-center" data-bind="foreach: HatcheryHelpers.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
-                            <div class="card text-left col-md-3 col-sm-6 col-xs-12 p-0 mt-1">
-                                <h5 class="card-header">
-                                    <knockout data-bind="text: $data.name">Name</knockout>
-                                    <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                            <div class="card text-left col-lg-3 col-md-6 col-xs-12 border-0 p-1">
+                                <h5 class="card-header d-flex align-items-center py-2">
+                                    <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                    <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                                 </h5>
                                 <div class="card-body p-0">
                                     <table class="table table-bordered table-sm m-0 h-100" style="overflow: visible;">

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -454,7 +454,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                     </div>
 
                     <div class="tab-pane fade" id="breeding-helpers">
-                        <div class="bg-primary text-left rounded-0 px-3 py-2 mb-1">
+                        <div class="bg-primary text-left rounded-0 px-3 py-2 mb-1" data-bind="visible: HatcheryHelpers.list.some(f => !f.isUnlocked())">
                             <h5 class="m-0 text-light">Available Helpers</h5>
                         </div>
                         <div class="row m-0 justify-content-center" data-bind="foreach: App.game.breeding.hatcheryHelpers.available()" style="max-width: 100%;">
@@ -586,11 +586,11 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                             </div>
                         </div>
 
-                        <!-- ko with: HatcheryHelpers.list.filter(f => !f.isUnlocked()), as: 'lockedHelpers' -->
+                        <!-- ko if: HatcheryHelpers.list.some(f => !f.isUnlocked()) -->
                         <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2">
                             <h5 class="m-0 text-light">Locked Helpers</h5>
                         </div>
-                        <div class="row m-0 justify-content-center" data-bind="foreach: lockedHelpers" style="max-width: 100%;">
+                        <div class="row m-0 justify-content-center" data-bind="foreach: HatcheryHelpers.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
                             <div class="card text-left col-md-3 col-sm-6 col-xs-12 p-0 mt-1">
                                 <h5 class="card-header">
                                     <knockout data-bind="text: $data.name">Name</knockout>

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -585,42 +585,44 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                         </div>
                         <!-- /ko -->
                         <!-- ko if: HatcheryHelpers.list.some(f => !f.isUnlocked()) -->
-                        <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2 mb-1 mx-1">
-                            <h5 class="m-0 text-light">Locked Helpers</h5>
+                        <div class="mt-1 px-1">
+                            <button class="btn btn-secondary btn-block" data-toggle="collapse" href="#lockedHatcheryHelpers">Show/Hide Locked Hatchery Helpers</button>
                         </div>
-                        <div class="row m-0 justify-content-center" data-bind="foreach: HatcheryHelpers.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
-                            <div class="card text-left col-lg-3 col-md-6 col-xs-12 border-0 p-1">
-                                <h5 class="card-header d-flex align-items-center py-2">
-                                    <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
-                                    <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
-                                </h5>
-                                <div class="card-body p-0">
-                                    <table class="table table-bordered table-sm m-0 h-100" style="overflow: visible;">
-                                        <tbody>
-                                            <tr>
-                                                <td class="text-left align-middle">Cost / Hatch:</td>
-                                                <td class="text-right" data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.cost.amount, 'currency': $data.cost.currency, 'reducedThreshold': 1e10}}"></td>
-                                            </tr>
-                                            <tr>
-                                                <td class="text-left">Step Efficiency:</td>
-                                                <td class="text-right">
-                                                    <knockout data-bind="text: `${$data.stepEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td class="text-left text-nowrap">Attack Efficiency:</td>
-                                                <td class="text-right">
-                                                    <knockout data-bind="text: `${$data.attackEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td colspan="2" class="text-center table-secondary">Unlock Requirement</td>
-                                            </tr>
-                                            <tr>
-                                                <td colspan="2" class="text-center p-2 h-100 align-middle" data-bind="text: $data.unlockRequirement.hint()"></td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
+                        <div class="collapse mt-1" id="lockedHatcheryHelpers">
+                            <div class="row m-0 justify-content-center" data-bind="foreach: HatcheryHelpers.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
+                                <div class="card text-left col-lg-3 col-md-6 col-xs-12 border-0 p-1">
+                                    <h5 class="card-header d-flex align-items-center py-2">
+                                        <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                        <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                                    </h5>
+                                    <div class="card-body p-0">
+                                        <table class="table table-bordered table-sm m-0 h-100" style="overflow: visible;">
+                                            <tbody>
+                                                <tr>
+                                                    <td class="text-left align-middle">Cost / Hatch:</td>
+                                                    <td class="text-right" data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.cost.amount, 'currency': $data.cost.currency, 'reducedThreshold': 1e10}}"></td>
+                                                </tr>
+                                                <tr>
+                                                    <td class="text-left">Step Efficiency:</td>
+                                                    <td class="text-right">
+                                                        <knockout data-bind="text: `${$data.stepEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td class="text-left text-nowrap">Attack Efficiency:</td>
+                                                    <td class="text-right">
+                                                        <knockout data-bind="text: `${$data.attackEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td colspan="2" class="text-center table-secondary">Unlock Requirement</td>
+                                                </tr>
+                                                <tr>
+                                                    <td colspan="2" class="text-center p-2 h-100 align-middle" data-bind="text: $data.unlockRequirement.hint()"></td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/src/components/dungeonGuidesModal.html
+++ b/src/components/dungeonGuidesModal.html
@@ -55,6 +55,49 @@
                                 </div>
                             </div>
                         </div>
+                        <!-- ko if: DungeonGuides.list.some(g => !g.isUnlocked()) -->
+                        <div class="px-2 mt-1 mb-2">
+                            <button class="btn btn-secondary btn-block" data-toggle="collapse" href="#lockedDungeonGuides">Show/Hide Locked Dungeon Guides</button>
+                        </div>
+                        <div class="collapse" id="lockedDungeonGuides">
+                            <div class="row m-0 justify-content-center d-flex px-1" data-bind="foreach: DungeonGuides.list.filter(g => !g.isUnlocked())" style="max-width: 100%;">
+                                <div class="card text-left col-lg-6 col-md-12 p-1 border-0 align-items-stretch">
+                                    <h5 class="card-header d-flex align-items-center py-2">
+                                        <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                        <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                                    </h5>
+                                    <div class="card-body p-0 text-center small">
+                                        <table class="table table-bordered table-sm h-100 mb-0">
+                                            <tbody>
+                                                <tr>
+                                                    <td colspan="2" class="align-middle h-100" data-bind="html: $data.description">Description</td>
+                                                </tr>
+                                                <tr>
+                                                    <td class="w-50 table-secondary" style="height: 1px;">Movement Speed</td>
+                                                    <td class="table-secondary">Currencies</td>
+                                                </tr>
+                                                <tr>
+                                                    <td class="align-middle" data-bind="text: `${($data.interval / 1000).toLocaleString('en-US')} seconds`"></td>
+                                                    <td class="align-middle" data-bind="foreach: $data.calcCost(1, player.town.dungeon.tokenCost, player.region)">
+                                                        <img width="24" src="" data-bind="attr: { src: `assets/images/currency/${GameConstants.Currency[$data.currency]}.svg` }"/>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td colspan="2" class="table-secondary" style="height: 1px;">Unlock Requirement</td>
+                                                </tr>
+                                                <tr>
+                                                    <td colspan="2" class="align-middle" data-bind="text: $data.unlockRequirement?.hint()"></td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="card-footer p-2">
+                                        <butto class="btn btn-block btn-sm btn-primary" href="#dungeonGuidesSubModal" data-toggle="modal" data-bind="click: () => DungeonGuides.selected($data.index)">Hire!</butto>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /ko -->
                         <!-- /ko -->
                     </div>
 

--- a/src/components/dungeonGuidesModal.html
+++ b/src/components/dungeonGuidesModal.html
@@ -7,52 +7,51 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="modal-body text-left p-2">
+            <div class="modal-body text-left p-0">
                 <ul class="nav nav-tabs nav-fill">
                     <li class="nav-item"><a class="nav-link active" href="#dungeonGuidesModalHireTab" data-toggle="tab">Hire</a></li>
                     <li class="nav-item"><a class="nav-link" href="#dungeonGuidesModalHelpTab" data-toggle="tab">Help</a></li>
                 </ul>
-                <div class="tab-content">
+                <div class="tab-content p-0">
                     <!-- Hiring Tab -->
                     <div id="dungeonGuidesModalHireTab" class="tab-pane fade active show">
                         <!-- ko if: player.town instanceof DungeonTown -->
-                        <div class="row m-0 justify-content-center d-flex" data-bind="foreach: DungeonGuides.available()" style="max-width: 100%;">
-                            <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0 align-items-stretch">
-                                <h5 class="card-header">
-                                    <knockout data-bind="text: $data.name">Name</knockout>
-                                    <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                        <div class="row m-0 justify-content-center d-flex p-1" data-bind="foreach: DungeonGuides.available()" style="max-width: 100%;">
+                            <div class="card text-left col-lg-6 col-md-12 p-1 border-0 align-items-stretch">
+                                <h5 class="card-header d-flex align-items-center py-2">
+                                    <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                    <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                                 </h5>
-                                <div class="card-body p-0 text-center">
-                                    <div class="card h-100">
-                                        <div class="card-header p-1">
-                                            Description
-                                        </div>
-                                        <div class="card-body p-1 flex-grow-0" data-bind="html: $data.description">
-                                            Description
-                                        </div>
-                                        <div class="card-header p-1">
-                                            Cost / Run
-                                        </div>
-                                        <div class="card-body p-1 flex-grow-1" data-bind="foreach: $data.calcCost(1, player.town.dungeon.tokenCost, player.region)">
-                                            <knockout class="w-100" data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.amount, 'currency': $data.currency}}">cost</knockout><br/>
-                                        </div>
-                                        <div class="card-header p-1">
-                                            Movement Speed
-                                        </div>
-                                        <div class="card-body p-1 flex-grow-0" data-bind="text: `${($data.interval / 1000).toLocaleString('en-US')} seconds`">
-                                            Speed
-                                        </div>
-                                        <div class="card-header p-1">
-                                            Statistics
-                                        </div>
-                                        <div class="card-body p-1 flex-grow-0">
-                                            <knockout data-bind="text: `Total Attempts: ${App.game.statistics.dungeonGuideAttempts[$data.index]().toLocaleString()}`">Attempts</knockout><br/>
-                                            <knockout data-bind="text: `Total Clears: ${App.game.statistics.dungeonGuideClears[$data.index]().toLocaleString()}`">Clears</knockout>
-                                        </div>
-                                    </div>
+                                <div class="card-body p-0 text-center small">
+                                    <table class="table table-bordered table-sm h-100 mb-0">
+                                        <tbody>
+                                            <tr>
+                                                <td colspan="2" class="align-middle h-100" data-bind="html: $data.description">Description</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="w-50 table-secondary" style="height: 1px;">Movement Speed</td>
+                                                <td class="table-secondary">Cost / Run</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="align-middle" data-bind="text: `${($data.interval / 1000).toLocaleString('en-US')} seconds`"></td>
+                                                <td rowspan="3" class="align-middle" data-bind="foreach: $data.calcCost(1, player.town.dungeon.tokenCost, player.region)">
+                                                    <knockout class="w-100 currency-template" data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.amount, 'currency': $data.currency}}">cost</knockout><br/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td class="table-secondary" style="height: 1px;">Statistics</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="align-middle">
+                                                    <knockout data-bind="text: `Total Attempts: ${App.game.statistics.dungeonGuideAttempts[$data.index]().toLocaleString()}`">Attempts</knockout><br/>
+                                                    <knockout data-bind="text: `Total Clears: ${App.game.statistics.dungeonGuideClears[$data.index]().toLocaleString()}`">Clears</knockout>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
                                 </div>
-                                <div class="card-footer">
-                                    <butto class="btn btn-block btn-primary" href="#dungeonGuidesSubModal" data-toggle="modal" data-bind="click: () => DungeonGuides.selected($data.index)">Hire!</butto>
+                                <div class="card-footer p-2">
+                                    <butto class="btn btn-block btn-sm btn-primary" href="#dungeonGuidesSubModal" data-toggle="modal" data-bind="click: () => DungeonGuides.selected($data.index)">Hire!</butto>
                                 </div>
                             </div>
                         </div>
@@ -83,31 +82,39 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="modal-body text-left p-2">
+            <div class="modal-body text-left p-0">
                 <!-- ko if: player.town instanceof DungeonTown -->
-                <table class="table table-striped table-hover m-0 text-center">
+                <table class="table m-0 text-center">
                     <tbody>
                         <tr>
-                            <td>Dungeon Attempts</td>
+                            <td class="table-secondary border-top-0 p-2">Dungeon Attempts</td>
                         </tr>
                         <tr>
-                            <td class="p-0">
+                            <td class="p-2">
                                 <input type="number" class="form-control" min="1" step="1" data-bind="value: DungeonGuides.clears"/>
                             </td>
                         </tr>
                         <tr>
-                            <td>Guide Cost</td>
+                            <td class="table-secondary p-2">Guide Cost</td>
                         </tr>
                         <tr>
-                            <td data-bind="foreach: DungeonGuides.calcCost()">
+                            <td class="p-2" data-bind="foreach: DungeonGuides.calcCost()">
                                 <knockout data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.amount, 'currency': $data.currency}}"></knockout><br/>
                             </td>
                         </tr>
                         <tr>
-                            <td>Dungeon Cost</td>
+                            <td class="table-secondary p-2">Dungeon Entry Cost</td>
                         </tr>
-                        <tr data-bind="with: DungeonGuides.calcDungeonCost()">
+                        <tr class="p-2" data-bind="with: DungeonGuides.calcDungeonCost()">
                             <td data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.amount, 'currency': $data.currency}}"></td>
+                        </tr>
+                        <tr>
+                            <td class="table-secondary p-2">Total Cost</td>
+                        </tr>
+                        <tr>
+                            <td class="p-2" data-bind="foreach: DungeonGuides.calcCost(true)">
+                                <knockout data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.amount, 'currency': $data.currency}}"></knockout><br/>
+                            </td>
                         </tr>
                         <tr class="bg-danger">
                             <td>ALL CHARGES NON REFUNDABLE</td>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -471,9 +471,6 @@
 
                 <div id="farmHandsView" class="tab-pane fade">
                     <!-- ko if: FarmHands.list.some(f => f.isUnlocked()) -->
-                    <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2 mb-1" data-bind="visible: FarmHands.list.some(f => !f.isUnlocked())">
-                        <h5 class="m-0 text-light">Available Farm Hands</h5>
-                    </div>
                     <div class="row m-0 justify-content-center" data-bind="foreach: App.game.farming.farmHands.available()" style="max-width: 100%;">
                         <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
                             <h5 class="card-header">

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -567,54 +567,56 @@
                     </div>
                     <!-- /ko -->
                     <!-- ko if: FarmHands.list.some(f => !f.isUnlocked()) -->
-                    <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2 mb-1">
-                        <h5 class="m-0 text-light">Locked Farm Hands</h5>
+                    <div class="my-2">
+                        <button class="btn btn-secondary btn-block" data-toggle="collapse" href="#lockedFarmHands">Show/Hide Locked Farm Hands</button>
                     </div>
-                    <div class="row mx-0 mt-0 mb-1 justify-content-center" data-bind="foreach: FarmHands.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
-                        <div class="card text-left col-lg-4 col-md-6 col-xs-12 p-0">
-                            <h5 class="card-header d-flex align-items-center py-2">
-                                <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
-                                <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
-                            </h5>
-                            <div class="card-body p-0">
-                                <table class="table table-bordered table-sm h-100 m-0">
-                                    <tbody>
-                                        <tr>
-                                            <td class="text-left">Cost:</td>
-                                            <td class="text-right tight"><img alt="Farm Points" src="assets/images/currency/farmPoint.svg" style="height: 24px; width: 24px;">&nbsp;<knockout data-bind="text: `${$data.cost.amount.toLocaleString('en-US')}/hour`">0/hour</knockout></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="text-left">Work Speed:</td>
-                                            <td class="text-right tight" data-bind="text: GameConstants.formatTimeFullLetters($data.workTick / 1000)">01m 00s</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="text-left">Efficiency:</td>
-                                            <td class="text-right tight">
-                                                <div class="progress">
-                                                    <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
-                                                        <span data-bind="text: $data.efficiency.toLocaleString('en-US')">0</span>
+                    <div class="collapse" id="lockedFarmHands">
+                        <div class="row mx-0 mt-0 mb-1 justify-content-center" data-bind="foreach: FarmHands.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
+                            <div class="card text-left col-lg-4 col-md-6 col-xs-12 p-0">
+                                <h5 class="card-header d-flex align-items-center py-2">
+                                    <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                    <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                                </h5>
+                                <div class="card-body p-0">
+                                    <table class="table table-bordered table-sm h-100 m-0">
+                                        <tbody>
+                                            <tr>
+                                                <td class="text-left">Cost:</td>
+                                                <td class="text-right tight"><img alt="Farm Points" src="assets/images/currency/farmPoint.svg" style="height: 24px; width: 24px;">&nbsp;<knockout data-bind="text: `${$data.cost.amount.toLocaleString('en-US')}/hour`">0/hour</knockout></td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-left">Work Speed:</td>
+                                                <td class="text-right tight" data-bind="text: GameConstants.formatTimeFullLetters($data.workTick / 1000)">01m 00s</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-left">Efficiency:</td>
+                                                <td class="text-right tight">
+                                                    <div class="progress">
+                                                        <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
+                                                            <span data-bind="text: $data.efficiency.toLocaleString('en-US')">0</span>
+                                                        </div>
                                                     </div>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="text-left">Max Energy:</td>
-                                            <td class="text-right tight">
-                                                <div class="progress">
-                                                    <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
-                                                        <span data-bind="text: $data.maxEnergy.toLocaleString('en-US')">0</span>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td class="text-left">Max Energy:</td>
+                                                <td class="text-right tight">
+                                                    <div class="progress">
+                                                        <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
+                                                            <span data-bind="text: $data.maxEnergy.toLocaleString('en-US')">0</span>
+                                                        </div>
                                                     </div>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td colspan="2" class="text-center table-secondary">Unlock Requirement</td>
-                                        </tr>
-                                        <tr>
-                                            <td colspan="2" class="text-center p-1 h-100 align-middle" data-bind="text: $data.unlockRequirement.hint()"></td>
-                                        </tr>
-                                    </tbody>
-                                </table>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="2" class="text-center table-secondary">Unlock Requirement</td>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="2" class="text-center p-1 h-100 align-middle" data-bind="text: $data.unlockRequirement.hint()"></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -470,6 +470,10 @@
                 </div>
 
                 <div id="farmHandsView" class="tab-pane fade">
+                    <!-- ko if: FarmHands.list.some(f => f.isUnlocked()) -->
+                    <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2 mb-1" data-bind="visible: FarmHands.list.some(f => !f.isUnlocked())">
+                        <h5 class="m-0 text-light">Available Farm Hands</h5>
+                    </div>
                     <div class="row m-0 justify-content-center" data-bind="foreach: App.game.farming.farmHands.available()" style="max-width: 100%;">
                         <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
                             <h5 class="card-header">
@@ -478,13 +482,6 @@
                             </h5>
                             <div class="card-body p-0">
                                 <table class="table table-striped table-hover table-bordered table-sm m-0">
-                                    <thead>
-                                        <tr>
-                                            <th colspan="2" class="text-center text-light bg-dark">
-                                                <h5 class="m-0">Information</h5>
-                                            </th>
-                                        </tr>
-                                    </thead>
                                     <tbody>
                                         <tr>
                                             <td class="text-left">Cost:</td>
@@ -515,13 +512,6 @@
                                             </td>
                                         </tr>
                                     </tbody>
-                                    <thead>
-                                        <tr>
-                                            <th colspan="2" class="text-center text-light bg-dark">
-                                                <h5 class="m-0">Settings</h5>
-                                            </th>
-                                        </tr>
-                                    </thead>
                                     <tbody>
                                         <tr>
                                             <td class="text-left">Should Harvest:</td>
@@ -578,6 +568,60 @@
                             </div>
                         </div>
                     </div>
+                    <!-- /ko -->
+                    <!-- ko if: FarmHands.list.some(f => !f.isUnlocked()) -->
+                    <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2 mb-1">
+                        <h5 class="m-0 text-light">Locked Farm Hands</h5>
+                    </div>
+                    <div class="row m-0 justify-content-center" data-bind="foreach: FarmHands.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
+                        <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
+                            <h5 class="card-header">
+                                <knockout data-bind="text: $data.name">Name</knockout>
+                                <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                            </h5>
+                            <div class="card-body p-0">
+                                <table class="table table-bordered table-sm h-100 m-0">
+                                    <tbody>
+                                        <tr>
+                                            <td class="text-left">Cost:</td>
+                                            <td class="text-right tight"><img alt="Farm Points" src="assets/images/currency/farmPoint.svg" style="height: 24px; width: 24px;">&nbsp;<knockout data-bind="text: `${$data.cost.amount.toLocaleString('en-US')}/hour`">0/hour</knockout></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left">Work Speed:</td>
+                                            <td class="text-right tight" data-bind="text: GameConstants.formatTimeFullLetters($data.workTick / 1000)">01m 00s</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left">Efficiency:</td>
+                                            <td class="text-right tight">
+                                                <div class="progress">
+                                                    <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + Math.floor(($data.efficiency / $data.maxEfficiency) * 100) + '%' }" aria-valuemin="0" aria-valuemax="50" style="width:0%">
+                                                        <span data-bind="text: $data.efficiency.toLocaleString('en-US')">0</span>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="text-left">Max Energy:</td>
+                                            <td class="text-right tight">
+                                                <div class="progress">
+                                                    <div class="progress-bar bg-primary" role="progressbar" data-bind="attr:{ style: 'width:' + $data.maxEnergy + '%' }" aria-valuemin="0" aria-valuemax="100" style="width:0%">
+                                                        <span data-bind="text: $data.maxEnergy.toLocaleString('en-US')">0</span>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="2" class="text-center table-secondary">Unlock Requirement</td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="2" class="text-center p-1 h-100 align-middle" data-bind="text: $data.unlockRequirement.hint()"></td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- /ko -->
                 </div>
             </div>
 

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -472,10 +472,10 @@
                 <div id="farmHandsView" class="tab-pane fade">
                     <!-- ko if: FarmHands.list.some(f => f.isUnlocked()) -->
                     <div class="row m-0 justify-content-center" data-bind="foreach: App.game.farming.farmHands.available()" style="max-width: 100%;">
-                        <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
-                            <h5 class="card-header">
-                                <knockout data-bind="text: $data.name">Name</knockout>
-                                <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                        <div class="card text-left col-lg-4 col-md-6 col-xs-12 p-0">
+                            <h5 class="card-header d-flex align-items-center py-2">
+                                <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                             </h5>
                             <div class="card-body p-0">
                                 <table class="table table-striped table-hover table-bordered table-sm m-0">
@@ -570,11 +570,11 @@
                     <div class="bg-primary text-left rounded-0 px-3 py-2 mt-2 mb-1">
                         <h5 class="m-0 text-light">Locked Farm Hands</h5>
                     </div>
-                    <div class="row m-0 justify-content-center" data-bind="foreach: FarmHands.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
-                        <div class="card text-left col-md-4 col-sm-6 col-xs-12 p-0">
-                            <h5 class="card-header">
-                                <knockout data-bind="text: $data.name">Name</knockout>
-                                <img class="float-right pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
+                    <div class="row mx-0 mt-0 mb-1 justify-content-center" data-bind="foreach: FarmHands.list.filter(f => !f.isUnlocked())" style="max-width: 100%;">
+                        <div class="card text-left col-lg-4 col-md-6 col-xs-12 p-0">
+                            <h5 class="card-header d-flex align-items-center py-2">
+                                <knockout class="flex-grow-1" data-bind="text: $data.name">Name</knockout>
+                                <img class="pixelated" src="" height="24px" data-bind="attr:{ src: `assets/images/profile/trainer-${$data.trainerSprite}.png` }">
                             </h5>
                             <div class="card-body p-0">
                                 <table class="table table-bordered table-sm h-100 m-0">

--- a/src/modules/requirements/BerriesUnlockedRequirement.ts
+++ b/src/modules/requirements/BerriesUnlockedRequirement.ts
@@ -11,6 +11,6 @@ export default class BerriesUnlockedRequirement extends AchievementRequirement {
     }
 
     public hint(): string {
-        return `${this.requiredValue} different Berry types need to be unlocked.`;
+        return `Have ${this.requiredValue} different Berry types unlocked.`;
     }
 }

--- a/src/modules/requirements/HatchRequirement.ts
+++ b/src/modules/requirements/HatchRequirement.ts
@@ -11,6 +11,6 @@ export default class HatchRequirement extends AchievementRequirement {
     }
 
     public hint(): string {
-        return `${this.requiredValue} eggs need to be hatched.`;
+        return `Hatch ${this.requiredValue.toLocaleString('en-US')} eggs.`;
     }
 }

--- a/src/modules/requirements/QuestRequirement.ts
+++ b/src/modules/requirements/QuestRequirement.ts
@@ -11,6 +11,6 @@ export default class QuestRequirement extends AchievementRequirement {
     }
 
     public hint(): string {
-        return `${this.requiredValue} Quests need to be completed.`;
+        return `Complete ${this.requiredValue.toLocaleString('en-US')} quests.`;
     }
 }

--- a/src/modules/requirements/UndergroundLayersMinedRequirement.ts
+++ b/src/modules/requirements/UndergroundLayersMinedRequirement.ts
@@ -12,6 +12,6 @@ export default class UndergroundLayersMinedRequirement extends AchievementRequir
 
     public hint(): string {
         const suffix = (this.requiredValue > 1) ? 's' : '';
-        return `${this.requiredValue} layer${suffix} need to be mined in the Underground.`;
+        return `Mine ${this.requiredValue.toLocaleString('en-US')} layer${suffix} in the Underground.`;
     }
 }

--- a/src/modules/requirements/UniqueItemOwnedRequirement.ts
+++ b/src/modules/requirements/UniqueItemOwnedRequirement.ts
@@ -3,11 +3,11 @@ import { ItemList } from '../items/ItemList';
 import ItemOwnedRequirement from './ItemOwnedRequirement';
 
 export default class UniqueItemOwnedRequirement extends ItemOwnedRequirement {
-    constructor(public itemName: string, private obtainText?: string) {
+    constructor(public itemName: string, private obtainText?: string, private unlockHint?: string) {
         super(itemName, 1, AchievementOption.more);
     }
 
     public hint(): string {
-        return `You must ${this.obtainText ?? 'obtain'} ${ItemList[this.itemName].displayName} first.`;
+        return this.unlockHint ?? `You must ${this.obtainText ?? 'obtain'} ${ItemList[this.itemName].displayName} first.`;
     }
 }

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -268,13 +268,13 @@ class HatcheryHelpers {
 // Note: Mostly Gender-neutral names used as the trainer sprite is (seeded) randomly generated, or check the sprite
 HatcheryHelpers.add(new HatcheryHelper('Sam', new Amount(1000, GameConstants.Currency.money), 10, 10, new HatchRequirement(100)));
 HatcheryHelpers.add(new HatcheryHelper('Blake', new Amount(10000, GameConstants.Currency.money), 10, 20, new HatchRequirement(500)));
-HatcheryHelpers.add(new HatcheryHelper('Jasmine', new Amount(50000, GameConstants.Currency.money), 15, 50, new UniqueItemOwnedRequirement('HatcheryHelperJasmine', 'purchase')));
-HatcheryHelpers.add(new HatcheryHelper('Leslie', new Amount(777777, GameConstants.Currency.money), 150, 50, new UniqueItemOwnedRequirement('HatcheryHelperLeslie', 'purchase')));
+HatcheryHelpers.add(new HatcheryHelper('Jasmine', new Amount(50000, GameConstants.Currency.money), 15, 50, new UniqueItemOwnedRequirement('HatcheryHelperJasmine', 'purchase', 'Purchased in the Hoenn region.')));
+HatcheryHelpers.add(new HatcheryHelper('Leslie', new Amount(777777, GameConstants.Currency.money), 150, 50, new UniqueItemOwnedRequirement('HatcheryHelperLeslie', 'purchase', 'Obtain and redeem a code from the PokéClicker Discord server.')));
 HatcheryHelpers.add(new HatcheryHelper('Parker', new Amount(1000, GameConstants.Currency.dungeonToken), 15, 25, new HatchRequirement(1000)));
-HatcheryHelpers.add(new HatcheryHelper('Dakota', new Amount(10000, GameConstants.Currency.dungeonToken), 50, 50, new UniqueItemOwnedRequirement('HatcheryHelperDakota', 'purchase')));
-HatcheryHelpers.add(new HatcheryHelper('Cameron', new Amount(75, GameConstants.Currency.farmPoint), 75, 75, new UniqueItemOwnedRequirement('HatcheryHelperCameron', 'purchase')));
+HatcheryHelpers.add(new HatcheryHelper('Dakota', new Amount(10000, GameConstants.Currency.dungeonToken), 50, 50, new UniqueItemOwnedRequirement('HatcheryHelperDakota', 'purchase', 'Purchased in the Johto region.')));
+HatcheryHelpers.add(new HatcheryHelper('Cameron', new Amount(75, GameConstants.Currency.farmPoint), 75, 75, new UniqueItemOwnedRequirement('HatcheryHelperCameron', 'purchase', 'Purchased in the Hoenn region.')));
 HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(10, GameConstants.Currency.questPoint), 100, 50, new QuestRequirement(200)));
-HatcheryHelpers.add(new HatcheryHelper('Carey', new Amount(20, GameConstants.Currency.questPoint), 50, 125, new UniqueItemOwnedRequirement('HatcheryHelperCarey', 'purchase')));
+HatcheryHelpers.add(new HatcheryHelper('Carey', new Amount(20, GameConstants.Currency.questPoint), 50, 125, new UniqueItemOwnedRequirement('HatcheryHelperCarey', 'purchase', 'Purchased in the Hoenn region.')));
 HatcheryHelpers.add(new HatcheryHelper('Aiden', new Amount(20, GameConstants.Currency.diamond), 100, 100, new UndergroundLayersMinedRequirement(100)));
-HatcheryHelpers.add(new HatcheryHelper('Kris', new Amount(40, GameConstants.Currency.diamond), 100, 150, new UniqueItemOwnedRequirement('HatcheryHelperKris', 'purchase')));
-HatcheryHelpers.add(new HatcheryHelper('Noel', new Amount(25, GameConstants.Currency.battlePoint), 100, 200, new UniqueItemOwnedRequirement('HatcheryHelperNoel', 'purchase')));
+HatcheryHelpers.add(new HatcheryHelper('Kris', new Amount(40, GameConstants.Currency.diamond), 100, 150, new UniqueItemOwnedRequirement('HatcheryHelperKris', 'purchase', 'Purchased in the Kanto region.')));
+HatcheryHelpers.add(new HatcheryHelper('Noel', new Amount(25, GameConstants.Currency.battlePoint), 100, 200, new UniqueItemOwnedRequirement('HatcheryHelperNoel', 'purchase', 'Purchased in the Hoenn region.')));

--- a/src/scripts/dungeons/DungeonGuides.ts
+++ b/src/scripts/dungeons/DungeonGuides.ts
@@ -63,7 +63,7 @@ class DungeonGuide {
         return this.unlockRequirement?.isCompleted() ?? true;
     }
 
-    calcCost(clears, price, region): Amount[] {
+    calcCost(clears, price, region, includeDungeonCost = false): Amount[] {
         const costs = [];
         let discount = clears ** 0.975;
         discount /= clears;
@@ -75,6 +75,14 @@ class DungeonGuide {
             newCost.amount = Math.round(cost.amount * clears * discount);
             costs.push(new Amount(newCost.amount, newCost.currency));
         });
+        if (includeDungeonCost) {
+            let dtCost = costs.find(c => c.currency === GameConstants.Currency.dungeonToken);
+            if (!dtCost) {
+                dtCost = new Amount(0, GameConstants.Currency.dungeonToken);
+                costs.push(dtCost);
+            }
+            dtCost.amount += price * clears;
+        }
         return costs;
     }
 
@@ -127,8 +135,8 @@ class DungeonGuides {
         this.hired()?.end();
     }
 
-    public static calcCost(): Amount[] {
-        return this.list[this.selected()].calcCost(this.clears(), player.town.dungeon.tokenCost, player.region);
+    public static calcCost(includeDungeonCost = false): Amount[] {
+        return this.list[this.selected()].calcCost(this.clears(), player.town.dungeon.tokenCost, player.region, includeDungeonCost);
     }
 
     public static calcDungeonCost(): Amount {

--- a/src/scripts/farming/FarmHand.ts
+++ b/src/scripts/farming/FarmHand.ts
@@ -399,8 +399,8 @@ FarmHands.add(new FarmHand('Alex', 10, 1, FarmHandSpeeds.Lazy, 1, 1, new Berries
 FarmHands.add(new FarmHand('Logan', 15, 3, FarmHandSpeeds.Slowest, 2, 4, new BerriesUnlockedRequirement(16)));
 FarmHands.add(new FarmHand('Joey', 10, 5, FarmHandSpeeds.Slow, 2, 5, new BerriesUnlockedRequirement(24)));
 FarmHands.add(new FarmHand('Charlie', 30, 10, FarmHandSpeeds.BelowAverage, 7, 6, new BerriesUnlockedRequirement(32)));
-FarmHands.add(new FarmHand('Bailey', 10, 12, FarmHandSpeeds.Average, 7, 7, new UniqueItemOwnedRequirement('FarmHandBailey', 'purchase')));
-FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8, new UniqueItemOwnedRequirement('FarmHandKerry', 'purchase')));
-FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10, new UniqueItemOwnedRequirement('FarmHandRiley', 'purchase')));
-FarmHands.add(new FarmHand('Jamie', 65, 5, FarmHandSpeeds.Faster, 9, 10, new UniqueItemOwnedRequirement('FarmHandJamie', 'purchase')));
+FarmHands.add(new FarmHand('Bailey', 10, 12, FarmHandSpeeds.Average, 7, 7, new UniqueItemOwnedRequirement('FarmHandBailey', 'purchase', 'Purchased in the Johto region.')));
+FarmHands.add(new FarmHand('Kerry', 50, 16, FarmHandSpeeds.AboveAverage, 8, 8, new UniqueItemOwnedRequirement('FarmHandKerry', 'purchase', 'Purchased in the Hoenn region.')));
+FarmHands.add(new FarmHand('Riley', 70, 25, FarmHandSpeeds.Fast, 8, 10, new UniqueItemOwnedRequirement('FarmHandRiley', 'purchase', 'Purchased in the Sinnoh region.')));
+FarmHands.add(new FarmHand('Jamie', 65, 5, FarmHandSpeeds.Faster, 9, 10, new UniqueItemOwnedRequirement('FarmHandJamie', 'purchase', 'Purchased in the Hoenn region.')));
 FarmHands.add(new FarmHand('Jessie', 100, 50, FarmHandSpeeds.Fastest, 10, 12, new BerriesUnlockedRequirement(56)));

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -883,3 +883,9 @@ button.btn-circle {
 .no-emoji-font {
     font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
 }
+
+#dungeonGuidesModal {
+    .card .currency-template span {
+        line-height: 30px;
+    }
+}


### PR DESCRIPTION
## Description
- Locked Helpers/Hands/Guides are now shown in a collapsible section w/ their unlock requirements
- Dungeon Guide UI completely overhauled and now also shows the "Total Cost" (combined guide cost + dungeon entry fee)
- Various size and spacing tweaks

## Motivation and Context
Continued effort to make more information available in-game instead of relying on the wiki, and gives players an idea of what they're working towards.

## How Has This Been Tested?
Checked each section on a file with everything unlocked and a file with some helpers/hands/guides still locked

## Screenshots (optional):
dungeon guide ui:
![image](https://github.com/user-attachments/assets/dcacecc2-d177-4665-9e18-1877be3f7ebe)
dungeon guide hire ui:
![image](https://github.com/user-attachments/assets/87370ec3-70c1-4c9f-a650-3898f02f5a0b)
dungeon guide ui w/ some locked:
![image](https://github.com/user-attachments/assets/e2f106b1-f176-4af2-aaaa-e4999912dfd0)
dungeon guide ui w/ some locked & expanded:
![image](https://github.com/user-attachments/assets/2c180f6c-3b8d-4448-8f6f-cb628d70e67b)
hatchery helper ui:
![image](https://github.com/user-attachments/assets/8080bf2e-de60-4ffa-84f0-383c1b427647)
farm hand ui:
![image](https://github.com/user-attachments/assets/b757eb6a-7fc0-4de2-9a6f-d518a088facb)


## Types of changes
- UI improvement
