### PR TITLE
Dev build : removed auto download on update and allowed Discord codes

### DIFF
--- a/src/modules/codes/RedeemableCodes.ts
+++ b/src/modules/codes/RedeemableCodes.ts
@@ -248,7 +248,7 @@ export default class RedeemableCodes implements Saveable {
 
     enterCode(code: string): void {
         // If this is a Discord code, send it to the Discord class to check
-        if (App.game.discord.enabled && this.isDiscordCode(code)) {
+        if (this.isDiscordCode(code)) {
             App.game.discord.enterCode(code);
             return;
         }

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2997,7 +2997,10 @@ class Update implements Saveable {
         if (!settingsData?.disableAutoDownloadBackupSaveOnUpdate) {
             button.style.display = 'none';
             document.body.appendChild(button);
-            button.click();
+            // We don't want auto download on dev build
+            if (!GameHelper.isDevelopmentBuild()) {
+                button.click();
+            }
             document.body.removeChild(button);
         }
         button.style.display = '';

--- a/src/scripts/discord/Discord.ts
+++ b/src/scripts/discord/Discord.ts
@@ -102,7 +102,6 @@ class Discord implements Saveable {
     enterCode(enteredCode: string): boolean {
         // Discord integration disabled
         // Unless dev, so we can enter codes anyway
-        console.log('Processing');
         if (!this.enabled && !GameHelper.isDevelopmentBuild()) {
             Notifier.notify({
                 message: 'Discord integration not enabled',
@@ -110,7 +109,6 @@ class Discord implements Saveable {
             });
             return false;
         }
-        console.log('blabla');
         // User not logged in to Discord
         if (!this.ID()) {
             Notifier.notify({

--- a/src/scripts/discord/Discord.ts
+++ b/src/scripts/discord/Discord.ts
@@ -66,7 +66,7 @@ class Discord implements Saveable {
     }
 
     calcCode(code) {
-        const discordID = +App.game.discord.ID() || false;
+        const discordID = +this.ID() || false;
         if (!discordID) {
             return;
         }
@@ -101,13 +101,16 @@ class Discord implements Saveable {
 
     enterCode(enteredCode: string): boolean {
         // Discord integration disabled
-        if (!this.enabled) {
+        // Unless dev, so we can enter codes anyway
+        console.log('Processing');
+        if (!this.enabled && !GameHelper.isDevelopmentBuild()) {
             Notifier.notify({
                 message: 'Discord integration not enabled',
                 type: NotificationConstants.NotificationOption.danger,
             });
             return false;
         }
+        console.log('blabla');
         // User not logged in to Discord
         if (!this.ID()) {
             Notifier.notify({


### PR DESCRIPTION
## Description
We won't get auto downloaded files anymore when testing dev builds.
Even though discord integration is disabled on dev build, we can still enter Discord code now.

## Motivation and Context
Easier for us.

## How Has This Been Tested?
Magically changed `isDevelopementBuild` function so I could test the expected outcomes.

## Types of changes
- Dev QOL, I guess...
