### PR TITLE
Mark new GiftNPCs as already talked to if the Pokémon has already been claimed

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2941,6 +2941,16 @@ class Update implements Saveable {
                 const noneCategory = cats.splice(categoryNoneIndex, 1)[0];
                 saveData.categories.categories = [noneCategory, ...cats];
             }
+
+            // Mark new Pokemon Gifts as claimed if they are already owned
+            const ownsFloetteEternal = saveData.party.caughtPokemon.find((p: PartyPokemon) => p.id === 670.05);
+            if (ownsFloetteEternal) {
+                saveData.statistics.npcTalkedTo[GameHelper.hash('eternalfloettegift')] = 1;
+            }
+            const ownsMagearnaOriginal = saveData.party.caughtPokemon.find((p: PartyPokemon) => p.id === 801.01);
+            if (ownsMagearnaOriginal) {
+                saveData.statistics.npcTalkedTo[GameHelper.hash('magearnamysterygift')] = 1;
+            }
         },
     };
 


### PR DESCRIPTION
## Description
Update the save file to hide the new Floette (Eternal) and Magearna (Original Color) GiftNPCs if the mon is already in the party

## Motivation and Context
Reduce confusion

## How Has This Been Tested?
Loaded a save file with both mons caught, and one with neither caught

## Types of changes
- Bug fix
