### PR TITLE
fix(farm): remove offset on plot age and stage

### DIFF
--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -55,7 +55,7 @@ class Plot implements Saveable {
         this._isSafeLocked = ko.observable(false);
         this._berry = ko.observable(berry).extend({ numeric: 0 });
         this._lastPlanted = ko.observable(berry).extend({ numeric: 0 });
-        this._age = ko.observable(age);
+        this._age = ko.observable(age).extend({ numeric: 5 });
         this._mulch = ko.observable(mulch).extend({ numeric: 0 });
         this._mulchTimeLeft = ko.observable(mulchTimeLeft).extend({ numeric: 3 });
         this._wanderer = ko.observable(undefined);
@@ -194,7 +194,7 @@ class Plot implements Saveable {
             if (this.berry === BerryType.None) {
                 return PlotStage.Seed;
             }
-            return this.berryData.growthTime.findIndex(t => this.age <= t);
+            return this.berryData.growthTime.findIndex(t => this.age < t);
         });
 
         this.tooltip = ko.pureComputed(() => {
@@ -319,7 +319,7 @@ class Plot implements Saveable {
 
             // Checking for Petaya Berries
             if (App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && this.berry !== BerryType.Petaya) {
-                this.age = Math.min(this.age, this.berryData.growthTime[3] + 1);
+                this.age = Math.min(this.age, this.berryData.growthTime[3]);
             }
 
             const updatedStage = this.stageUpdated(oldAge, this.age);
@@ -333,12 +333,12 @@ class Plot implements Saveable {
                 change = true;
             }
 
-            if (!this._hasWarnedAboutToWither && this.age + 15 > this.berryData.growthTime[4]) {
+            if (!this._hasWarnedAboutToWither && this.age + 15 >= this.berryData.growthTime[4]) {
                 this.notifications.push(FarmNotificationType.AboutToWither);
                 this._hasWarnedAboutToWither = true;
             }
 
-            if (this.age > this.berryData.growthTime[4]) {
+            if (this.age >= this.berryData.growthTime[4]) {
                 this.die();
                 change = true;
             }


### PR DESCRIPTION
## Description
Added age rounding back with more significant digits : this prevents the ~~shitty~~ wonderful JS math accuracy from messing with timers.
Fixed bug / inconsistancy : plot stage was erroneously updated on the next tick.

## Motivation and Context
Fixes the fix (#5460), closes #5817 with a cleaner solution.

## How Has This Been Tested?
Witnessed no error from earlier stage actualization, confirmed #5460 was still fine. Hired Jessy for tick-perfect harvests.

## Screenshots (optional):
<img width="900" height="506" alt="image" src="https://github.com/user-attachments/assets/dedb7e4e-d204-42b1-8944-3d88e04ac543" />


## Types of changes
- Bug fix
