### PR TITLE
Add a total efficiency stat to the helpers

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -558,6 +558,12 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                 </td>
                                             </tr>
                                             <tr>
+                                                <td class="text-left text-nowrap">Total Efficiency:</td>
+                                                <td class="text-right">
+                                                    <knockout data-bind="text: `${$data.totalEfficiency().toLocaleString('en-US')}%`, css: $data.totalEfficiencyColor(), attr: {title: `The total effectiveness is the result of both efficiency stats multiplied proportionally to manual breeding.`}">0%</knockout>
+                                                </td>
+                                            </tr>
+                                            <tr>
                                                 <td class="text-left align-middle">Sort:</td>
                                                 <td class="text-center align-middle">
                                                     <div class="input-group input-group-sm">

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -32,6 +32,9 @@ class HatcheryHelper {
     public hatchBonus: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 1 });
     public stepEfficiency: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 1 });
     public attackEfficiency: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 1 });
+    public totalEfficiency: KnockoutComputed<number> = ko.computed(() => {
+        return (this.stepEfficiency() / 100) * (this.attackEfficiency() / 100) * 100;
+    });
     public prevBonus: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 0 });
     public nextBonus: KnockoutObservable<number> = ko.observable(1).extend({ numeric: 0 });
     public categories: KnockoutObservableArray<number> = ko.observableArray([]);
@@ -142,6 +145,23 @@ class HatcheryHelper {
             );
             return;
         }
+    }
+
+    totalEfficiencyColor(): string {
+        const totalEff = this.totalEfficiency();
+
+        switch (true) {
+
+            case totalEff < 33:
+                return 'text-danger';
+            case totalEff < 100:
+                return 'text-warning';
+            case totalEff < 150:
+                return 'text-success';
+            default:
+                return 'text-primary';
+        }
+
     }
 
     toJSON(): Record<string, any> {

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -56,7 +56,8 @@ class HatcheryHelper {
             Cost: <img src="assets/images/currency/${GameConstants.Currency[this.cost.currency]}.svg" width="20px">&nbsp;${(this.cost.amount).toLocaleString('en-US')}/hatch<br/>
             Step Efficiency: ${this.stepEfficiency()}%<br/>
             Attack Efficiency: ${this.attackEfficiency()}%<br/>
-            Hatched: ${this.hatched().toLocaleString('en-US')}<br/>`
+            Hatched: ${this.hatched().toLocaleString('en-US')}<br/>
+            Total Efficiency: ${this.totalEfficiency().toLocaleString('en-US')}%<br/>`
         );
 
         // Update our bonus values


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Add a total efficiency (compared to manual breeding) stat to the hatchery helper overview
Current threshold for color changes are 33, 100, 150. Willing to change.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Too many people misunderstand Sam. Also it was a stat not yet shown ingame.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Looked ingame
Known bug(?) Darkly doesnt have a primary color (it uses #f5f5f5), unrelated to this change

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
<img width="981" height="753" alt="image (2)" src="https://github.com/user-attachments/assets/62068e39-13af-493f-88aa-5f2975acddbd" />



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement
