### PR TITLE
Better hints and various minir fixes

### DIFF
--- a/src/components/KalosSVG.html
+++ b/src/components/KalosSVG.html
@@ -809,7 +809,7 @@
          , width: 4, height: 4
          , databind: "click: () => TemporaryBattleList['Trevor'].protectedOnclick()"
          , visible:  "TemporaryBattleList['Trevor'] && TemporaryBattleList['Trevor'].isVisible()"
-         , image: "assets/images/map/shauna.png"
+         , image: "assets/images/map/trevor.png"
          })
      %>
 

--- a/src/components/KantoSVG.html
+++ b/src/components/KantoSVG.html
@@ -971,7 +971,7 @@
             , x: 72, y: 6
             , width: 16, height: 16
             , databind: "style: {'pointer-events': 'none'}"
-            , visible:  "App.isUsingClient && App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Cinnabar Island')]() >= 1"
+            , visible:  "App.isUsingClient && App.game.badgeCase.hasBadge(BadgeEnums.Volcano)"
             , image: "assets/images/map/client_island.png"
             })
         %>
@@ -981,7 +981,7 @@
             , x: 76, y: 12
             , width: 7, height: 4
             , databind: "click:function(){MapHelper.moveToTown('Client Island')}, attr:{ class: MapHelper.calculateTownCssClass('Client Island') }"
-            , visible:  "App.isUsingClient && App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Cinnabar Island')]() >= 1"
+            , visible:  "App.isUsingClient && App.game.badgeCase.hasBadge(BadgeEnums.Volcano)"
             , image: "assets/images/map/transparent.png"
             , connectedToTown: "Client Island"
             })
@@ -992,7 +992,7 @@
             , x: 77, y: 16
             , width: 5, height: 1
             , databind: "click:function(){MapHelper.moveToTown('Client Island')}, attr:{ class: MapHelper.calculateTownCssClass('Client Island') }"
-            , visible:  "App.isUsingClient && App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Cinnabar Island')]() >= 1"
+            , visible:  "App.isUsingClient && App.game.badgeCase.hasBadge(BadgeEnums.Volcano)"
             , image: "assets/images/map/transparent.png"
             , isExtension: true
             })
@@ -1003,7 +1003,7 @@
             , x: 77, y: 11
             , width: 6, height: 1
             , databind: "click:function(){MapHelper.moveToTown('Client Island')}, attr:{ class: MapHelper.calculateTownCssClass('Client Island') }"
-            , visible:  "App.isUsingClient && App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Cinnabar Island')]() >= 1"
+            , visible:  "App.isUsingClient && App.game.badgeCase.hasBadge(BadgeEnums.Volcano)"
             , image: "assets/images/map/transparent.png"
             , isExtension: true
             })
@@ -1014,7 +1014,7 @@
             , x: 78, y: 10
             , width: 3, height: 1
             , databind: "click:function(){MapHelper.moveToTown('Client Island')}, attr:{ class: MapHelper.calculateTownCssClass('Client Island') }"
-            , visible:  "App.isUsingClient && App.game.statistics.gymsDefeated[GameConstants.getGymIndex('Cinnabar Island')]() >= 1"
+            , visible:  "App.isUsingClient && App.game.badgeCase.hasBadge(BadgeEnums.Volcano)"
             , image: "assets/images/map/transparent.png"
             , isExtension: true
             })

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -191,7 +191,7 @@ ItemList.Pokemon_egg = new EggItem(EggItemType.Pokemon_egg, 1000, undefined, 'Po
 ItemList.Mystery_egg = new EggItem(EggItemType.Mystery_egg, 700, undefined, 'Mystery Egg');
 
 // Quest Items
-ItemList.Meteorite_Bills_Errand = new QuestItem('Meteorite_Bills_Errand', 'Meteorite', 'A Meteorite the Game Corner owner gave you for find his daughter', 'Bill\'s Errand');
+ItemList.Meteorite_Bills_Errand = new QuestItem('Meteorite_Bills_Errand', 'Meteorite for Celio', 'A Meteorite the Game Corner owner gave you for find his daughter', 'Bill\'s Errand');
 ItemList.Tidal_Bell_Lugia = new QuestItem('Tidal_Bell_Lugia', 'Tidal Bell', 'A Bell that can summon the Legendary Pokémon Lugia', 'Whirl Guardian');
 ItemList.Clear_Bell_Hooh = new QuestItem('Clear_Bell_Hooh', 'Clear Bell', 'A Bell that can summon the Legendary Pokémon Ho-oh', 'Rainbow Guardian');
 ItemList.GS_Ball_Celebi = new QuestItem('GS_Ball_Celebi', 'GS Ball', 'A Strange Pokéball that Professor Ivy gave you', 'Unfinished Business');

--- a/src/modules/routes/RouteData.ts
+++ b/src/modules/routes/RouteData.ts
@@ -27,6 +27,7 @@ import SpecialEventRequirement from '../requirements/SpecialEventRequirement';
 import StatisticRequirement from '../requirements/StatisticRequirement';
 import PokemonLevelRequirement from '../requirements/PokemonLevelRequirement';
 import { getPokemonByName } from '../pokemons/PokemonHelper';
+import CustomRequirement from '../requirements/CustomRequirement';
 
 /*
 KANTO
@@ -645,22 +646,23 @@ Routes.add(new RegionRoute(
     }),
     [new RouteKillRequirement(10, Region.johto, 40)],
 ));
+const cuteMeowthReq = new MultiRequirement([
+    new StatisticRequirement(['pokemonHatched', getPokemonByName('Phanpy').id], 1, 'Hatch Phanpy first.'),
+    new OneFromManyRequirement([
+        new PokemonLevelRequirement('Phanpy', 21, AchievementOption.less),
+        new MultiRequirement([
+            new PokemonLevelRequirement('Phanpy', 51, AchievementOption.less),
+            new ClearDungeonRequirement(250, getDungeonIndex('Team Rocket\'s Hideout')),
+        ]),
+    ]),
+]);
 Routes.add(new RegionRoute(
     'Johto Route 42', Region.johto, 42,
     new RoutePokemon({
         land: ['Spearow', 'Zubat', 'Mankey', 'Mareep', 'Flaaffy'],
         water: ['Goldeen', 'Seaking', 'Magikarp'],
         headbutt: ['Aipom', 'Heracross'],
-        special: [new SpecialRoutePokemon(['Meowth (Phanpy)'], new MultiRequirement([
-            new StatisticRequirement(['pokemonHatched', getPokemonByName('Phanpy').id], 1, 'Hatch Phanpy first.'),
-            new OneFromManyRequirement([
-                new PokemonLevelRequirement('Phanpy', 21, AchievementOption.less),
-                new MultiRequirement([
-                    new PokemonLevelRequirement('Phanpy', 51, AchievementOption.less),
-                    new ClearDungeonRequirement(250, getDungeonIndex('Team Rocket\'s Hideout')),
-                ]),
-            ]),
-        ]))],
+        special: [new SpecialRoutePokemon(['Meowth (Phanpy)'], new CustomRequirement(ko.pureComputed(() => cuteMeowthReq.isCompleted()), true, 'Have Phanpy newly hatched and at level below 21, or 51 if you cleared the Team Rocket\'s Hideout 250 times or more.'))],
     }),
     [
         new OneFromManyRequirement([
@@ -4244,29 +4246,30 @@ Routes.getRoutesByRegion(Region.hoenn).forEach(route => {
 });
 
 // Christmas Event
+const santaJynxReq = new OneFromManyRequirement([
+    new MultiRequirement([
+        new ItemOwnedRequirement('Christmas_present', 11, AchievementOption.less),
+        new TemporaryBattleRequirement('Santa Jynx 1'),
+        new SpecialEventRequirement('Merry Christmas!'),
+    ]),
+    new MultiRequirement([
+        new ItemOwnedRequirement('Christmas_present', 27, AchievementOption.less),
+        new TemporaryBattleRequirement('Santa Jynx 2'),
+        new SpecialEventRequirement('Merry Christmas!'),
+    ]),
+    new MultiRequirement([
+        new ItemOwnedRequirement('Christmas_present', 49, AchievementOption.less),
+        new TemporaryBattleRequirement('Santa Jynx 3'),
+        new SpecialEventRequirement('Merry Christmas!'),
+    ]),
+    new MultiRequirement([
+        new ItemOwnedRequirement('Christmas_present', 150, AchievementOption.less),
+        new TemporaryBattleRequirement('Santa Jynx 4'),
+        new SpecialEventRequirement('Merry Christmas!'),
+    ]),
+]);
 Routes.getRoutesByRegion(Region.kanto).forEach(route => {
     route.pokemon.special.push(
-        new SpecialRoutePokemon(['Santa Jynx'], new OneFromManyRequirement([
-            new MultiRequirement([
-                new ItemOwnedRequirement('Christmas_present', 11, AchievementOption.less),
-                new TemporaryBattleRequirement('Santa Jynx 1'),
-                new SpecialEventRequirement('Merry Christmas!'),
-            ]),
-            new MultiRequirement([
-                new ItemOwnedRequirement('Christmas_present', 27, AchievementOption.less),
-                new TemporaryBattleRequirement('Santa Jynx 2'),
-                new SpecialEventRequirement('Merry Christmas!'),
-            ]),
-            new MultiRequirement([
-                new ItemOwnedRequirement('Christmas_present', 49, AchievementOption.less),
-                new TemporaryBattleRequirement('Santa Jynx 3'),
-                new SpecialEventRequirement('Merry Christmas!'),
-            ]),
-            new MultiRequirement([
-                new ItemOwnedRequirement('Christmas_present', 150, AchievementOption.less),
-                new TemporaryBattleRequirement('Santa Jynx 4'),
-                new SpecialEventRequirement('Merry Christmas!'),
-            ]),
-        ])),
+        new SpecialRoutePokemon(['Santa Jynx'], new CustomRequirement(ko.pureComputed(() => santaJynxReq.isCompleted()), true, 'During Merry Christmas! event, Santa Jynx appears for the day once its band is defeated at Bill\'s House and until too many Christmas presents have been collected.')),
     );
 });

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -7816,7 +7816,7 @@ dungeonList['Fullmoon Island'] = new Dungeon('Fullmoon Island',
             new CustomRequirement(
                 ko.pureComputed(() => cresseliaDungeonMoonReq.isCompleted()),
                 true,
-                'Cresselia lives on the island aroud New Moon, and roams Sinnoh during other moon phases.'
+                'Cresselia lives on the island around New Moon, and roams Sinnoh during other moon phases.'
             ),
         ])}),
     ],

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1896,6 +1896,7 @@ dungeonList['Altering Cave'] = new Dungeon('Altering Cave',
 
 // All Unown except "EFHP"
 const TanobyUnownList = 'ABCDGIJKLMNOQRSTUVWXYZ!?'.split('');
+const UnownHint = 'Unown appear at random everyday one at a time. An additional Unown will spawn after 100 and 250 clears of the ruins.';
 
 dungeonList['Tanoby Ruins'] = new Dungeon('Tanoby Ruins',
     [
@@ -1927,14 +1928,17 @@ dungeonList['Tanoby Ruins'] = new Dungeon('Tanoby Ruins',
     },
     720600,
     [
-        ...TanobyUnownList.map((char, index) => new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 4100000, 30, {
-            hide: true,
-            requirement: new OneFromManyRequirement([
+        ...TanobyUnownList.map((char, index) => {
+            const req = new OneFromManyRequirement([
                 new SeededDateSelectNRequirement(index, TanobyUnownList.length, 1),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, TanobyUnownList.length, 2), new ClearDungeonRequirement(100, GameConstants.getDungeonIndex('Tanoby Ruins'))]),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, TanobyUnownList.length, 3), new ClearDungeonRequirement(250, GameConstants.getDungeonIndex('Tanoby Ruins'))]),
-            ]),
-        })),
+            ]);
+            return new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 4100000, 30, {
+                hide: true,
+                requirement: new CustomRequirement(ko.pureComputed(() => req.isCompleted()), true, UnownHint),
+            });
+        }),
     ],
     43000, 39,
     () => {},
@@ -2089,14 +2093,17 @@ dungeonList['Ruins of Alph'] = new Dungeon('Ruins of Alph',
     },
     60600,
     [
-        ...AlphUnownList.map((char, index) => new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 280000, 14, {
-            hide: true,
-            requirement: new OneFromManyRequirement([
+        ...AlphUnownList.map((char, index) => {
+            const req = new OneFromManyRequirement([
                 new SeededDateSelectNRequirement(index, AlphUnownList.length, 1),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, AlphUnownList.length, 2), new ClearDungeonRequirement(100, GameConstants.getDungeonIndex('Ruins of Alph'))]),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, AlphUnownList.length, 3), new ClearDungeonRequirement(250, GameConstants.getDungeonIndex('Ruins of Alph'))]),
-            ]),
-        })),
+            ]);
+            return new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 280000, 14, {
+                hide: true,
+                requirement: new CustomRequirement(ko.pureComputed(() => req.isCompleted()), true, UnownHint),
+            });
+        }),
         new DungeonBossPokemon('Togepi (Flowering Crown)', 2700000, 23, {
             requirement: new MultiRequirement([
                 new PokemonDefeatedSelectNRequirement('Togepi (Flowering Crown)', 0, 6, 1),
@@ -7075,14 +7082,17 @@ dungeonList['Solaceon Ruins'] = new Dungeon('Solaceon Ruins',
     },
     960000,
     [
-        ...SolaceonUnownList.map((char, index) => new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 4100000, 30, {
-            hide: true,
-            requirement: new OneFromManyRequirement([
+        ...SolaceonUnownList.map((char, index) => {
+            const req = new OneFromManyRequirement([
                 new SeededDateSelectNRequirement(index, SolaceonUnownList.length, 1),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, SolaceonUnownList.length, 2), new ClearDungeonRequirement(100, GameConstants.getDungeonIndex('Solaceon Ruins'))]),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, SolaceonUnownList.length, 3), new ClearDungeonRequirement(250, GameConstants.getDungeonIndex('Solaceon Ruins'))]),
-            ]),
-        })),
+            ]);
+            return new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 4100000, 30, {
+                hide: true,
+                requirement: new CustomRequirement(ko.pureComputed(() => req.isCompleted()), true, UnownHint),
+            });
+        }),
     ],
     62500, 209);
 
@@ -7781,6 +7791,9 @@ dungeonList['Hall of Origin'] = new Dungeon('Hall of Origin',
     ],
     106500, 230);
 
+const cresseliaDungeonMoonReq = new MoonCyclePhaseRequirement([MoonCyclePhase.NewMoon, MoonCyclePhase.WaxingCrescent, MoonCyclePhase.WaningCrescent]);
+const darkraiDungeonMoonReq = new MoonCyclePhaseRequirement([MoonCyclePhase.FullMoon, MoonCyclePhase.WaxingGibbous, MoonCyclePhase.WaningGibbous, MoonCyclePhase.FirstQuarter, MoonCyclePhase.ThirdQuarter]);
+
 dungeonList['Fullmoon Island'] = new Dungeon('Fullmoon Island',
     ['Illumise', 'Minun', 'Hypno', 'Luvdisc'],
     {
@@ -7798,7 +7811,14 @@ dungeonList['Fullmoon Island'] = new Dungeon('Fullmoon Island',
     [
         new DungeonBossPokemon('Lunatone', 11000000, 100),
         new DungeonBossPokemon('Clefable', 11000000, 100),
-        new DungeonBossPokemon('Cresselia', 11000000, 100, {requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.NewMoon, MoonCyclePhase.WaxingCrescent, MoonCyclePhase.WaningCrescent])}),
+        new DungeonBossPokemon('Cresselia', 11000000, 100, {requirement: new MultiRequirement([
+            new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Fullmoon Island')),
+            new CustomRequirement(
+                ko.pureComputed(() => cresseliaDungeonMoonReq.isCompleted()),
+                true,
+                'Cresselia lives on the island aroud New Moon, and roams Sinnoh during other moon phases.'
+            ),
+        ])}),
     ],
     96500, 230);
 
@@ -7820,7 +7840,13 @@ dungeonList['Newmoon Island'] = new Dungeon('Newmoon Island',
     [
         new DungeonBossPokemon('Lunatone', 9900000, 100),
         new DungeonBossPokemon('Absol', 9900000, 100),
-        new DungeonBossPokemon('Darkrai', 11000000, 100, {requirement: new MoonCyclePhaseRequirement([MoonCyclePhase.FullMoon, MoonCyclePhase.WaxingGibbous, MoonCyclePhase.WaningGibbous, MoonCyclePhase.FirstQuarter, MoonCyclePhase.ThirdQuarter])}),
+        new DungeonBossPokemon('Darkrai', 11000000, 100, {requirement: new MultiRequirement([
+            new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Newmoon Island')),
+            new CustomRequirement(
+                ko.pureComputed(() => darkraiDungeonMoonReq.isCompleted()),
+                true,
+                'Darkrai roams Sinnoh around New Moon, and live on the island during other moon phases.'),
+        ])}),
     ],
     96500, 230);
 
@@ -13329,14 +13355,17 @@ dungeonList['Ancient Solaceon Ruins'] = new Dungeon('Ancient Solaceon Ruins',
     },
     960000,
     [
-        ...AncientSolaceonUnownList.map((char, index) => new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 4100000, 30, {
-            hide: true,
-            requirement: new OneFromManyRequirement([
+        ...AncientSolaceonUnownList.map((char, index) => {
+            const req = new OneFromManyRequirement([
                 new SeededDateSelectNRequirement(index, AncientSolaceonUnownList.length, 1),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, AncientSolaceonUnownList.length, 2), new ClearDungeonRequirement(100, GameConstants.getDungeonIndex('Ancient Solaceon Ruins'))]),
                 new MultiRequirement([new SeededDateSelectNRequirement(index, AncientSolaceonUnownList.length, 3), new ClearDungeonRequirement(250, GameConstants.getDungeonIndex('Ancient Solaceon Ruins'))]),
-            ]),
-        })),
+            ]);
+            return new DungeonBossPokemon(`Unown (${char})` as PokemonNameType, 4100000, 30, {
+                hide: true,
+                requirement: new CustomRequirement(ko.pureComputed(() => req.isCompleted()), true, UnownHint),
+            });
+        }),
     ],
     96500, 13);
 

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -2538,7 +2538,7 @@ const CoolTrainerDillan = new NPC('Cool Trainer Dillan', [
 
 const EasterEggHunter = new NPC('Egg Hunter', [
     'My eggs! They ran away!',
-    'Can you help me get them back? They have most likely fleed to a dungeon in Kanto, Hoenn or Johto.',
+    'Can you help me get them back? They have most likely fled to a dungeon in Kanto, Hoenn or Johto.',
     'But be careful! If you defeat them, they will run away again!',
 ], {
     image: 'assets/images/npcs/Egg Hunter.png',


### PR DESCRIPTION
## Description
Darkrai / Cresselia hints describes their cycle instead of just stating about the dungeon part. Unown hint does not sound like a James Bond movie advertising (Wiki), Meowth (Phanpy) and Santa Jynx now have human-like written hints for the Wiki.
Changed Client island binding to Volcano badge instead of Cinnabar Island gym.
Fixed Trevor using Shaina OW sprite. Fixed typo in Egg Hunt NPC dialogs.

## Motivation and Context
Game better.

## How Has This Been Tested?
Read the hints, ensured the requirements were still working. Magically made Client Island appear and disappear.

## Types of changes
- Bug fix
- UI improvement
