### PR TITLE
update GameController to filter achievement list on achievement hotkey

### DIFF
--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -395,6 +395,7 @@ class GameController {
                     // Open the achievmeents tracker
                     if (achievements.canAccess() && !$achievementsModal.data('disable-toggle')) {
                         $('.modal').modal('hide');
+                        AchievementHandler.filterAchievementList(true);
                         $achievementsModal.modal('toggle');
                         return e.preventDefault();
                     }


### PR DESCRIPTION

## Description

Added the Achievement tracker filter on hotkey trigger. This now applies the achievement filter upon modal display when using the hotkey.



## Motivation and Context

Bug submitted in Discord
Achievement tracker filters don't update when opening with shortcut




## How Has This Been Tested?

Running testing environment locally
Tested the original functionality and how it did not apply the filter upon hotkey press(but did on button click), then tested again after applying fix




## Screenshots (optional):

Original function

<img width="830" height="743" alt="image" src="https://github.com/user-attachments/assets/1800e4d8-ebfa-4038-b0a5-aa974c5ee1cf" />
<img width="829" height="743" alt="image" src="https://github.com/user-attachments/assets/e781f213-b7ae-41b4-b9a9-f58a721f1228" />


After Update

<img width="1037" height="743" alt="image" src="https://github.com/user-attachments/assets/9e2acf67-ca31-42e3-ad7f-c84d63a728e2" />
<img width="987" height="743" alt="image" src="https://github.com/user-attachments/assets/c3264d9e-0574-4587-b3f6-500b43f324ab" />




## Types of changes
- Bug fix
- UI improvement
