### PR TITLE
Pokerus Questline

### DIFF
--- a/src/modules/quests/QuestLineNameType.ts
+++ b/src/modules/quests/QuestLineNameType.ts
@@ -32,6 +32,7 @@ export type QuestLineNameType
     | 'A Meta Discovery'
     | 'Shadows in the Desert'
     | 'A New World'
+    | 'An Incurable Disease?'
     | 'Recover the Precious Egg!'
     | 'Zero\'s Ambition'
     | 'Hollow Truth and Ideals'

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -1269,7 +1269,25 @@ class QuestLineHelper {
 
         App.game.quests.questLines().push(manaphyQuestLine);
     }
+     // Pokerus NPC - Available post-A New World
+       
+     public static AnIncurableDisease() {
+        const AnIncurableDisease = new QuestLine('An Incurable Disease?', 'Your Pokemon have a new disease but is it all that bad?', new MultiRequirement([new QuestLineCompletedRequirement('A New World'), new PokerusStatusRequirement(1, GameConstants.Pokerus.Contagious)]), GameConstants.BulletinBoards.Sinnoh);
+    
+        const talktoJulia = new TalkToNPCQuest(SunyshoreRibbonerJulia, 'There\'s a woman in Sunyshore city who seems to know a lot about this new Pokevirus. Talk to her to learn more');
+        AnIncurableDisease.addQuest(talktoJulia);
+    
+        const learntoinfect = new CustomQuest(3, 0, 'Infect three pokemon by putting your contagious Kanto starter in the hatchery with three pokemon that share at least 1 type with it then wait for them to hatch', new PokerusStatusRequirement(3, GameConstants.Pokerus.Contagious));
+        AnIncurableDisease.addQuest(learntoinfect);
 
+        const talktoDoctor = new TalkToNPCQuest(SunyshoreDoctor, "A doctor found out you're spreading diseases to your Pokemon and seems upset. Talk some sense into them in Sunyshore City")
+        AnIncurableDisease.addQuest(talktoDoctor);
+
+        const learntoresist = new CustomQuest(1, 0, 'Try to resist Pokerus on one of your contagious Pokemon by catching it repeatedly and obtaining 50 EVs', new PokerusStatusRequirement(1, GameConstants.Pokerus.resistant));
+        AnIncurableDisease.addQuest(learntoresist)
+
+        App.game.quests.questLines().push(AnIncurableDisease);
+        }
     // Giratina quest - Available post-E4, must have obtained Azelf, Mesprit, and Uxie
     public static createGiratinaQuestLine() {
         const giratinaQuestLine = new QuestLine('Zero\'s Ambition', 'Help Zero find an entrance to the Distortion World.', new MultiRequirement([new ObtainedPokemonRequirement('Uxie'), new ObtainedPokemonRequirement('Mesprit'), new ObtainedPokemonRequirement('Azelf'), new GymBadgeRequirement(BadgeEnums.Elite_SinnohChampion)]), GameConstants.BulletinBoards.Sinnoh);

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -4294,6 +4294,15 @@ const SunyshoreRibbonerJulia = new NPC('Ribboner Julia', [
     'If you have a Pokémon with Pokérus, try catching more of that type of Pokémon. When he got back from his next trip, oddly enough Wailmer seemed stronger than ever!',
 ], {image: 'assets/images/npcs/Beauty.png'});
 
+const SunyshoreDoctor = new NPC('Sunyshore Doctor', [ 
+    'How irresponsible of you spreading disease without a proper medical license! We must treat your Pokemon immediately!',
+    'Once your Pokemon are contagious, I found Pokerus can be resisted by obtaining multiples of the same Pokemon which increases their EV\'s or Effort Values.',
+    'I suspect this repeated exposure and increasing their EV\'s could even make your Pokemon stronger - could you please test this for me?'
+], {image: 'assets/images/npcs/Doctor.png', 
+requirement: new QuestLineStepCompletedRequirement('An Incurable Disease?', 2)
+}
+); 
+
 const FightAreaAceTrainer = new NPC('Ace Trainer Quinn', [
     'Something amazing happened on top of Mt. Coronet. We could see it all the way from here. I\'m sure everyone in the entire region saw it.',
     'What? You were there? What happened? What was that purple thing?',

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -4732,7 +4732,7 @@ TownList['Sunyshore City'] = new Town(
     [SunyshoreCityShop, new ShardTraderShop(GameConstants.ShardTraderLocations['Sunyshore City'])],
     {
         requirements: [new RouteKillRequirement(10, GameConstants.Region.sinnoh, 222)],
-        npcs: [SunyshoreRibbonerJulia],
+        npcs: [SunyshoreRibbonerJulia, SunyshoreDoctor],
     }
 );
 TownList['Fight Area'] = new Town(


### PR DESCRIPTION
## Description
Added a "Persons of Interest" style quest upon unlocking pokerus including quest steps teaching infection and resisting. 



## Motivation and Context
Too many people gloss over the mechanic and the game doesn't do a great job of explaining how it works currently.  


## How Has This Been Tested?
It hasn't 


## Types of changes
- New Questline