### PR TITLE
Fix gift pokemon locations

### DIFF
--- a/src/scripts/pokemons/PokemonLocations.ts
+++ b/src/scripts/pokemons/PokemonLocations.ts
@@ -537,15 +537,13 @@ class PokemonLocations {
                 return false;
             }
 
-            const npcs = town.npcs?.filter(n => n instanceof GiftNPC);
+            const npcs = town.npcs?.filter(n => n instanceof PokemonGiftNPC);
             npcs?.forEach(npc => {
-                const rewardFunction = (npc as GiftNPC).giftFunction?.toString();
-                this.getPokemonRewards(rewardFunction).forEach(pokemon => {
-                    cacheLine[pokemon].push({
-                        town: townName,
-                        npc: npc.name,
-                        requirements: npc.options?.requirement,
-                    });
+                const pokemon = (npc as PokemonGiftNPC).giftPokemon;
+                cacheLine[pokemon].push({
+                    town: townName,
+                    npc: npc.name,
+                    requirements: npc.options?.requirement,
                 });
             });
         });

--- a/src/scripts/towns/PokemonGiftNPC.ts
+++ b/src/scripts/towns/PokemonGiftNPC.ts
@@ -2,7 +2,7 @@ class PokemonGiftNPC extends GiftNPC {
     constructor(
         public name: string,
         public dialog: string[],
-        private giftPokemon: PokemonNameType,
+        public giftPokemon: PokemonNameType,
         public giftImage?: string,
         options: NPCOptionalArgument = {}
     ) {


### PR DESCRIPTION
## Description
With the addition of `PokemonGiftNPC` the gift pokemon location function was no longer functioning as expected. This fixes that.

## Types of changes
- Bug fix
