### PR TITLE
Add tooltip to Berries list w/ Berry info

### DIFF
--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -53,8 +53,9 @@
                                                 title: `<u>Growth Duration</u>: ${GameConstants.formatSecondsToTime(App.game.farming.berryData[$data].growthTime[3])}<br/>
                                                     ${App.game.farming.berryData[$data].harvestAmount.toLocaleString('en-US')} <img width='12px' alt='${BerryType[$data]}' src='${FarmController.getBerryImage($data)}' /> per harvest<br/>
                                                     ${App.game.farming.berryData[$data].farmValue.toLocaleString('en-US')} <img width='12px' alt='Farm Points' src='assets/images/currency/farmPoint.svg' /> per harvest`,
-                                                placement: 'bottom',
-                                                trigger: 'hover'
+                                                placement: 'right',
+                                                trigger: 'hover',
+                                                animation: false,
                                             } : {}">
                                             <img src="" height="28px"
                                                 data-bind="attr:{ src: FarmController.getBerryImage($data) },

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -47,7 +47,15 @@
                                             data-bind="click: function() {
                                                 FarmController.selectedBerry($data);
                                                 FarmController.selectedFarmTool(FarmingTool.Berry);
-                                            }, css: { 'active': FarmController.selectedBerry() === $data && FarmController.selectedFarmTool() == FarmingTool.Berry }">
+                                            }, css: { 'active': FarmController.selectedBerry() === $data && FarmController.selectedFarmTool() == FarmingTool.Berry },
+                                            tooltip: App.game.farming.unlockedBerries[$data]() ? {
+                                                html: true,
+                                                title: `<u>Growth Duration</u>: ${GameConstants.formatSecondsToTime(App.game.farming.berryData[$data].growthTime[3])}<br/>
+                                                    ${App.game.farming.berryData[$data].harvestAmount.toLocaleString('en-US')} <img width='12px' alt='${BerryType[$data]}' src='${FarmController.getBerryImage($data)}' /> per harvest<br/>
+                                                    ${App.game.farming.berryData[$data].farmValue.toLocaleString('en-US')} <img width='12px' alt='Farm Points' src='assets/images/currency/farmPoint.svg' /> per harvest`,
+                                                placement: 'bottom',
+                                                trigger: 'hover'
+                                            } : {}">
                                             <img src="" height="28px"
                                                 data-bind="attr:{ src: FarmController.getBerryImage($data) },
                                                 css: {'berryLocked': !App.game.farming.unlockedBerries[$data]() }">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Adds a tooltip on hover on the berries list that quickly shows Growth Duration, Berry Harvest gain and FP gain


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

Easier and quicker berry reference, especially helpful for newer players who miss the dex or wiki. Mulch already has a tooltip in the same place.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Checked tooltip over locked and unlocked berries, checked the alt text as well

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->

<img width="238" height="362" alt="Screenshot 2025-09-18 at 7 38 17 PM" src="https://github.com/user-attachments/assets/6fa93cc9-aa0c-48ac-b83a-56bc95763bd9" />
<img width="240" height="361" alt="Screenshot 2025-09-18 at 7 38 24 PM" src="https://github.com/user-attachments/assets/967a1ba7-a0b6-463c-a90c-12386671def3" />


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->

- UI improvement
