### PR TITLE
Vitamin UI improvement to make distributing vitamins less tedious

### DIFF
--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -126,12 +126,16 @@
                                 <td class="text-center align-middle tight" data-bind="text: $data.totalVitaminsUsed().toLocaleString('en-US')"></td>
                                 <!-- ko foreach: GameHelper.enumNumbers(GameConstants.VitaminType) -->
                                 <td class="text-center align-middle tight">
-                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" tabindex="-1" style="line-height: 0.6; font-size: 1rem;"
                                         data-bind="
                                             click: () => { $parent.removeVitamin($data, VitaminController.getMultiplier()) },
                                             class: ($parent.vitaminsUsed[$data]() > 0 && !$parent.breeding ? 'text-success' : 'text-muted')">-</button>
-                                    <knockout class="align-middle d-inline-block" style="width: .875rem;" data-bind="text: $parent.vitaminsUsed[$data]().toLocaleString('en-US')">0</knockout>
-                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" style="line-height: 0.6; font-size: 1rem;"
+
+                                    <knockout class="align-middle d-inline-block border border-secondary rounded" style="width: 2rem; overflow: hidden;" data-bind="text: $parent.vitaminsUsed[$data], event: {
+                                        blur: (data, event) => { $parent.updateVitamin($data, +event.currentTarget.textContent); $parent.vitaminsUsed[$data].notifySubscribers(); window.getSelection().empty(); }
+                                    }" contenteditable="plaintext-only" tabindex="1" onfocus="window.getSelection().selectAllChildren(this)">0</knockout>
+
+                                    <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" tabindex="-1" style="line-height: 0.6; font-size: 1rem;"
                                         data-bind="
                                             click: () => { $parent.useVitamin($data, VitaminController.getMultiplier()) },
                                             class: ($parent.vitaminUsesRemaining() && player.itemList[GameConstants.VitaminType[$data]]() && !$parent.breeding ? 'text-success' : 'text-muted')">+</button>

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -132,7 +132,7 @@
                                             class: ($parent.vitaminsUsed[$data]() > 0 && !$parent.breeding ? 'text-success' : 'text-muted')">-</button>
 
                                     <knockout class="align-middle d-inline-block border border-secondary rounded" style="width: 2rem; overflow: hidden;" data-bind="text: $parent.vitaminsUsed[$data], event: {
-                                        blur: (data, event) => { $parent.updateVitamin($data, +event.currentTarget.textContent); $parent.vitaminsUsed[$data].notifySubscribers(); window.getSelection().empty(); }
+                                        blur: (data, event) => { $parent.setVitaminAmount($data, +event.currentTarget.textContent); $parent.vitaminsUsed[$data].notifySubscribers(); window.getSelection().empty(); }
                                     }" contenteditable="plaintext-only" tabindex="1" onfocus="window.getSelection().selectAllChildren(this)">0</knockout>
 
                                     <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" tabindex="-1" style="line-height: 0.6; font-size: 1rem;"

--- a/src/components/pokemonVitaminExpandedModal.html
+++ b/src/components/pokemonVitaminExpandedModal.html
@@ -133,7 +133,7 @@
 
                                     <knockout class="align-middle d-inline-block border border-secondary rounded" style="width: 2rem; overflow: hidden;" data-bind="text: $parent.vitaminsUsed[$data], event: {
                                         blur: (data, event) => { $parent.setVitaminAmount($data, +event.currentTarget.textContent); $parent.vitaminsUsed[$data].notifySubscribers(); window.getSelection().empty(); }
-                                    }" contenteditable="plaintext-only" tabindex="1" onfocus="window.getSelection().selectAllChildren(this)">0</knockout>
+                                    }, attr: { contenteditable: $parent.breeding ? false : 'plaintext-only' }" tabindex="1" onfocus="window.getSelection().selectAllChildren(this)">0</knockout>
 
                                     <button type="button" class="btn btn-link btn-sm text-decoration-none align-text-top" tabindex="-1" style="line-height: 0.6; font-size: 1rem;"
                                         data-bind="

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -336,23 +336,18 @@ class PartyPokemon implements Saveable {
         GameHelper.incrementObservable(player.itemList[vitaminName], amount);
     }
 
-    public updateVitamin(vitamin: GameConstants.VitaminType, amount: number) {
+    public setVitaminAmount(vitamin: GameConstants.VitaminType, amount: number) {
         if (this.breeding || isNaN(amount) || amount < 0) {
             return;
         }
 
-        const origAmount = this.vitaminsUsed[vitamin]();
-        const usesRemaining = this.vitaminUsesRemaining() + origAmount;
-        amount = Math.min(amount, player.itemList[GameConstants.VitaminType[vitamin]](), usesRemaining);
-
-        if (amount === origAmount) {
+        const diff = amount - this.vitaminsUsed[vitamin]();
+        if (diff === 0) {
             return;
-        }
-
-        if (amount > origAmount) {
-            this.useVitamin(vitamin, amount - origAmount);
-        } else {
-            this.removeVitamin(vitamin, origAmount - amount);
+        } else if (diff > 0) {
+            this.useVitamin(vitamin, diff);
+        } else if (diff < 0) {
+            this.removeVitamin(vitamin, Math.abs(diff));
         }
     }
 

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -341,7 +341,7 @@ class PartyPokemon implements Saveable {
             return;
         }
 
-        const diff = amount - this.vitaminsUsed[vitamin]();
+        const diff = Math.floor(amount) - this.vitaminsUsed[vitamin]();
         if (diff === 0) {
             return;
         } else if (diff > 0) {

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -336,6 +336,26 @@ class PartyPokemon implements Saveable {
         GameHelper.incrementObservable(player.itemList[vitaminName], amount);
     }
 
+    public updateVitamin(vitamin: GameConstants.VitaminType, amount: number) {
+        if (this.breeding || isNaN(amount) || amount < 0) {
+            return;
+        }
+
+        const origAmount = this.vitaminsUsed[vitamin]();
+        const usesRemaining = this.vitaminUsesRemaining() + origAmount;
+        amount = Math.min(amount, player.itemList[GameConstants.VitaminType[vitamin]](), usesRemaining);
+
+        if (amount === origAmount) {
+            return;
+        }
+
+        if (amount > origAmount) {
+            this.useVitamin(vitamin, amount - origAmount);
+        } else {
+            this.removeVitamin(vitamin, origAmount - amount);
+        }
+    }
+
     public useConsumable(type: GameConstants.ConsumableType, amount: number): void {
         const itemName = GameConstants.ConsumableType[type];
         if (!player.itemList[itemName]()) {


### PR DESCRIPTION
## Description
Allows editing the number of vitamins applied to a pokemon directly. Like any normal input the tab key can be used to move to the next field.

`notifySubscribers` is called after the `setVitaminAmount` function to force the UI to update if the amount of vitamins applied differs from the amount entered, or if the amount doesn't change

## Motivation and Context
While I do think vitamins need a rework, this should make it less tedious until then

## How Has This Been Tested?
Adjusted vitamins, tried to enter invalid amounts and verified it handled all scenarios correctly

## Screenshots (optional):
https://github.com/user-attachments/assets/e7111f06-b5af-4947-9cb4-ced659050d33

## Types of changes
- UI improvement
