### PR TITLE
Update QuestLineHelper.ts Deoxys Quest typos

### DIFF
--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1455,10 +1455,10 @@ class QuestLineHelper {
     public static createDestinyDeoxysQuestLine() {
         const destinyDeoxysQuest = new QuestLine('Destiny Deoxys', 'Discover the mystery of the crashed meteor.', new QuestLineCompletedRequirement('Hollow Truth and Ideals'), GameConstants.BulletinBoards.Unova);
 
-        const clearGiantChasm = new DefeatDungeonQuest(5, 0, 'Giant Chasm').withDescription('There seems to be a big fuzz about new foundings in the Giant Chasm. Try finding it.');
+        const clearGiantChasm = new DefeatDungeonQuest(5, 0, 'Giant Chasm').withDescription('There seems to be a big fuss about a new discovery in the Giant Chasm. Try finding it.');
         destinyDeoxysQuest.addQuest(clearGiantChasm);
 
-        const talkToGreenGem = new TalkToNPCQuest(destinyGem, 'You found a Green Pulsing Gemstone. Take a closer look.');
+        const talkToGreenGem = new TalkToNPCQuest(destinyGem, 'You found a pulsating Green Gemstone. Take a closer look.');
         destinyDeoxysQuest.addQuest(talkToGreenGem);
 
         const rayquazaDeoxysBattle = new DefeatTemporaryBattleQuest('Destiny Deoxys Rayquaza', 'Rayquaza and Deoxys are rampaging in the area. Try to calm them down.');
@@ -1481,13 +1481,13 @@ class QuestLineHelper {
         destinyDeoxysQuest.addQuest(new MultipleQuestsQuest([
             gainElectricGems,
             gainSteelGems,
-        ], 'The generator isn\t working. Look around for scraps to repair it.'));
+        ], 'The generator isn\'t working. Look around for scraps to repair it.'));
 
 
         const rayquazaBFBattle = new DefeatTemporaryBattleQuest('Destiny Rayquaza', 'Rayquaza attacks again. Calm it down for the last time.');
         destinyDeoxysQuest.addQuest(rayquazaBFBattle);
 
-        const talkToDeoxys = new TalkToNPCQuest(destinyDeoxysReunion, 'Rayquaza realized that the Deoxys are no threat. Reunite the Purple and Green Gemed Deoxys.');
+        const talkToDeoxys = new TalkToNPCQuest(destinyDeoxysReunion, 'Rayquaza realized that the Deoxys are no threat. Reunite the Purple and Green Gemmed Deoxys.');
         destinyDeoxysQuest.addQuest(talkToDeoxys);
 
         App.game.quests.questLines().push(destinyDeoxysQuest);


### PR DESCRIPTION
Fixed Typos in the Deoxys Quest Line

## Description
Step 1: The first sentence in the quest should say "There seems to be a big 'fuss' about 'the' new 'findings' in the Giant Chasm.
Step 8: The quest description has a typo. It says 'isn' instead of 'isn't'
Step 10: The quest description says 'Purple and Green Gemed Deoxys' instead of 'Purple and Green Gemmed Deoxys'

Green Pulsing Gemstone The correct adjective order would be Pulsing Green Gemstone, but I'm not sure if the entire thing (or just Pulsing Gemstone) is a proper noun, in which case the ordering wouldn't apply



## Motivation and Context
Typos from beta testing 



## How Has This Been Tested?
no test, but there was an escaped "\t" that was a "isn" and is now "isn\'t" to become "isn't" in game



## Screenshots (optional):



## Types of changes
- Typos


