### PR TITLE
Reduced Bomb destruction from 100% to 87.5%

### DIFF
--- a/src/modules/underground/tools/UndergroundTools.ts
+++ b/src/modules/underground/tools/UndergroundTools.ts
@@ -59,7 +59,7 @@ export default class UndergroundTools {
                 displayName: 'Bomb',
                 description: 'Mines a maximum of 2 layers on each of 10 random tiles (including fully mined tiles). The number of tiles increases when equipped with the Explosive Charge Oak Item. Items cannot be mined with the Bomb tool and will instead be destroyed. You will not receive XP for these items.',
                 durabilityPerUse: 0.18,
-                itemDestroyChance: 0.85,
+                itemDestroyChance: 0.875,
                 action: () => {
                     const coordinatesActuallyMined: Array<Coordinate> = [];
                     const baseBombTiles: number = 10;

--- a/src/modules/underground/tools/UndergroundTools.ts
+++ b/src/modules/underground/tools/UndergroundTools.ts
@@ -59,7 +59,7 @@ export default class UndergroundTools {
                 displayName: 'Bomb',
                 description: 'Mines a maximum of 2 layers on each of 10 random tiles (including fully mined tiles). The number of tiles increases when equipped with the Explosive Charge Oak Item. Items cannot be mined with the Bomb tool and will instead be destroyed. You will not receive XP for these items.',
                 durabilityPerUse: 0.18,
-                itemDestroyChance: 1,
+                itemDestroyChance: 0.85,
                 action: () => {
                     const coordinatesActuallyMined: Array<Coordinate> = [];
                     const baseBombTiles: number = 10;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Made it so Bomb doesn't always destroy the items when dug up, but in 87.5% of the cases
<img width="1355" alt="image" src="https://github.com/user-attachments/assets/9f819e0b-209c-40b3-9f80-2df12a1088b1" />
This makes autoclicker gain 33% of the items that a manual player at 4.5 CPS would get. Or 20% with no oak items.
XP is 122% (70% no oak)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
No items was too harsh of a nerf for autoclickers

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Balancing
