### PR TITLE
Added XP to Solgaleo (Radiant Sun) and Lunala (Full Moon)

### DIFF
--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -24154,7 +24154,7 @@ export const pokemonList = createPokemonArray(
         'type': [PokemonType.Psychic, PokemonType.Steel],
         'eggCycles': 120,
         'levelType': LevelType.slow,
-        'exp': null,
+        'exp': 306,
         'catchRate': 45,
         'base': {
             'hitpoints': 137,
@@ -24197,7 +24197,7 @@ export const pokemonList = createPokemonArray(
         'type': [PokemonType.Psychic, PokemonType.Ghost],
         'eggCycles': 120,
         'levelType': LevelType.slow,
-        'exp': null,
+        'exp': 306,
         'catchRate': 45,
         'base': {
             'hitpoints': 137,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Solgaleo (Radiant Sun) and Lunala (Full Moon) were the only pokemon that were not giving any XP. Now they give the same XP as their base forms.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
🪄 BF to check, pokemon were not levelling before fix, they are now levelling after fix.

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
