### PR TITLE
Add DungeonGuide as a DungeonInteractionSource

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -2596,6 +2596,7 @@ export enum DungeonInteractionSource {
     Click,
     Keybind,
     HeldKeybind,
+    DungeonGuide,
 }
 
 export const ModalCollapseList = [

--- a/src/scripts/dungeons/DungeonGuides.ts
+++ b/src/scripts/dungeons/DungeonGuides.ts
@@ -37,7 +37,7 @@ class DungeonGuide {
                     case GameConstants.DungeonTileType.chest:
                     case GameConstants.DungeonTileType.boss:
                     case GameConstants.DungeonTileType.ladder:
-                        DungeonRunner.handleInteraction();
+                        DungeonRunner.handleInteraction(GameConstants.DungeonInteractionSource.DungeonGuide);
                         break;
                 }
             } catch (e) {

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -142,7 +142,7 @@ class DungeonRunner {
     public static handleInteraction(source: GameConstants.DungeonInteractionSource = GameConstants.DungeonInteractionSource.Click) {
         if (DungeonRunner.fighting() && !DungeonBattle.catching() && source === GameConstants.DungeonInteractionSource.Click) {
             DungeonBattle.clickAttack();
-        } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTileType.entrance && source !== GameConstants.DungeonInteractionSource.HeldKeybind && !DungeonGuides.hired()) {
+        } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTileType.entrance && (source === GameConstants.DungeonInteractionSource.Click || source === GameConstants.DungeonInteractionSource.Keybind)) {
             DungeonRunner.dungeonLeave();
         } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTileType.chest) {
             DungeonRunner.openChest();

--- a/src/scripts/dungeons/DungeonRunner.ts
+++ b/src/scripts/dungeons/DungeonRunner.ts
@@ -142,7 +142,7 @@ class DungeonRunner {
     public static handleInteraction(source: GameConstants.DungeonInteractionSource = GameConstants.DungeonInteractionSource.Click) {
         if (DungeonRunner.fighting() && !DungeonBattle.catching() && source === GameConstants.DungeonInteractionSource.Click) {
             DungeonBattle.clickAttack();
-        } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTileType.entrance && (source === GameConstants.DungeonInteractionSource.Click || source === GameConstants.DungeonInteractionSource.Keybind)) {
+        } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTileType.entrance && (source === GameConstants.DungeonInteractionSource.Click || source === GameConstants.DungeonInteractionSource.Keybind) && !DungeonGuides.hired()) {
             DungeonRunner.dungeonLeave();
         } else if (DungeonRunner.map.currentTile().type() === GameConstants.DungeonTileType.chest) {
             DungeonRunner.openChest();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

Adds `DungeonGuide` to the `DungeonInteractionSource` enum, and makes relevant updates.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

When a dungeon guide is active, it will activate click attacks when fighting the boss. This fixes that issue

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Built

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->

n/a

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix

Note: accidentally deleted the initial pull request (#5854, fb3bc23400981b691eb4b9d9f1d23d571e825cde), this is a reupload