### PR TITLE
Make Silver 4 temp battle visible

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -491,6 +491,7 @@ TemporaryBattleList['Silver 4'] = new TemporaryBattle(
     {
         displayName: 'Rival Silver',
         imageName: 'Silver',
+        visibleRequirement: new QuestLineStepCompletedRequirement('Team Rocket Again', 1),
     }
 );
 TemporaryBattleList['Silver 5'] = new TemporaryBattle(


### PR DESCRIPTION
## Description
Makes the Silver 4 battle visible during the Team Rocket Again step that requires beating the Radio Tower dungeon.

## Motivation and Context
Players often get stuck here unsure what they need to do.

## How Has This Been Tested?
Loaded a file on this step and checked that the battle was visible and alerted the player to the requirements

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/6afc98b9-33cb-4438-93ca-f248246c7942)
