### PR TITLE
Berry searching

### DIFF
--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -29,9 +29,21 @@
 
                             <div class="tab-content">
                                 <div id="seeds" class="tab-pane active">
+                                    <div class="input-group input-group-sm mt-1">
+                                        <input type="text" class="form-control" placeholder="Search" data-bind="textInput: FarmController.berryListSearch" />
+                                        <div class="input-group-append">
+                                            <span class="input-group-text justify-content-center" style="min-width: 32px; cursor: pointer;"
+                                                data-bind="visible: FarmController.berryListSearch().length, click: () =>  FarmController.berryListSearch('')">✕</span>
+                                            <span class="input-group-text justify-content-center" style="min-width: 32px;" data-bind="tooltip: {
+                                                title: 'Search for berries by name. Use a space to search for multiple berries.',
+                                                trigger: 'hover',
+                                                placement: 'right',
+                                            }">ⓘ</span>
+                                        </div>
+                                    </div>
                                     <ul id="seedList" class="list-group p-0">
                                         <!-- ko foreach: FarmController.getUnlockedBerryListWithIndex() -->
-                                        <li class="list-group-item list-group-item-action seed-list-item p-2"
+                                        <li class="list-group-item list-group-item-action seed-list-item p-2 d-flex align-items-center"
                                             data-bind="click: function() {
                                                 FarmController.selectedBerry($data);
                                                 FarmController.selectedFarmTool(FarmingTool.Berry);
@@ -40,12 +52,12 @@
                                                 data-bind="attr:{ src: FarmController.getBerryImage($data) },
                                                 css: {'berryLocked': !App.game.farming.unlockedBerries[$data]() }">
                                             <span data-bind="text: App.game.farming.unlockedBerries[$data]() ? BerryType[$data] : '???'"></span>
-                                            <span class="float-right" data-bind="text: App.game.farming.berryList[$data]().toLocaleString('en-US')"></span>
+                                            <span class="flex-grow-1 text-right" data-bind="text: App.game.farming.berryList[$data]().toLocaleString('en-US')"></span>
                                         </li>
                                         <!-- /ko -->
                                     </ul>
 
-                                    <div class="row justify-content-center align-items-center py-1">
+                                    <div class="row justify-content-center align-items-center">
                                         <div class="col-4 pr-0">
                                             <button class="btn btn-block btn-secondary"
                                                 onclick="FarmController.navigateLeft()"
@@ -54,12 +66,12 @@
                                                 <img src="assets/images/arrow.svg" style="transform: scaleX(-1);" height="20">
                                             </button>
                                         </div>
-                                        <div class="col-4" data-bind="text: FarmController.navigateIndex()+1 + '/' + (FarmController.numberOfTabs()+1)"></div>
+                                        <div class="col-4" data-bind="text: FarmController.navigateIndex()+1 + '/' + (FarmController.numberOfTabs())"></div>
                                         <div class="col-4 pl-0">
                                             <button class="btn btn-block btn-secondary"
                                                 onclick="FarmController.navigateRight()"
-                                                data-bind="disable: FarmController.navigateIndex() ===  FarmController.numberOfTabs(),
-                                                    css: { disabled: FarmController.navigateIndex() ===  FarmController.numberOfTabs() }">
+                                                data-bind="disable: FarmController.navigateIndex() === FarmController.numberOfTabs() - 1,
+                                                    css: { disabled: FarmController.navigateIndex() === FarmController.numberOfTabs() - 1 }">
                                                 <img src="assets/images/arrow.svg" height="20">
                                             </button>
                                         </div>
@@ -120,7 +132,7 @@
 
                             <ul id="shovelList" class="list-group">
                                 <!-- ko if: FarmController.berryListVisible() -->
-                                <li class="list-group-item list-group-item-action seed-list-item p-2"
+                                <li class="list-group-item list-group-item-action seed-list-item p-2 mb-1"
                                     data-bind="click: function() {
                                         FarmController.selectedFarmTool(FarmingTool.Shovel);
                                     },
@@ -135,7 +147,7 @@
                             </ul>
                             <ul id="shovelMulch" class="list-group p-0">
                                 <!-- ko ifnot: FarmController.berryListVisible() -->
-                                <li class="list-group-item list-group-item-action seed-list-item p-3"
+                                <li class="list-group-item list-group-item-action seed-list-item p-2"
                                     data-bind="click: function() {
                                         FarmController.selectedFarmTool(FarmingTool.MulchShovel);
                                     },


### PR DESCRIPTION
## Description
Adds a search input to the berry list in the farm modal

## Motivation and Context
QoL

## How Has This Been Tested?
Checked that searching and the paging worked on multiple files of varying farm progression

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/e3a30100-fb1d-4587-a30c-0e83b2f92d05)
![image](https://github.com/user-attachments/assets/d73e8981-73c6-4592-89ad-d9b448d6457f)


## Types of changes
- UI improvement
