### PR TITLE
Add hatchery safety check

### DIFF
--- a/src/scripts/breeding/Breeding.ts
+++ b/src/scripts/breeding/Breeding.ts
@@ -262,6 +262,11 @@ class Breeding implements Feature {
     }
 
     public addPokemonToHatchery(pokemon: PartyPokemon): boolean {
+        if (pokemon.breeding) {
+            // Prevent putting multiple copies of a pokemon in the hatchery
+            console.error(`Tried to add ${pokemon.name} to the hatchery while already being bred!`);
+            return false;
+        }
         // If they have a free eggslot, add the pokemon to the egg now
         if (this.hasFreeEggSlot()) {
             return this.gainPokemonEgg(pokemon);


### PR DESCRIPTION
Add an extra safety check to the hatchery to prevent theoretically having multiple copies of the same pokemon in the hatchery at once.

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix