### PR TITLE
Remove old single vitamin modal

### DIFF
--- a/src/components/itemModal.html
+++ b/src/components/itemModal.html
@@ -138,13 +138,10 @@
                                     <div class="col-6 col-lg-3 mb-2">
                                         <div class="btn btn-secondary text-left w-100 px-1" style="padding-top: 1px; padding-bottom: 2px;"
                                             data-bind="template: { name: 'otherItemTemplate', data: GameConstants.VitaminType[$data]},
-                                                click: () => { VitaminController.currentlySelected($data); $('#pokemonVitaminModal').modal('show'); }">
+                                                click: () => { VitaminController.currentlySelected($data); $('#pokemonVitaminExpandedModal').modal('show'); }">
                                         </div>
                                     </div>
                                     <!-- /ko -->
-                                </div>
-                                <div class="row justify-content-center mb-1">
-                                    <button type="button" class="btn btn-secondary btn-sm" data-bind="click: () => { $('#pokemonVitaminExpandedModal').modal('show') }">All Vitamins</button>
                                 </div>
                             </div>
                         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -550,9 +550,6 @@
 <!-- Statistics Modal-->
 @import "pokemonStatisticsModal.html"
 
-<!-- Vitamin Modal-->
-@import "pokemonVitaminModal.html"
-
 <!-- Expanded Vitamin Modal -->
 @import "pokemonVitaminExpandedModal.html"
 

--- a/src/scripts/party/PartyController.ts
+++ b/src/scripts/party/PartyController.ts
@@ -156,7 +156,7 @@ class PartyController {
     private static vitaminSortedList = [];
     static getVitaminSortedList = ko.pureComputed(() => {
         // If the vitamin modal is open, we should sort it.
-        if (DisplayObservables.modalState.pokemonVitaminModal === 'show' || DisplayObservables.modalState.pokemonVitaminExpandedModal === 'show') {
+        if (DisplayObservables.modalState.pokemonVitaminExpandedModal === 'show') {
             PartyController.vitaminSortedList = PartyController.getVitaminFilteredList();
             return PartyController.vitaminSortedList.sort(PartyController.compareBy(Settings.getSetting('vitaminSort').observableValue(), Settings.getSetting('vitaminSortDirection').observableValue()));
         }


### PR DESCRIPTION
## Description
Removes the old single vitamin modal in favor of the expanded all-in-one vitamin modal. I removed the import for pokemonVitaminModal.html but left the file.

## How Has This Been Tested?
Clicked each vitamin and verified the expanded modal opened
