### PR TITLE
Remove second Alola Ash from Poni Island

### DIFF
--- a/src/components/AlolaSVG.html
+++ b/src/components/AlolaSVG.html
@@ -5147,16 +5147,6 @@
         %>
 
         <%- include('templates/mapOverlay',
-           { name: "Ash Ketchum"
-           , x: 45, y: 10
-           , width: 4, height: 4
-           , databind: "click: () => TemporaryBattleList['Ash Ketchum Alola'].protectedOnclick()"
-           , visible:  "TemporaryBattleList['Ash Ketchum Alola'] && TemporaryBattleList['Ash Ketchum Alola'].isVisible()"
-           , image: "assets/images/map/ashketchumoverworld.png"
-           })
-        %>
-
-        <%- include('templates/mapOverlay',
             { name: "Team Skull Gang"
             , x: 48, y: 33
             , width: 8, height: 4


### PR DESCRIPTION
## Description
In #5181 Ash's Alola battle was moved from Poni Island to Akala Island, but somehow it got readded to Poni at some point. This removes the redundant Ash in Poni

## Motivation and Context
He's not meant to be there, also it's kinda weird for it to return-town to Pikachu Valley if you aren't in the subregion that dungeon is in lol

## How Has This Been Tested?
Tested file with Hau defeated but not Ash, confirmed he was in Akala but not Poni

## Types of changes
- Bug fix
