### PR TITLE
Sound notification for when a dungeon guide has completed all dungeon attempts

### DIFF
--- a/src/modules/notifications/NotificationConstants.ts
+++ b/src/modules/notifications/NotificationConstants.ts
@@ -20,6 +20,7 @@ const NotificationConstants = {
             dream_orb: new Sound('dream_orb', 'Opening Dream Orb'),
             pokerus: new Sound('pokerus_resistant', 'Pokémon has become Resistant to Pokérus'),
             max_flow: new Sound('max_flow', 'Maximum Flow has accumulated at the Purify Chamber'),
+            dungeon_guide_complete: new Sound('battle_frontier', 'Dungeon Guide has completed all dungeon attempts'),
         },
         Hatchery: {
             ready_to_hatch: new Sound('ready_to_hatch', 'Egg ready to hatch'),

--- a/src/scripts/dungeons/DungeonGuides.ts
+++ b/src/scripts/dungeons/DungeonGuides.ts
@@ -120,6 +120,7 @@ class DungeonGuide {
             message: 'Thanks for the work.\nLet me know when you\'re hiring again!',
             type: NotificationConstants.NotificationOption.info,
             timeout: 30 * GameConstants.SECOND,
+            sound: NotificationConstants.NotificationSound.General.dungeon_guide_complete,
         });
         // Hide modals
         $('.modal.show').modal('hide');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

Added sound for when a dungeon guide has completed all of their hired dungeon attempts. Reused Battle Frontier sound for now because it had the right vibe.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

really hard to guess how long a dungeon guide will take, and I paid them primo internet dollars so they should tell me when they're done

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- hired dungeon guide for 1 run
- hired dungeon guide for multiple runs (sound should only play once at the end of all attempts)

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->

- UI improvement
