### PR TITLE
Battle Café: no more incomplete status

### DIFF
--- a/src/scripts/towns/BattleCafe.ts
+++ b/src/scripts/towns/BattleCafe.ts
@@ -22,21 +22,14 @@ class BattleCafe extends TownContent {
         }
         const pokerusUnlocked = Settings.getSetting(`--${areaStatus[areaStatus.missingResistant]}`).isUnlocked();
         const alcremieList = Object.values(BattleCafeController.evolutions).flatMap(sweet => Object.values(sweet));
-        let incomplete = false;
         if (alcremieList.some(a => a.getCaughtStatus() == CaughtStatus.NotCaught)) {
             status.push(areaStatus.uncaughtPokemon);
-            incomplete = true;
         }
         if (alcremieList.some(a => a.getCaughtStatus() == CaughtStatus.Caught)) {
             status.push(areaStatus.uncaughtShinyPokemon);
-            incomplete = true;
         }
         if (pokerusUnlocked && alcremieList.some(a => a.getPokerusStatus() < GameConstants.Pokerus.Resistant)) {
             status.push(areaStatus.missingResistant);
-            incomplete = true;
-        }
-        if (incomplete && BattleCafeController.spinsLeft() > 0) {
-            status.push(areaStatus.incomplete);
         }
         return status;
     }


### PR DESCRIPTION
## Description
Removed incomplete status from Battle Café.

## Motivation and Context
Players didn't seem to find it intuitive or useful.
We might reconsider an improved version of this once we're settled on #5734.

## How Has This Been Tested?
Just loaded a file that showed incomplete on live version.

## Types of changes
- UI improvement
