### PR TITLE
Feature: improvement to area status computations

### DIFF
--- a/src/modules/enums/AreaStatus.ts
+++ b/src/modules/enums/AreaStatus.ts
@@ -6,7 +6,6 @@ enum areaStatus {
     questAtLocation,
     uncaughtPokemon,
     uncaughtShadowPokemon,
-    uncaughtShinyPokemonAndMissingAchievement,
     uncaughtShinyPokemon,
     missingAchievement,
     missingResistant,

--- a/src/scripts/gym/Gym.ts
+++ b/src/scripts/gym/Gym.ts
@@ -59,7 +59,7 @@ class Gym extends TownContent implements TmpGymType {
     public areaStatus(): areaStatus[] {
         const states = [];
         if (!this.isUnlocked()) {
-            states.push(areaStatus.locked);
+            return [areaStatus.locked];
         }
         if (!App.game.badgeCase.hasBadge(this.badgeReward)) {
             states.push(areaStatus.incomplete);

--- a/src/scripts/shop/BerryMasterShop.ts
+++ b/src/scripts/shop/BerryMasterShop.ts
@@ -18,6 +18,9 @@ class BerryMasterShop extends Shop {
 
     public areaStatus() {
         const itemStatusArray = super.areaStatus();
+        if (itemStatusArray.includes(areaStatus.locked)) {
+            return [areaStatus.locked];
+        }
 
         const berryListIndex = GameConstants.BerryTraderLocations[this.parent.name];
         if (berryListIndex > -1) {

--- a/src/scripts/shop/GemMasterShop.ts
+++ b/src/scripts/shop/GemMasterShop.ts
@@ -17,6 +17,9 @@ class GemMasterShop extends Shop {
 
     public areaStatus() {
         const itemStatusArray = super.areaStatus();
+        if (itemStatusArray.includes(areaStatus.locked)) {
+            return [areaStatus.locked];
+        }
 
         const deals = GemDeals.getDeals(this.shop);
         if (deals) {

--- a/src/scripts/shop/GenericTraderShop.ts
+++ b/src/scripts/shop/GenericTraderShop.ts
@@ -17,6 +17,9 @@ class GenericTraderShop extends Shop {
 
     public areaStatus() {
         const itemStatusArray = super.areaStatus();
+        if (itemStatusArray.includes(areaStatus.locked)) {
+            return [areaStatus.locked];
+        }
         const deals = GenericDeal.getDeals(this.traderID)?.();
 
         if ((deals?.length || 0) > 0) {

--- a/src/scripts/shop/ShardTraderShop.ts
+++ b/src/scripts/shop/ShardTraderShop.ts
@@ -17,6 +17,9 @@ class ShardTraderShop extends Shop {
 
     public areaStatus() {
         const itemStatusArray = super.areaStatus();
+        if (itemStatusArray.includes(areaStatus.locked)) {
+            return [areaStatus.locked];
+        }
 
         const deals = ShardDeal.getDeals(this.location)?.();
         if (deals) {

--- a/src/scripts/shop/Shop.ts
+++ b/src/scripts/shop/Shop.ts
@@ -29,6 +29,9 @@ class Shop extends TownContent {
 
     public areaStatus() {
         const itemStatusArray = super.areaStatus();
+        if (itemStatusArray.includes(areaStatus.locked)) {
+            return [areaStatus.locked];
+        }
         const pokerusUnlocked = Settings.getSetting(`--${areaStatus[areaStatus.missingResistant]}`).isUnlocked();
         this.items.forEach(i => {
             if (i instanceof PokemonItem) {

--- a/src/scripts/shop/Shop.ts
+++ b/src/scripts/shop/Shop.ts
@@ -37,9 +37,11 @@ class Shop extends TownContent {
             if (i instanceof PokemonItem) {
                 if (i.getCaughtStatus() == CaughtStatus.NotCaught) {
                     itemStatusArray.push(areaStatus.uncaughtPokemon);
-                } else if (i.getCaughtStatus() == CaughtStatus.Caught) {
+                }
+                if (i.getCaughtStatus() == CaughtStatus.Caught) {
                     itemStatusArray.push(areaStatus.uncaughtShinyPokemon);
-                } else if (pokerusUnlocked && i.getPokerusStatus() < GameConstants.Pokerus.Resistant) {
+                }
+                if (pokerusUnlocked && i.getPokerusStatus() < GameConstants.Pokerus.Resistant) {
                     itemStatusArray.push(areaStatus.missingResistant);
                 }
             }

--- a/src/scripts/temporaryBattle/TemporaryBattle.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattle.ts
@@ -31,15 +31,13 @@ class TemporaryBattle extends TownContent implements TmpTemporaryBattleType {
         TemporaryBattleRunner.startBattle(this);
     }
     public areaStatus() {
-        const states = [];
         if (!this.isUnlocked()) {
-            states.push(areaStatus.locked);
+            return [areaStatus.locked];
         }
         if (App.game.statistics.temporaryBattleDefeated[GameConstants.getTemporaryBattlesIndex(this.name)]() == 0 && this.isVisible()) {
-            states.push(areaStatus.incomplete);
+            return [areaStatus.incomplete];
         }
-        states.push(areaStatus.completed);
-        return states;
+        return [areaStatus.completed];
     }
     public getDisplayName() {
         return this.optionalArgs.displayName ?? this.name.replace(/( route)? \d+$/, '');

--- a/src/scripts/towns/BattleCafe.ts
+++ b/src/scripts/towns/BattleCafe.ts
@@ -17,6 +17,9 @@ class BattleCafe extends TownContent {
 
     public areaStatus(): areaStatus[] {
         const status = super.areaStatus();
+        if (status.includes(areaStatus.locked)) {
+            return [areaStatus.locked];
+        }
         const pokerusUnlocked = Settings.getSetting(`--${areaStatus[areaStatus.missingResistant]}`).isUnlocked();
         const alcremieList = Object.values(BattleCafeController.evolutions).flatMap(sweet => Object.values(sweet));
         let incomplete = false;

--- a/src/scripts/towns/PurifyChamber.ts
+++ b/src/scripts/towns/PurifyChamber.ts
@@ -17,10 +17,11 @@ class PurifyChamberTownContent extends TownContent {
     }
 
     public areaStatus(): areaStatus[] {
-        const states = super.areaStatus();
+        if (!this.isUnlocked()) {
+            return [areaStatus.locked];
+        }
         const canPurify = App.game.purifyChamber.currentFlow() >= App.game.purifyChamber.flowNeeded() && App.game.party.caughtPokemon.some(p => p.shadow == GameConstants.ShadowStatus.Shadow);
-        states.push(canPurify ? areaStatus.uncaughtPokemon : areaStatus.completed);
-        return states;
+        return [canPurify ? areaStatus.incomplete : areaStatus.completed];
     }
 
 }

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -167,9 +167,6 @@ class MapHelper {
         if (!RouteHelper.routeCompleted(route, region, false)) {
             states.add(areaStatus.uncaughtPokemon);
         }
-        if (!RouteHelper.routeCompleted(route, region, true) && !RouteHelper.isAchievementsComplete(route, region)) {
-            states.add(areaStatus.uncaughtShinyPokemonAndMissingAchievement);
-        }
         if (!RouteHelper.routeCompleted(route, region, true)) {
             states.add(areaStatus.uncaughtShinyPokemon);
         }
@@ -211,7 +208,7 @@ class MapHelper {
         const states = new Set([areaStatus.completed]);
         // Check if this location is locked
         if (!MapHelper.accessToTown(townName)) {
-            states.add(areaStatus.locked);
+            return areaStatus[areaStatus.locked];
         }
         // Is this location a dungeon
         if (dungeonList[townName] && dungeonList[townName].isUnlocked()) {
@@ -243,17 +240,13 @@ class MapHelper {
         }
         const town = TownList[townName];
         town.content.forEach(c => {
-            c.areaStatus().forEach(s => {
-            // If the town itself is not locked, it should never show locked
-                if (s != areaStatus.locked) {
+            const s = c.areaStatus();
+            if (!s.includes(areaStatus.locked)) {
+                s.forEach(s => {
                     states.add(s);
-                }
-            });
+                });
+            }
         });
-
-        if (states.has(areaStatus.uncaughtShinyPokemon) && states.has(areaStatus.missingAchievement)) {
-            states.add(areaStatus.uncaughtShinyPokemonAndMissingAchievement);
-        }
         const statusPriority = Settings.getSetting('mapAreaStateOrder').observableValue();
         const importantState = statusPriority.find(state => states.has(state));
         return areaStatus[importantState];


### PR DESCRIPTION
## Description
Locked contents doesn't affect town map colour anymore.
Removed combined missing achievements + missing shiny pokémon.
Changed the logic for a bunch of town contents to make them compute faster.

## Motivation and Context
It's weird to have some contents show as incomplete while they just can't be completed.
The missing achievements + missing shiny pokémon status lost its relevance with the new reordering feature.

## How Has This Been Tested?
Loaded the game, checked gyms, tempbattles and shops wouldn't affect the status of their town before they unlock.
Compared all town contents and made sure their status compute fine before and after their logic is changed.
confirmed the removed status was fully removed from the UIs.

## Types of changes
- Bug fix ?
- UI improvement
