### PR TITLE
Add a separate color for affordable gem upgrades

### DIFF
--- a/src/components/gemsModal.html
+++ b/src/components/gemsModal.html
@@ -42,7 +42,7 @@
                                 <div class="d-flex" style="gap: 0.25rem">
                                     <!-- ko foreach: Array(Gems.nEffects) -->
                                     <div class="flex-grow-1" style="height: 2px;" data-bind="
-                                        class: App.game.gems.isValidUpgrade($parentContext.$index(), $index()) ? (App.game.gems.hasMaxUpgrade($parentContext.$index(), $index()) ? 'bg-success' : 'bg-warning') : 'bg-success',
+                                        class: App.game.gems.getGemCaseClass($parentContext.$index(), $index()),
                                         style: { opacity: App.game.gems.isValidUpgrade($parentContext.$index(), $index()) ? 1 : 0.25 }
                                     "></div>
                                     <!-- /ko -->

--- a/src/modules/gems/Gems.ts
+++ b/src/modules/gems/Gems.ts
@@ -117,6 +117,16 @@ export default class Gems implements Feature {
         return this.gemUpgrades[typeNum * Gems.nEffects + effectNum]();
     }
 
+    public getGemCaseClass(
+        typeNum: PokemonType,
+        effectNum: TypeEffectiveness,
+    ): string {
+        if (!this.isValidUpgrade(typeNum, effectNum)) return 'bg-success';
+        if (this.hasMaxUpgrade(typeNum, effectNum)) return 'bg-success';
+        if (this.canBuyGemUpgrade(typeNum, effectNum)) return 'bg-info';
+        return 'bg-warning';
+    }
+
     initialize() {}
 
     canAccess(): boolean {


### PR DESCRIPTION
## Description
Currently, non-maxed upgrades have the same color in the gem summary section. This PR makes affordable upgrades show up with a different color.

I think the color blends a bit with a maxed color, but that's a general problem with the theme.

## Motivation and Context
I'd like to be able to quickly tell when I can afford gem upgrades.


## How Has This Been Tested?
Opened the gem case and confirmed that the colors are correct.



## Screenshots (optional):
Maxed - affordable - unaffordable - maxed
<img width="191" height="44" alt="изображение" src="https://github.com/user-attachments/assets/d5a5bedb-790c-4cd6-a8d2-780d52ed0b73" />

## Types of changes
- UI improvement
