### PR TITLE
Moon Phase information modal

### DIFF
--- a/src/components/moonPhaseModal.html
+++ b/src/components/moonPhaseModal.html
@@ -1,0 +1,34 @@
+<div class="modal fade noselect" id="moonPhaseModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Moon Phases</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p class="small">Moon Phases rotate daily and influence the catch rate of Moon Balls. Additionally, some Pokémon move around according to the current phase.</p>
+                <table class="table table-bordered mb-0">
+                    <thead>
+                        <tr>
+                            <th class="align-middle text-left" colspan="2">Phase</th>
+                            <th class="align-middle">Moon Ball Bonus</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: Object.values(MoonCycle.currentMoonPhases)">
+                        <tr>
+                            <td class="align-middle text-center tight p-2" data-bind="style: { 'background-color': $data.color }">
+                                <img src="" width="30px" data-bind="attr: { src: `assets/images/moonCycle/${MoonCyclePhase[$data.phase]}.png` }">
+                            </td>
+                            <td class="align-middle text-left" data-bind="text: $data.description,
+                                css: { 'bg-primary text-light': $data.phase === MoonCycle.currentMoonCyclePhase() }"></td>
+                            <td class="align-middle" data-bind="text: `+${MoonCycle.catchChanceBonus($data.phase)}%`,
+                                css: { 'bg-primary text-light': $data.phase === MoonCycle.currentMoonCyclePhase() }"></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/components/townMap.html
+++ b/src/components/townMap.html
@@ -22,7 +22,7 @@
                     <i>NOTE: Colors and priority can be customized in the settings menu</i>
                 </div>
             </div>`}">ⓘ</button>
-        <button class='btn btn-sm' style="position: absolute; right: 96px; top: 0px; width: auto; height: 41px;"
+        <button class='btn btn-sm' style="position: absolute; right: 96px; top: 0px; width: auto; height: 41px; cursor: default;"
         data-bind='style: { background: DayCycle.color() },
             tooltip: {
                 title: DayCycle.tooltip(),
@@ -32,7 +32,7 @@
             }'>
             <img width=30px src="" data-bind="attr: { src: DayCycle.image() }"/>
         </button>
-        <button class='btn btn-sm' style="position: absolute; right: 48px; top: 0px; width: auto; height: 41px;"
+        <button class='btn btn-sm' style="position: absolute; right: 48px; top: 0px; width: auto; height: 41px; cursor: default;"
         data-bind='style: { background: Weather.color() },
             tooltip: {
                 title: Weather.tooltip(),
@@ -42,14 +42,14 @@
             }'>
             <img width=30px src="" data-bind="attr: { src: Weather.image() }"/>
         </button>
-        <button class='btn btn-sm' style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px;"
-        data-bind='style: { background: MoonCycle.color() },
-            tooltip: {
-                title: MoonCycle.tooltip(),
-                html: true,
-                placement: "bottom",
-                trigger: "hover"
-            }'>
+        <button class='btn btn-sm' style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px;" data-toggle="modal" data-target="#moonPhaseModal"
+            data-bind='style: { background: MoonCycle.color() },
+                tooltip: {
+                    title: `${MoonCycle.tooltip()}<br/><br/>Click for more information.`,
+                    html: true,
+                    placement: "bottom",
+                    trigger: "hover"
+                }'>
             <img width=30px src="" data-bind="attr: { src: MoonCycle.image() }"/>
         </button>
         <div id="mapBody" class="card-body p-0 show">

--- a/src/index.html
+++ b/src/index.html
@@ -532,6 +532,9 @@
 <!-- Consumable Modal -->
 @import "consumableModal.html"
 
+<!-- Moon Phase Modal -->
+@import "moonPhaseModal.html"
+
 <script type="text/javascript">
 // Check if we are running in an iframe
 if (self !== top) {

--- a/src/modules/moonCycle/MoonCycle.ts
+++ b/src/modules/moonCycle/MoonCycle.ts
@@ -48,4 +48,8 @@ export default class MoonCycle {
         [MoonCyclePhase.WaningCrescent]:
             new CurrentMoonPhase(MoonCyclePhase.WaningCrescent, '#3b365e', 'Waning Crescent Moon'),
     };
+
+    public static catchChanceBonus(phase: MoonCyclePhase): number {
+        return (4 - Math.abs((phase % 8) - 4)) * 5;
+    }
 }

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -120,7 +120,7 @@ class Pokeballs implements Feature {
 
             new Pokeball(GameConstants.Pokeball.Moonball, (opts) => {
                 const moonCycleMod = MoonCycle.currentMoonCyclePhase();
-                const moonCycleBonus = (4 - Math.abs((moonCycleMod % 8) - 4)) * 5;
+                const moonCycleBonus = MoonCycle.catchChanceBonus(moonCycleMod);
 
                 if (GameConstants.MoonEvoPokemon.has(opts.pokemon)) {
                     return Math.min(20, moonCycleBonus + 10);


### PR DESCRIPTION
## Description
Adds a simple modal that opens when clicking the Moon Phase icon to provide information about moon phases. Also removes the `cursor: pointer` on the weather and time of day buttons.

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/f05a7049-0a5d-455b-a9c0-b4aece786a86)

