### PR TITLE
fix(questline): Lower the required amount of clears of Castelia Sewers in Hollow Truth and Ideals

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1338,7 +1338,7 @@ class QuestLineHelper {
         const clearVirbankGrunt = new DefeatTemporaryBattleQuest('Team Plasma Grunt 1', 'A Team Plasma Grunt in Virbank City would like to steal your Pokémon. Defeat the grunt.');
         plasmaUnovaQuestLine.addQuest(clearVirbankGrunt);
 
-        const clearCastliaSewers = new DefeatDungeonQuest(10, 0, 'Castelia Sewers').withDescription('Some Team Plasma Grunts were seen entering the Castelia Sewers. Clear Castelia Sewers.');
+        const clearCastliaSewers = new DefeatDungeonQuest(1, 0, 'Castelia Sewers').withDescription('Some Team Plasma Grunts were seen entering the Castelia Sewers. Clear Castelia Sewers.');
         plasmaUnovaQuestLine.addQuest(clearCastliaSewers);
 
         const talktoPlasmaGrunt1 = new TalkToNPCQuest(PlasmaGrunt1, 'Investigate the Perfectly Ordinary Frigate.');


### PR DESCRIPTION
## Description
The quest initially required 1 clear, I mistakenly made it 10 in #4874, now making it 1 again.

## Motivation and Context
That change was unintended, and it's very annoying.

## How Has This Been Tested?
Hasn't, people with higher progress will just be warped to the next quest.

## Types of changes
- Bug fix
