### PR TITLE
Update farm mutation indicator

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -75,12 +75,10 @@ class Farming implements Feature {
             const plotMutations = [...Array(GameConstants.FARM_PLOT_WIDTH * GameConstants.FARM_PLOT_HEIGHT)].map(() => []);
             App.game.farming.mutations.forEach((mutation) => {
                 const isUnlocked = App.game.farming.unlockedBerries[mutation.mutatedBerry]();
-                if (!isUnlocked && !mutation.hintSeen) {
-                    return;
-                }
                 mutation.getMutationPlots().forEach((plot) => {
                     if (mutation.getTotalMutationChance(plot) > 0) {
-                        plotMutations[plot].push(isUnlocked ? BerryType[mutation.mutatedBerry] : '???');
+                        const berry = isUnlocked || mutation.hintSeen ? BerryType[mutation.mutatedBerry] : '???';
+                        plotMutations[plot].push(berry);
                     }
                 });
             });

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -74,6 +74,9 @@ class Farming implements Feature {
         this.possiblePlotMutations = ko.pureComputed(() => {
             const plotMutations = [...Array(GameConstants.FARM_PLOT_WIDTH * GameConstants.FARM_PLOT_HEIGHT)].map(() => []);
             App.game.farming.mutations.forEach((mutation) => {
+                if (!mutation.unlocked) {
+                    return;
+                }
                 const isUnlocked = App.game.farming.unlockedBerries[mutation.mutatedBerry]();
                 mutation.getMutationPlots().forEach((plot) => {
                     if (mutation.getTotalMutationChance(plot) > 0) {


### PR DESCRIPTION
## Description
Updates the farm mutation indicator to always be visible when a mutation is possible, even if the player has not yet seen the hint. The tooltip will display the berry name if the player has unlocked the berry previously or has seen the mutation hint, otherwise it will display '???'

## Motivation and Context
something something where green dot

## How Has This Been Tested?
Loaded several saves with active mutation layouts and verified the indicator was visible and showed the berry or ??? 

## Types of changes
- UI improvement
