### PR TITLE
Fix hiring locked dungeon guides

### DIFF
--- a/src/components/dungeonGuidesModal.html
+++ b/src/components/dungeonGuidesModal.html
@@ -91,9 +91,6 @@
                                             </tbody>
                                         </table>
                                     </div>
-                                    <div class="card-footer p-2">
-                                        <butto class="btn btn-block btn-sm btn-primary" href="#dungeonGuidesSubModal" data-toggle="modal" data-bind="click: () => DungeonGuides.selected($data.index)">Hire!</butto>
-                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Description
Fixes a copy/paste remnant that allowed hiring locked Dungeon Guides

## How Has This Been Tested?
Checked that the Hire button was no longer visible

## Types of changes
- Bug fix
