### PR TITLE
Typos on genesect questline and kalos start temp battle fix

### DIFF
--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -2420,7 +2420,7 @@ TemporaryBattleList['Shauna 1'] = new TemporaryBattle(
     undefined,
     {
         displayName: 'Pokémon Trainer Shauna',
-        returnTown: 'Aquacorde Town',
+        returnTown: 'Vaniville Town',
         imageName: 'Shauna',
     }
 );

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -5372,8 +5372,8 @@ const AncientBugHunter2 = new NPC('Ancient Bug Hunter', [
 
 const AncientBugHunter3 = new NPC('Ancient Bug Hunter', [
     'Trainers report on sightings of various Genesect holding the same Drives as the Genesect they own.',
-    'It seems like this Dungeon\'s Genesect is choosing it\'s Drive based on the Moon Cycle!',
-    'While the high-speed form races to different Dungeons all across Unova.',
+    'It seems like this Dungeon\'s Genesect is choosing its Drive based on the Moon Cycle!',
+    'Meanwhile the high-speed form races to different Dungeons all across Unova.',
 ], {
     image: 'assets/images/npcs/Super Nerd.png',
     requirement: new QuestLineCompletedRequirement('The Legend Awakened'),


### PR DESCRIPTION
Updated typos to the Ancient Bug Hunter Speech

Changed Kalos  Shauna 1 temp battle return location

## Description
For the typos i changed the, it's -> its and While -> Meanwhile

For the Shauna 1 Temp battle set new return location to Vaniville Town


## Motivation and Context

Due to bugs listed on Discord bug channel.

Typos in the quest text.

Shauna 1 Temp battle it was incorrectly sending the trainer to Aquacorde, and bypassed the unlock requirement of clearing the first route.





## How Has This Been Tested?
None.



## Screenshots (optional):

<img width="358" height="538" alt="image" src="https://github.com/user-attachments/assets/7b09fbaf-f3d5-48d3-bf97-760e923404dd" />


<img width="1016" height="599" alt="image" src="https://github.com/user-attachments/assets/ef5dd778-0872-41d2-879f-48d227478381" />



## Types of changes

- Typos
- Bug fix

