### PR TITLE
Add Turkish Language Option

### DIFF
--- a/src/modules/translation/Language.ts
+++ b/src/modules/translation/Language.ts
@@ -10,6 +10,7 @@ enum Language {
     'zh-Hans' = 'zh-Hans',
     'zh-Hant' = 'zh-Hant',
     'ru' = 'ru',
+    'tr' = 'tr',
 }
 
 export const LanguageNames: Record<Language, string> = {
@@ -23,6 +24,7 @@ export const LanguageNames: Record<Language, string> = {
     'zh-Hans': '简体中文',
     'zh-Hant': '繁體中文',
     'ru': 'Русский',
+    'tr': 'Türkçe',
 };
 
 export default Language;


### PR DESCRIPTION
## Description
@kuroiteiken has added turkish translations to the [translations repo](https://github.com/pokeclicker/pokeclicker-translations), this PR just makes them available in game.


## Motivation and Context
Can't see the turkish translations without this


## How Has This Been Tested?
1. Run the game
2. Switch language setting to Turkish
3. See Turkish words


## Types of changes
- UI improvement
