### PR TITLE
Added rare candy to the wild halloween pokemon

### DIFF
--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -175,6 +175,7 @@ export const pokemonList = createPokemonArray(
         'gender': {
             'femaleRatio': 0.125,
         },
+        'heldItem': { type: ItemType.item, id: 'Rare_Candy' },
     },
     {
         'id': 1.03,
@@ -1640,6 +1641,7 @@ export const pokemonList = createPokemonArray(
         'gender': {
             'femaleRatio': 0,
         },
+        'heldItem': { type: ItemType.item, id: 'Rare_Candy' },
     },
     {
         'id': 25.13,
@@ -7350,6 +7352,7 @@ export const pokemonList = createPokemonArray(
         'gender': {
             'femaleRatio': 0.125,
         },
+        'heldItem': { type: ItemType.item, id: 'Rare_Candy' },
     },
     {
         'id': 175.02,

--- a/src/modules/specialEvents/SpecialEvents.ts
+++ b/src/modules/specialEvents/SpecialEvents.ts
@@ -167,7 +167,7 @@ export default class SpecialEvents implements Feature {
             },
         );
         // Halloween
-        this.newEvent('Halloween!', 'Spooky Pokémon are Trick-or-treating for a limited time around Kanto, Johto and Hoenn.',
+        this.newEvent('Halloween!', 'Spooky Pokémon are trick-or-treating for a limited time around Kanto, Johto and Hoenn.',
             // Start
             new Date(new Date().getFullYear(), 9, 30, 1), () => {
             },

--- a/src/modules/specialEvents/SpecialEvents.ts
+++ b/src/modules/specialEvents/SpecialEvents.ts
@@ -167,7 +167,7 @@ export default class SpecialEvents implements Feature {
             },
         );
         // Halloween
-        this.newEvent('Halloween!', 'Encounter Spooky Pokémon for a limited time around Kanto, Johto and Hoenn.',
+        this.newEvent('Halloween!', 'Spooky Pokémon are Trick-or-treating for a limited time around Kanto, Johto and Hoenn.',
             // Start
             new Date(new Date().getFullYear(), 9, 30, 1), () => {
             },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Spooky Bulbasaur, Spooky Togepi and Pikachu (Gengar) can now drop rare candy.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Halloween is all about candy


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Hasn't.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
<img width="1035" height="476" alt="image" src="https://github.com/user-attachments/assets/8c1483e9-f0a9-4620-a99c-ba4a1eb0e775" />



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- New drops
