### PR TITLE
Fix confusing rounding of displayed achievement progress

### DIFF
--- a/src/modules/achievements/Achievement.ts
+++ b/src/modules/achievements/Achievement.ts
@@ -15,7 +15,7 @@ export default class Achievement {
         // roundingMode isn't understood by our typescript version
         // @ts-ignore
         const progress = this.getProgress().toLocaleString('en-US', { roundingMode: 'trunc' });
-        return `${progress} / ${this.property.requiredValue.toLocaleString('en-US')}`
+        return `${progress} / ${this.property.requiredValue.toLocaleString('en-US')}`;
     });
     public bonus = 0;
     public unlocked : KnockoutObservable<boolean> = ko.observable(false);

--- a/src/modules/achievements/Achievement.ts
+++ b/src/modules/achievements/Achievement.ts
@@ -11,7 +11,12 @@ import AchievementCategory from './AchievementCategory';
 
 export default class Achievement {
     public isCompleted: KnockoutComputed<boolean> = ko.pureComputed(() => this.achievable() && (this.unlocked() || this.property.isCompleted()));
-    public getProgressText: KnockoutComputed<string> = ko.pureComputed(() => `${this.getProgress().toLocaleString('en-US')} / ${this.property.requiredValue.toLocaleString('en-US')}`);
+    public getProgressText: KnockoutComputed<string> = ko.pureComputed(() => {
+        // roundingMode isn't understood by our typescript version
+        // @ts-ignore
+        const progress = this.getProgress().toLocaleString('en-US', { roundingMode: 'trunc' });
+        return `${progress} / ${this.property.requiredValue.toLocaleString('en-US')}`
+    });
     public bonus = 0;
     public unlocked : KnockoutObservable<boolean> = ko.observable(false);
     protected notificationTitle: string = 'Achievement';


### PR DESCRIPTION
Displayed achievement progress now always rounds down, avoiding near-completion fractional values rounding up to the required level.

## Description
Displayed achievement progress now uses the `Intl.NumberFormat`'s `trunc` rounding mode. Our Typescript target output version is too old to recognize this option, thus the `@ts-ignore`, but the desktop client version is (just barely) new enough to support it so I say it's fair game.

## Motivation and Context
The EV secret achievements were sometimes confusing for players as `toLocaleString()` could round the high-precision tracked value up to the achievement's required level before it was actually completed. 

## How Has This Been Tested?
Confirmed that the confusing achievement accurately displays that it is not yet completed for progress that previously would round confusingly.

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
- UI improvement
