### PR TITLE
Change: Region requirements now tells the player that the region is WIP.

### DIFF
--- a/src/modules/requirements/MaxRegionRequirement.ts
+++ b/src/modules/requirements/MaxRegionRequirement.ts
@@ -1,4 +1,4 @@
-import { AchievementOption, Region, camelCaseToString } from '../GameConstants';
+import { AchievementOption, Region, camelCaseToString, MAX_AVAILABLE_REGION } from '../GameConstants';
 import Requirement from './Requirement';
 
 export default class MaxRegionRequirement extends Requirement {
@@ -11,6 +11,9 @@ export default class MaxRegionRequirement extends Requirement {
     }
 
     public hint(): string {
+        if (this.requiredValue > MAX_AVAILABLE_REGION) {
+            return 'This is from a region that hasn\'t been released yet.';
+        }
         return `You need to reach the ${camelCaseToString(Region[this.requiredValue])} region.`;
     }
 }

--- a/src/scripts/achievements/StoneUnlockedRequirement.ts
+++ b/src/scripts/achievements/StoneUnlockedRequirement.ts
@@ -22,6 +22,9 @@ class StoneUnlockedRequirement extends Requirement {
     }
 
     public hint(): string {
-        return `You need to reach the ${GameConstants.Region[this.requiredValue]} region.`;
+        if (this.requiredValue > GameConstants.MAX_AVAILABLE_REGION) {
+            return 'This item is from a region that hasn\'t been released yet.';
+        }
+        return `You need to reach the ${GameConstants.camelCaseToString(GameConstants.Region[this.requiredValue])} region.`;
     }
 }


### PR DESCRIPTION
## Description
If the region is not released, the hint doesn't say the player has to reach it anymore.

## Motivation and Context
Required as per #5805.

## How Has This Been Tested?
Created requirements with reachable and unreachable regions and read their hints.

## Types of changes
- UI improvement
