### PR TITLE
Display player owned amount in shop item tooltip

### DIFF
--- a/src/components/shopModal.html
+++ b/src/components/shopModal.html
@@ -77,7 +77,7 @@
                css: { active: ShopHandler.selected() == $index() },
                attr: { disabled: !$data.isAvailable() || $data.isSoldOut() },
                tooltip: {
-                  title: $data.description ? `<u>${$data.displayName}:</u><br/>${$data.description}` : '',
+                  title: $data.shopTooltip,
                   trigger: 'hover',
                   placement:'bottom',
                   boundary: 'viewport',

--- a/src/modules/items/Item.ts
+++ b/src/modules/items/Item.ts
@@ -189,6 +189,14 @@ export default class Item {
         this.price(Math.round(this.basePrice * player.itemMultipliers[this.saveName]));
     }
 
+    showBagAmount() {
+        return this.maxAmount > 1;
+    }
+
+    getBagAmount() {
+        return player.amountOfItem(this.name);
+    }
+
     // eslint-disable-next-line class-methods-use-this
     init() {
         // Override in specific item class for any item specific initialization needed
@@ -205,5 +213,20 @@ export default class Item {
     get image() {
         const subDirectory = this.imageDirectory ? `${this.imageDirectory}/` : '';
         return `assets/images/items/${subDirectory}${this.name}.png`;
+    }
+
+    get shopTooltip() {
+        if (!this.description && !this.showBagAmount()) {
+            return '';
+        }
+
+        let tooltip = `<u>${this.displayName}:</u>`;
+        if (this.description) {
+            tooltip += `<br/>${this.description}`;
+        }
+        if (this.showBagAmount()) {
+            tooltip += `<br/><br/>In Bag: ${this.getBagAmount().toLocaleString('en-US')}`;
+        }
+        return tooltip;
     }
 }

--- a/src/modules/items/MulchItem.ts
+++ b/src/modules/items/MulchItem.ts
@@ -15,4 +15,8 @@ export default class MulchItem extends Item {
     gain(amt: number) {
         GameHelper.incrementObservable(App.game.farming.mulchList[this.type], amt);
     }
+
+    getBagAmount() {
+        return App.game.farming.mulchList[this.type]();
+    }
 }

--- a/src/modules/items/PokeballItem.ts
+++ b/src/modules/items/PokeballItem.ts
@@ -14,4 +14,7 @@ export default class PokeballItem extends Item {
         App.game.pokeballs.gainPokeballs(this.type, amt);
     }
 
+    getBagAmount() {
+        return App.game.pokeballs.getBallQuantity(this.type);
+    }
 }

--- a/src/modules/items/PokemonItem.ts
+++ b/src/modules/items/PokemonItem.ts
@@ -88,6 +88,10 @@ export default class PokemonItem extends PokerusIndicatingItem {
         return evs >= 50 ? 'Already resistant!' : `EVs: ${evs.toLocaleString('en-US')} / 50`;
     }
 
+    showBagAmount() {
+        return false;
+    }
+
     get image() {
         const subDirectory = this.imageDirectory ? `${this.imageDirectory}/` : '';
         return `assets/images/items/${subDirectory}${this.name.replace(/[^\s\w.()-]/g, '')}.png`;

--- a/src/modules/items/ShovelItem.ts
+++ b/src/modules/items/ShovelItem.ts
@@ -14,6 +14,10 @@ export class ShovelItem extends Item {
     gain(amt: number) {
         GameHelper.incrementObservable(App.game.farming.shovelAmt, amt);
     }
+
+    getBagAmount() {
+        return App.game.farming.shovelAmt();
+    }
 }
 
 export class MulchShovelItem extends Item {
@@ -23,5 +27,9 @@ export class MulchShovelItem extends Item {
 
     gain(amt: number) {
         GameHelper.incrementObservable(App.game.farming.mulchShovelAmt, amt);
+    }
+
+    getBagAmount() {
+        return App.game.farming.mulchShovelAmt();
     }
 }

--- a/src/modules/items/buyKeyItem.ts
+++ b/src/modules/items/buyKeyItem.ts
@@ -31,4 +31,8 @@ export default class BuyKeyItem extends Item {
     get image(): string {
         return `assets/images/keyitems/${this.name}.png`;
     }
+
+    get description() {
+        return App.game.keyItems.itemList[this.item].description;
+    }
 }


### PR DESCRIPTION
## Description
Displays the amount of an item the player owns in the shop tooltip. Does not show for one-off items such as oak items, key items, hatchery helpers, etc.

## Motivation and Context
QoL

## How Has This Been Tested?
Hovered on some items

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/6cd188ea-a87c-4cb8-ac4e-64d029e76161)
![image](https://github.com/user-attachments/assets/f7974fff-185f-4ca1-ac21-6b0089a0d4d5)
![image](https://github.com/user-attachments/assets/b5cfe9be-7cac-4ad3-8c86-83015f8a5f06)
![image](https://github.com/user-attachments/assets/12d39408-09ce-471c-973c-345850aa2900)
![image](https://github.com/user-attachments/assets/eb466f42-2aaa-4a75-9333-25fe9866aa30)


## Types of changes
- New feature
- UI improvement
