### PR TITLE
Fix update error for files from v0.10.14 or earlier

### DIFF
--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2943,6 +2943,7 @@ class Update implements Saveable {
             }
 
             // Mark new Pokemon Gifts as claimed if they are already owned
+            saveData.statistics.npcTalkedTo = saveData.statistics.npcTalkedTo || {};
             const ownsFloetteEternal = saveData.party.caughtPokemon.find((p: PartyPokemon) => p.id === 670.05);
             if (ownsFloetteEternal) {
                 saveData.statistics.npcTalkedTo[GameHelper.hash('eternalfloettegift')] = 1;


### PR DESCRIPTION
## Description
`npcTalkedTo` statistic doesn't exist on files earlier than v0.10.14 so it would error on update

## How Has This Been Tested?
Loaded a save file from v0.10.0

## Types of changes
- Bug fix