### PR TITLE
Fix Red fight during An Unrivaled Power

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2852,6 +2852,12 @@ class Update implements Saveable {
             // Reset the Sprinklotad
             saveData.oakItems[OakItemType[OakItemType.Sprinklotad]].level = 0;
             saveData.oakItems[OakItemType[OakItemType.Sprinklotad]].exp = 0;
+
+            // Resets An Unrivaled Power Red tempbattle if needed
+            const megaMewtwoQl = saveData.quests.questLines.find(ql => ql.name === 'An Unrivaled Power');
+            if (megaMewtwoQl && [1, 3].includes(megaMewtwoQl.state) && megaMewtwoQl.quest === 0) {
+                megaMewtwoQl.initial = 0;
+            }
         },
     };
 

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -3761,7 +3761,7 @@ TemporaryBattleList['Unrivaled Red'] = new TemporaryBattle(
         new GymPokemon('Mega Venusaur', 90263333, 85),
     ],
     '... ... ...!',
-    [new QuestLineStartedRequirement('An Unrivaled Power')],
+    [new MultiRequirement([new QuestLineStepCompletedRequirement('An Unrivaled Power', 0, GameConstants.AchievementOption.less), new QuestLineStartedRequirement('An Unrivaled Power')])],
     undefined,
     {
         displayName: 'Pokémon Trainer Red',


### PR DESCRIPTION
## Description
I broke the requirement a few months ago when fixing another softlock... It now only appears when the quest is active.
The update function skips the quest for people who defeated Red while the questline was paused.

## Motivation and Context
Bug bad.

## How Has This Been Tested?
Loaded a file at different steps of the quest line to ensure it was working as expected.

## Types of changes
- Bug fix
