### PR TITLE
Gift NPCs now affect town area status

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -542,7 +542,7 @@ export function pluralizeString(str: string, amt: number): string {
     switch (true) {
         case /s$/.test(str):
             return str;
-        case /y$/.test(str):
+        case /[^aeiou]y$/.test(str):
             return str.replace(/y$/, 'ies');
         case /ch$/.test(str):
             return `${str}es`;

--- a/src/scripts/towns/PokemonGiftNPC.ts
+++ b/src/scripts/towns/PokemonGiftNPC.ts
@@ -1,0 +1,14 @@
+class PokemonGiftNPC extends GiftNPC {
+    constructor(
+        public name: string,
+        public dialog: string[],
+        public giftPokemon: PokemonNameType,
+        public giftImage?: string,
+        options: NPCOptionalArgument = {}
+    ) {
+        const giftFunction = () => {
+            App.game.party.gainPokemonByName(this.giftPokemon, PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
+        };
+        super(name, dialog, giftFunction, giftImage, options);
+    }
+}

--- a/src/scripts/towns/PokemonGiftNPC.ts
+++ b/src/scripts/towns/PokemonGiftNPC.ts
@@ -2,7 +2,7 @@ class PokemonGiftNPC extends GiftNPC {
     constructor(
         public name: string,
         public dialog: string[],
-        public giftPokemon: PokemonNameType,
+        private giftPokemon: PokemonNameType,
         public giftImage?: string,
         options: NPCOptionalArgument = {}
     ) {
@@ -10,5 +10,16 @@ class PokemonGiftNPC extends GiftNPC {
             App.game.party.gainPokemonByName(this.giftPokemon, PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
         };
         super(name, dialog, giftFunction, giftImage, options);
+    }
+
+    public areaStatus(): areaStatus[] {
+        const status = [];
+        if (!App.game.party.alreadyCaughtPokemonByName(this.giftPokemon)) {
+            status.push(areaStatus.uncaughtPokemon);
+        }
+        if (!App.game.party.alreadyCaughtPokemonByName(this.giftPokemon, true)) {
+            status.push(areaStatus.uncaughtShinyPokemon);
+        }
+        return status;
     }
 }

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -5,6 +5,8 @@
 ///<reference path="ProfNPC.ts"/>
 ///<reference path="RoamerNPC.ts"/>
 ///<reference path="GiftNPC.ts"/>
+///<reference path="PokemonGiftNPC.ts"/>
+///<reference path="AssistantNPC.ts"/>
 ///<reference path="TownContent.ts"/>
 
 type TownOptionalArgument = {

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -468,12 +468,10 @@ const SaffronBreeder = new NPC('Breeder', [
     requirement: new GymBadgeRequirement(BadgeEnums.Earth),
 });
 
-const LaprasGift = new GiftNPC('Silph Co. Employee', [
+const LaprasGift = new PokemonGiftNPC('Silph Co. Employee', [
     'Oh! Hi! You\'re not a member of Team Rocket! You came to save us? Why thank you!',
     'I want you to have this Pokémon for saving us.',
-], () => {
-    App.game.party.gainPokemonByName('Lapras', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
-}, 'assets/images/pokemon/131.png', { saveKey: 'laprasgift', image: 'assets/images/npcs/Office Worker (male).png', requirement: new MultiRequirement([new TemporaryBattleRequirement('Blue 5'), new ObtainedPokemonRequirement('Lapras', true)]) });
+], 'Lapras', 'assets/images/pokemon/131.png', { saveKey: 'laprasgift', image: 'assets/images/npcs/Office Worker (male).png', requirement: new MultiRequirement([new TemporaryBattleRequirement('Blue 5'), new ObtainedPokemonRequirement('Lapras', true)]) });
 
 const FuchsiaKantoRoamerNPC = new RoamerNPC('Youngster Wendy', [
     'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
@@ -6285,13 +6283,11 @@ const TeamFlareBossLysandre1 = new NPC('Team Flare Boss Lysandre', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('A Beautiful World', 31), new QuestLineStepCompletedRequirement('A Beautiful World', 33, GameConstants.AchievementOption.less)]),
 });
 
-const EternalFloetteGift = new GiftNPC('AZ', [
+const EternalFloetteGift = new PokemonGiftNPC('AZ', [
     'Floette... It\'s been 3,000 years...',
     'And with you... another of your kind?',
     'Ah... it seems to be interested in you, $playername$. Would you like to take it with you?',
-], () => {
-    App.game.party.gainPokemonByName('Floette (Eternal)', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
-}, 'assets/images/pokemon/670.05.png', { saveKey: 'eternalfloettegift', image: 'assets/images/npcs/AZ.png', requirement: new QuestLineCompletedRequirement('A Beautiful World') });
+], 'Floette (Eternal)', 'assets/images/pokemon/670.05.png', { saveKey: 'eternalfloettegift', image: 'assets/images/npcs/AZ.png', requirement: new QuestLineCompletedRequirement('A Beautiful World') });
 
 const CouriwayOldGentlemanHarold = new NPC('Old Gentleman Harold', [
     'I love going on walks at <b>dusk</b>. It\'s my favourite part of the day, everything\'s so calm...',
@@ -6320,11 +6316,9 @@ const Spelunker = new NPC('Spelunker', [
     'That would be big news, sure to be reported on local bulletin boards!',
 ]);
 
-const ExamineAegislash = new GiftNPC('Millis and Argus Steels\' Aeglislash', [
+const ExamineAegislash = new PokemonGiftNPC('Millis and Argus Steels\' Aeglislash', [
     '<i>Aegislash wants to join you on your adventure.</i>',
-], () => {
-    App.game.party.gainPokemonByName('Aegislash (Blade)', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
-}, 'assets/images/pokemon/681.01.png', { requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Princess Diancie', 4, GameConstants.AchievementOption.more), new ObtainedPokemonRequirement('Aegislash (Blade)', true)]) });
+], 'Aegislash (Blade)', 'assets/images/pokemon/681.01.png', { requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('Princess Diancie', 4, GameConstants.AchievementOption.more), new ObtainedPokemonRequirement('Aegislash (Blade)', true)]) });
 
 const ThanksDiancie = new NPC('Princess Diancie', [
     'Thank you for your help saving the Diamond Domain. I will be waiting for you in Reflection Cave.',
@@ -8646,11 +8640,9 @@ const EnergyPlantRose = new NPC('Chairman Rose', [
     requirement: new MultiRequirement([new QuestLineStepCompletedRequirement('The Darkest Day', 15), new QuestLineStepCompletedRequirement('The Darkest Day', 17, GameConstants.AchievementOption.less)]),
 });
 
-const EternatusCatch = new GiftNPC('Catch Eternatus', [
+const EternatusCatch = new PokemonGiftNPC('Catch Eternatus', [
     'You caught Eternatus!',
-], () => {
-    App.game.party.gainPokemonByName('Eternatus', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
-}, 'assets/images/pokemon/890.png', { saveKey: 'eternatuscatch', requirement: new MultiRequirement([new TemporaryBattleRequirement('The Darkest Day'), new ObtainedPokemonRequirement('Eternatus', true)]) });
+], 'Eternatus', 'assets/images/pokemon/890.png', { saveKey: 'eternatuscatch', requirement: new MultiRequirement([new TemporaryBattleRequirement('The Darkest Day'), new ObtainedPokemonRequirement('Eternatus', true)]) });
 
 const Leon = new NPC('Leon', [
     'My matches are always sold out, but this... I\'ve never seen a crowd this wild!',
@@ -9152,11 +9144,9 @@ const ProfMagnolia = new ProfNPC('Prof. Magnolia',
     //*TODO*: Change second line to this text when Paldea is available: 'Now be on your way, the illustrious Paldea region awaits over the horizons.',
     'assets/images/npcs/Professor Magnolia.png');
 
-const MagearnaMysteryGift = new GiftNPC('Mystery Gift', [
+const MagearnaMysteryGift = new PokemonGiftNPC('Mystery Gift', [
     'You have received a Mystery Gift for completing the National Shiny Dex!',
-], () => {
-    App.game.party.gainPokemonByName('Magearna (Original Color)', PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_REWARD));
-}, 'assets/images/pokemon/801.01.png', { saveKey: 'magearnamysterygift', requirement: new MultiRequirement([
+], 'Magearna (Original Color)', 'assets/images/pokemon/801.01.png', { saveKey: 'magearnamysterygift', requirement: new MultiRequirement([
     new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.kanto),
     new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.johto),
     new CaughtUniqueShinyPokemonsByRegionRequirement(GameConstants.Region.hoenn),

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -250,6 +250,14 @@ class MapHelper {
                 }
             });
         });
+        town.npcs?.filter(npc => npc instanceof PokemonGiftNPC && npc.isVisible()).forEach((npc: PokemonGiftNPC) => {
+            if (!App.game.party.alreadyCaughtPokemonByName(npc.giftPokemon)) {
+                states.add(areaStatus.uncaughtPokemon);
+            }
+            if (!App.game.party.alreadyCaughtPokemonByName(npc.giftPokemon, true)) {
+                states.add(areaStatus.uncaughtShinyPokemon);
+            }
+        });
 
         if (states.has(areaStatus.uncaughtShinyPokemon) && states.has(areaStatus.missingAchievement)) {
             states.add(areaStatus.uncaughtShinyPokemonAndMissingAchievement);

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -251,12 +251,7 @@ class MapHelper {
             });
         });
         town.npcs?.filter(npc => npc instanceof PokemonGiftNPC && npc.isVisible()).forEach((npc: PokemonGiftNPC) => {
-            if (!App.game.party.alreadyCaughtPokemonByName(npc.giftPokemon)) {
-                states.add(areaStatus.uncaughtPokemon);
-            }
-            if (!App.game.party.alreadyCaughtPokemonByName(npc.giftPokemon, true)) {
-                states.add(areaStatus.uncaughtShinyPokemon);
-            }
+            npc.areaStatus().forEach(s => states.add(s));
         });
 
         if (states.has(areaStatus.uncaughtShinyPokemon) && states.has(areaStatus.missingAchievement)) {


### PR DESCRIPTION
## Description
Added `PokemonGiftNPC`, a subclass of `GiftNPC` specifically for gifting Pokemon, to allow a cleaner approach to having Gift NPCs affect area status. It's used in the exact same way as GiftNPC except a pokemon is specified instead of a reward function. Changed all of the current GiftNPCs to PokemonGiftNPC

## Motivation and Context
Map overlay colors

## How Has This Been Tested?
Went to Postwick on a file that already has Magearna (Original Color) and there was no overlay color. Set Magearna (Original Color) to not shiny and the town changed to the uncaught shiny color. Removed Magearna (Original Color) from my party and it changed to the uncaught pokemon color.

## Types of changes
- UI improvement
