### PR TITLE
Fix missing Team Rocket Again questline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "description": "PokéClicker repository",
   "main": "index.js",
   "scripts": {

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2953,6 +2953,13 @@ class Update implements Saveable {
                 saveData.statistics.npcTalkedTo[GameHelper.hash('magearnamysterygift')] = 1;
             }
         },
+
+        '0.10.26': ({ playerData, saveData, settingsData }) => {
+            // Fix old saves missing Johto Rocket questline blocking them from entering the Mahogany Town hideout, hopefully for good
+            if (saveData.badgeCase[17]) {
+                Update.startQuestLine(saveData, 'Team Rocket Again');
+            }
+        },
     };
 
     constructor() {


### PR DESCRIPTION
Fix Team Rocket Again questline missing on some older saves, which prevented them from accessing the Mahogany Town hideout dungeon.

## Description
The Team Rocket Hideout in Mahogany Town is now only accessible after defeating the Red Gyarados, but some older saves had somehow progressed past that point without starting the associated quest, preventing them from fighting the Red Gyarados and accessing the dungeon. Hopefully this is a permanent fix, but if not we'll at least know it's a bug with current code rather than an update check.