### PR TITLE
fix(dungeon): crashes when the guide looks for the chest tile they already are at

### DIFF
--- a/src/scripts/dungeons/DungeonGuides.ts
+++ b/src/scripts/dungeons/DungeonGuides.ts
@@ -255,8 +255,9 @@ DungeonGuides.add(new DungeonGuide('Timmy', 'Can smell when there is a treasure 
             if (paths?.length) {
                 const shortestPath = Math.min(...paths.map(p => p.length));
                 const path = Rand.fromArray(paths.filter(p => p.length == shortestPath));
-                // We found some treasure, move to it
-                DungeonRunner.map.moveToTile(path[0]);
+                if (path.length) { // If we're not already there
+                    DungeonRunner.map.moveToTile(path[0]);
+                }
                 return;
             }
         }
@@ -307,8 +308,9 @@ DungeonGuides.add(new DungeonGuide('Angeline', 'Can find treasure anywhere, love
             if (paths?.length) {
                 const shortestPath = Math.min(...paths.map(p => p.length));
                 const path = Rand.fromArray(paths.filter(p => p.length == shortestPath));
-                // We found some treasure, move to it
-                DungeonRunner.map.moveToTile(path[0]);
+                if (path.length) { // If we're not already there
+                    DungeonRunner.map.moveToTile(path[0]);
+                }
                 return;
             }
         }


### PR DESCRIPTION
## Description
This fixes a soft crash caused by both treasure hunter guides when trying to follow a path to the tile they are on (the path is empty).

## Motivation and Context
Reported as per https://discord.com/channels/450412847017754644/1406571215400996884.

## How Has This Been Tested?
Went on a chest tile and made sure the guide collected it and moved on instead of staying put ~~like a dumbass~~.

## Types of changes
- Bug fix
