### PR TITLE
feat(farm): Kee aura is causing Wandering Pokémon to evolve as they appear

### DIFF
--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -1119,7 +1119,10 @@ class Farming implements Feature {
             BerryColor.Yellow,
             5.7,
             BerryFirmness.Very_Hard,
-            ['This Berry remains poisonous until fully ripened. Once ripe it has a spicy and sweet complex flavor.']
+            [
+                'This Berry remains poisonous until fully ripened. Once ripe it has a spicy and sweet complex flavor.',
+                'Its scent causes nearby Pokémon to evolve.',
+            ]
         );
 
         this.berryData[BerryType.Maranga] = new Berry(

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -384,16 +384,28 @@ class PokemonFactory {
 
     public static generateWandererData(plot: Plot): WandererPokemon {
         const berry = plot.berryData;
-        const mulch = plot.mulch;
-        const availablePokemon = [];
-        const weights = [];
-        berry.wander.forEach((p, i) => {
-            if (pokemonMap[p].nativeRegion <= player.highestRegion()) {
-                availablePokemon.push(p);
-                weights.push(mulch === MulchType.Gooey_Mulch && i >= Berry.baseWander.length ? 2 : 1);
+        const useGooey = plot.mulch === MulchType.Gooey_Mulch;
+        const availablePokemon = new Set<PokemonNameType>();
+        const evolve = App.game.farming.berryInFarm(BerryType.Kee);
+        berry.wander.forEach(p => {
+            const wanderers = [];
+            if (evolve) {
+                wanderers.push(
+                    ...PokemonHelper.getPokemonByName(p).evolutions?.filter(evo => evo.trigger == EvoTrigger.LEVEL
+                        && App.game.statistics.pokemonCaptured[PokemonHelper.getPokemonByName(evo.evolvedPokemon).id]()).map(evo => evo.evolvedPokemon)
+                        ?? []
+                );
             }
+            if (!wanderers.length) {
+                wanderers.push(p);
+            }
+            wanderers.forEach(w => {
+                if (pokemonMap[w].nativeRegion <= player.highestRegion()) {
+                    availablePokemon.add(w);
+                }
+            });
         });
-        const pokemon = Rand.fromWeightedArray(availablePokemon, weights);
+        const pokemon = Rand.fromWeightedArray<PokemonNameType>([...new Set(availablePokemon)], [...new Set(availablePokemon)].map((p: PokemonNameType) => useGooey && !Berry.baseWander.includes(p) ? 2 : 1));
         const pokemonData = pokemonMap[pokemon];
         const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_FARM);
         const catchChance = PokemonFactory.catchRateHelper(pokemonData.catchRate + 25, true);


### PR DESCRIPTION
## Description
As the title says, when Kee is planted and ripe, a Psyduck wandering onto the farm would be Golduck instead. Only works on level evo if evo has been obtained once. It's actually not finalized, more like a POC for now.
What's missing : updating Pokémon Locations, OW sprites for a handful of alt Pokémon, maybe removing some extra obtaining methods (route SL Squirtle and roaming Vivillion (Meadow)).

## Motivation and Context
Partial implementation of #6076.
Gets 17 (!) Pokémon out of FS and makes resisting Pokémon like Forretress and Toxtricity more comfortable.
Makes one more gen 5 berry somewhat useful....

## How Has This Been Tested?
Got a bunch of evolved and non evolved wandering Pokémon.

## Types of changes
- New feature
