### PR TITLE
Fix rare loading error on older files

### DIFF
--- a/src/scripts/Player.ts
+++ b/src/scripts/Player.ts
@@ -72,7 +72,7 @@ class Player implements TmpPlayerType {
                 if (i != GameConstants.Region.kanto) { // Kanto has it's own starter code
                     if (this.region != i) {
                         this.region = i;
-                        this.subregion = 0;
+                        this._subregion(0);
                         this.route = undefined;
                         this._townName = GameConstants.StartingTowns[i];
                         this.town = TownList[this._townName];


### PR DESCRIPTION
## Description
Fixes a rare error when loading an older file

```
Uncaught (in promise) TypeError: App.game is undefined
    get quest webpack://pokeclicker/./src/modules/requirements/QuestLineStartedRequirement.ts?:14
    getProgress webpack://pokeclicker/./src/modules/requirements/QuestLineStartedRequirement.ts?:23
    isCompleted webpack://pokeclicker/./src/modules/requirements/Requirement.ts?:28
    unlocked webpack://pokeclicker/./src/modules/subRegion/SubRegion.ts?:14
    getSubRegions webpack://pokeclicker/./src/modules/subRegion/SubRegions.ts?:33
    getSubRegions webpack://pokeclicker/./src/modules/subRegion/SubRegions.ts?:33
    set subregion https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:1890
    Player https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:1835
    load https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:2010
    Game https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:822
    start https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:23
    promise callback*start https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:20
    getTrainerCard webpack://pokeclicker/./src/modules/profile/Profile.ts?:62
    getTrainerCard webpack://pokeclicker/./src/modules/profile/Profile.ts?:51
    getTrainerCard webpack://pokeclicker/./src/modules/SaveSelector.ts?:100
    loadSaves webpack://pokeclicker/./src/modules/SaveSelector.ts?:26
    loadSaves webpack://pokeclicker/./src/modules/SaveSelector.ts?:25
    <anonymous> https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:5378
    EventListener.handleEvent* https://www.pokeclicker.com/scripts/script.min.js?v=0.10.23:5367
modules.min.js:14:13
```

Test file: 
[[v0.8.11] PokeClickerSave_2021-12-19 04_15_23.txt](https://github.com/user-attachments/files/20418524/v0.8.11.PokeClickerSave_2021-12-19.04_15_23.txt)

## How Has This Been Tested?
Loaded the file where the error occurs

## Types of changes
- Bug fix
