### PR TITLE
Replace Mystery Gift Questline with Mystery Gift NPC, replace 2nd AZ fight with gift NPC

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -2054,7 +2054,6 @@ export const TemporaryBattles = [
     'Merilyn',
     'Millis and Argus Steel',
     'Rampaging Yveltal',
-    'Storyline AZ',
     'AZ',
     'Ash Ketchum Kanto',
     'Ash Ketchum Johto',

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2916,6 +2916,9 @@ class Update implements Saveable {
                 playerData._itemList.Calcium = (playerData._itemList.Calcium ?? 0) + (vitaminsUsed[1] ?? 0);
                 playerData._itemList.Carbos = (playerData._itemList.Carbos ?? 0) + (vitaminsUsed[2] ?? 0);
             }
+
+            //Remove second AZ battle.
+            saveData.statistics.temporaryBattleDefeated.splice(202, 1);
         },
     };
 

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1901,7 +1901,7 @@ class QuestLineHelper {
         flareKalosQuestLine.addQuest(clearKalosLeague);
 
         // Battle AZ and finish the quest
-        const battleAZ1 = new DefeatTemporaryBattleQuest('Storyline AZ', 'What an amazing trainer! You became Kalos Champion! There is a parade in your honor in Lumiose City. But wait, AZ is there asking you for a battle. Show him what being a Pokémon Trainer is like!').withCustomReward(this.itemReward('Key_stone', 1));
+        const battleAZ1 = new DefeatTemporaryBattleQuest('AZ', 'What an amazing trainer! You became Kalos Champion! There is a parade in your honor in Lumiose City. But wait, AZ is there asking you for a battle. Show him what being a Pokémon Trainer is like!').withCustomReward(this.itemReward('Key_stone', 1));
         flareKalosQuestLine.addQuest(battleAZ1);
 
         App.game.quests.questLines().push(flareKalosQuestLine);
@@ -4067,33 +4067,6 @@ class QuestLineHelper {
         App.game.quests.questLines().push(gigantamaxQuestLine);
     }
 
-    public static createOriginalColorMagearnaQuestLine() {
-        const magearnaQuestLine = new QuestLine('A Mystery Gift', 'You have received a Mystery Gift.',
-            new MultiRequirement([
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.kanto),
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.johto),
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.hoenn),
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.sinnoh),
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.unova),
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.kalos),
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.alola),
-                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.galar),
-            ]), GameConstants.BulletinBoards.Galar);
-
-        const mysteryGift = new TalkToNPCQuest(MagearnaMysteryGift, 'Go home and open your Mystery Gift').withCustomReward(() => {
-            App.game.party.gainPokemonByName('Magearna (Original Color)', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
-            Notifier.notify({
-                title: magearnaQuestLine.name,
-                message: 'You obtained Magearna (Original Color)!',
-                type: NotificationConstants.NotificationOption.success,
-                timeout: 3e4,
-            });
-        });
-        magearnaQuestLine.addQuest(mysteryGift);
-
-        App.game.quests.questLines().push(magearnaQuestLine);
-    }
-
     /* Hisui QuestLines */
 
     public static createHisuiForcesQuestLine() {
@@ -4286,7 +4259,6 @@ class QuestLineHelper {
         this.createDynaTreeBirdsQuestLine();
         this.createAncientGolemsQuestLine();
         this.createGigantamaxQuestLine();
-        this.createOriginalColorMagearnaQuestLine();
         this.createHisuiForcesQuestLine();
         this.createHisuiArceusQuestLine();
         this.createPaldeaLegendsQuestLine();

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -3415,8 +3415,8 @@ TemporaryBattleList['Calem 5'] = new TemporaryBattle(
         imageName: 'Calem',
     }
 );
-TemporaryBattleList['Storyline AZ'] = new TemporaryBattle(
-    'Storyline AZ',
+TemporaryBattleList.AZ = new TemporaryBattle(
+    'AZ',
     [
         new GymPokemon('Torkoal', 153757520, 60),
         new GymPokemon('Golurk', 153757520, 60),
@@ -3428,23 +3428,6 @@ TemporaryBattleList['Storyline AZ'] = new TemporaryBattle(
     {
         displayName: 'Pokémon Trainer AZ',
         imageName: 'AZ',
-    }
-);
-TemporaryBattleList.AZ = new TemporaryBattle(
-    'AZ',
-    [
-        new GymPokemon('Torkoal', 161445396, 80),
-        new GymPokemon('Golurk', 161445396, 80),
-        new GymPokemon('Sigilyph', 161445396, 80),
-    ],
-    'Floette... It\'s been 3,000 years...',
-    [new QuestLineCompletedRequirement('A Beautiful World')],
-    undefined,
-    {
-        displayName: 'Pokémon Trainer AZ',
-        firstTimeRewardFunction: () => {
-            App.game.party.gainPokemonByName('Floette (Eternal)', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
-        },
     }
 );
 TemporaryBattleList['Ash Ketchum Kanto'] = new TemporaryBattle(

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -6280,6 +6280,14 @@ const TeamFlareBossLysandre1 = new NPC('Team Flare Boss Lysandre', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('A Beautiful World', 31), new QuestLineStepCompletedRequirement('A Beautiful World', 33, GameConstants.AchievementOption.less)]),
 });
 
+const EternalFloetteGift = new GiftNPC('AZ', [
+    'Floette... It\'s been 3,000 years...',
+    'And with you... another of your kind?',
+    'Ah... it seems to be interested in you, $playername$. Would you like to take it with you?',
+], () => {
+    App.game.party.gainPokemonByName('Floette (Eternal)', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
+}, 'assets/images/pokemon/670.05.png', { saveKey: 'eternalfloettegift', image: 'assets/images/npcs/AZ.png', requirement: new QuestLineCompletedRequirement('A Beautiful World') });
+
 const CouriwayOldGentlemanHarold = new NPC('Old Gentleman Harold', [
     'I love going on walks at <b>dusk</b>. It\'s my favourite part of the day, everything\'s so calm...',
     'Though lately, I\'ve been hearing roars near the waterfalls, but I\'m too scared to see for myself what kind of monster is making those sounds.',
@@ -6493,10 +6501,10 @@ TownList['Lumiose City'] = new Town(
     'Lumiose City',
     GameConstants.Region.kalos,
     GameConstants.KalosSubRegions.Kalos,
-    [TemporaryBattleList['Sycamore 1'], DepartmentStoreShop, FriseurFurfrouShop, KalosStoneSalesman, TemporaryBattleList['Team Flare Lysandre 1'], TemporaryBattleList['Team Flare Xerosic'], TemporaryBattleList['Storyline AZ'], TemporaryBattleList.AZ, TemporaryBattleList.Merilyn, TemporaryBattleList['Grand Duchess Diantha'], TemporaryBattleList['Kalos Stone Salesman']],
+    [TemporaryBattleList['Sycamore 1'], DepartmentStoreShop, FriseurFurfrouShop, KalosStoneSalesman, TemporaryBattleList['Team Flare Lysandre 1'], TemporaryBattleList['Team Flare Xerosic'], TemporaryBattleList.AZ, TemporaryBattleList.Merilyn, TemporaryBattleList['Grand Duchess Diantha'], TemporaryBattleList['Kalos Stone Salesman']],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.kalos, 4)],
-        npcs: [ProfSycamore, LumioseDexio, LumioseEngineer, Lysandre1, Calem1, Lysandre3, Lysandre4, AZ1, BlueButton, RedButton, KalosStoneSalesman1, KalosStoneSalesman2],
+        npcs: [ProfSycamore, LumioseDexio, LumioseEngineer, Lysandre1, Calem1, Lysandre3, Lysandre4, AZ1, BlueButton, RedButton, EternalFloetteGift, KalosStoneSalesman1, KalosStoneSalesman2],
     }
 );
 TownList['Camphrier Town'] = new Town(
@@ -9139,13 +9147,20 @@ const ProfMagnolia = new ProfNPC('Prof. Magnolia',
     //*TODO*: Change second line to this text when Paldea is available: 'Now be on your way, the illustrious Paldea region awaits over the horizons.',
     'assets/images/npcs/Professor Magnolia.png');
 
-const MagearnaMysteryGift = new NPC('Mystery Gift', [
+const MagearnaMysteryGift = new GiftNPC('Mystery Gift', [
     'You have received a Mystery Gift for completing the National Shiny Dex!',
-], {
-    image: 'assets/images/pokemon/801.01.png',
-    requirement: new MultiRequirement([new QuestLineStartedRequirement('A Mystery Gift'), new QuestLineCompletedRequirement('A Mystery Gift', GameConstants.AchievementOption.less)]),
-}
-);
+], () => {
+    App.game.party.gainPokemonByName('Magearna (Original Color)', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
+}, 'assets/images/pokemon/801.01.png', { saveKey: 'magearnamysterygift', requirement: new MultiRequirement([
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.kanto),
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.johto),
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.hoenn),
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.sinnoh),
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.unova),
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.kalos),
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.alola),
+                new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.galar),
+            ]), });
 
 //Galar Towns
 TownList.Postwick = new Town(


### PR DESCRIPTION
## Description
Removed the Mystery Gift Questline and replaced it with a gift NPC with the same requirements.
Removed the second AZ (note: renamed the first one so it kinda looks like I removed the first one) and replaced it with a gift NPC.

## Motivation and Context
The questline just for one NPC is kinda excessive, and this feels more like a "Mystery Gift" if you ask me.
Having to do the AZ fight again feels kinda weird, but it can't be on the first fight because that is required.

## How Has This Been Tested?
Tested that the Magearna NPC appears when its requirements are met.
Tested that the AZ gift appears when the first fight is cleared, pretty sure the second fight is properly removed, not 100% sure I did that right.