### PR TITLE
Click attack breakdown updates

### DIFF
--- a/src/components/statisticsModal.html
+++ b/src/components/statisticsModal.html
@@ -99,14 +99,8 @@
                                     </td>
                                 </tr>
                                 <tr>
-                                    <td>Achievement Bonus</td>
-                                    <td class="text-center">
-                                        <code data-bind="text: AchievementHandler.achievementBonus()"></code>
-                                    </td>
-                                </tr>
-                                <tr>
                                     <td colspan="2" class="text-center">
-                                        <code data-bind="html: `(1 + ${$data.caughtPokemon} + ${$data.shinyPokemon} + ${$data.resistantPokemon} + ${$data.purifiedPokemon})<sup>1.4</sup> * (1 + ${AchievementHandler.achievementBonus()})`"></code>
+                                        <code data-bind="html: `(1 + ${$data.caughtPokemon} + ${$data.shinyPokemon} + ${$data.resistantPokemon} + ${$data.purifiedPokemon})<sup>1.4</sup>`"></code>
                                     </td>
                                 </tr>
                                 <tr>
@@ -120,6 +114,12 @@
                         <h5>Modifiers</h5>
                         <table class="table table-bordered table-sm mb-0">
                             <tbody>
+                                <tr>
+                                    <td>Achievement Bonus</td>
+                                    <td class="text-center">
+                                        <code data-bind="text: `×(1 + ${AchievementHandler.achievementBonus()})`"></code>
+                                    </td>
+                                </tr>
                                 <tr>
                                     <td class="w-50">xClick</td>
                                     <td class="text-center w-50">
@@ -140,7 +140,7 @@
                                 </tr>
                                 <tr>
                                     <td colspan="2" class="text-center">
-                                        <code data-bind="text: `${$data.baseClickAttack} * ${$data.xClickModifier} * ${$data.rockyHelmetModifier} * ${$data.blackFluteModifier}`"></code>
+                                        <code data-bind="text: `${$data.baseClickAttack} * (1 + ${AchievementHandler.achievementBonus()}) * ${$data.xClickModifier} * ${$data.rockyHelmetModifier} * ${$data.blackFluteModifier}`"></code>
                                     </td>
                                 </tr>
                                 <tr>

--- a/src/modules/items/FluteItem.ts
+++ b/src/modules/items/FluteItem.ts
@@ -37,7 +37,7 @@ export default class FluteItem extends Item {
     }
 
     public getMultiplier() {
-        return (this.multiplyBy - 1) * (AchievementHandler.achievementBonus() + 1) + 1;
+        return Number(((this.multiplyBy - 1) * (AchievementHandler.achievementBonus() + 1) + 1).toFixed(4));
     }
 
     isSoldOut(): boolean {

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -7,7 +7,7 @@ class AchievementHandler {
     public static navigateIndex: KnockoutObservable<number> = ko.observable(0);
     public static achievementListFiltered: KnockoutObservableArray<Achievement> = ko.observableArray([]);
     public static numberOfTabs: KnockoutObservable<number> = ko.observable(0);
-    public static _cachedAchievementBonus: KnockoutObservable<number> = ko.observable(0);
+    public static _cachedAchievementBonus: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 4 });
 
     public static setNavigateIndex(index: number): void {
         if (index < 0 || index >= AchievementHandler.numberOfTabs()) {

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -339,7 +339,7 @@ class Party implements Feature, TmpPartyType {
             xClickModifier: EffectEngineRunner.isActive(ItemList.xClick.name)() ? (ItemList.xClick as BattleItem).multiplyBy : 1,
             blackFluteModifier: FluteEffectRunner.getFluteMultiplier(GameConstants.FluteItemType.Black_Flute),
             rockyHelmetModifier: App.game.oakItems.calculateBonus(OakItemType.Rocky_Helmet),
-            baseClickAttack: Math.floor(App.game.party.calculateBaseClickAttack() * (1 + AchievementHandler.achievementBonus())),
+            baseClickAttack: Number(App.game.party.calculateBaseClickAttack().toFixed(4)),
         };
     });
 


### PR DESCRIPTION
## Description
Following feedback in the testing thread, I've made some adjustments:
- Achievement bonus & flute bonus are capped at 4 decimals **globally**
- Moved the Achievement Bonus part of the click attack breakdown to the Modifiers section

Capping of the achievement and flute bonuses to 4 decimals may result in slight changes to click attack and other calculations for some players, but the maximum is unchanged.

## Screenshots
![image](https://github.com/user-attachments/assets/8feed49c-4683-4181-a5e4-5681e3336366)

## Types of changes
- UI improvement
