### PR TITLE
Update Plot.ts Micle Carveout Fix

### DIFF
--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -75,7 +75,7 @@ class Plot implements Saveable {
 
                 const boost = this.auraBoost();
                 const value = this.berryData.aura.getAuraValue(this.stage());
-                return value > 1 || this.berry === BerryType.Micle ? value * boost : value / boost;
+                return value > 1 ? value * boost : value / boost;
             }).extend({ rateLimit: 50 }),
         };
 


### PR DESCRIPTION
Removed old Carveout for Micle + lum interaction


## Description

Removed old invalid Carveout for Micle + lum interaction it was making micle aura worse due to the old micle Aura

previously it was 0.97x with lum instead and now 0.92x attract aura

## Motivation and Context
clean up old code that was never changed with new functionality


## How Has This Been Tested?
ran test on testing environment through visual studio and npm start


## Screenshots (optional):
NEW Without Lum
<img width="299" height="407" alt="image" src="https://github.com/user-attachments/assets/f3c28da8-71ca-40e9-913e-017fc6d35d74" />

NEW With Lum
<img width="344" height="399" alt="image" src="https://github.com/user-attachments/assets/6ad4e89d-9de5-401b-b37e-5016f60deec7" />

previously it was 0.97x with lum instead


## Types of changes

- Bug fix
