### PR TITLE
Yellow teams for Blue

### DIFF
--- a/src/scripts/gym/GymList.ts
+++ b/src/scripts/gym/GymList.ts
@@ -217,9 +217,21 @@ GymList['Champion Blue'] = new Gym(
     'Blue',
     'Champion Blue',
     [
-        new GymPokemon('Pidgeot', 52340, 59),
-        new GymPokemon('Alakazam', 56320, 57),
-        new GymPokemon('Rhydon', 58340, 59),
+        new GymPokemon('Pidgeot', 52340, 59, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Alakazam', 56320, 57, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Rhydon', 58340, 59, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
         new GymPokemon('Exeggutor', 57520, 59, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Gyarados', 65340, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Charizard', 70000, 63, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
@@ -229,9 +241,33 @@ GymList['Champion Blue'] = new Gym(
         new GymPokemon('Gyarados', 57520, 59, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
         new GymPokemon('Arcanine', 65340, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
         new GymPokemon('Venusaur', 70000, 63, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Gyarados', 57520, 59, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Arcanine', 65340, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Venusaur', 70000, 63, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Sandslash', 38447, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Alakazam', 38447, 59, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Exeggutor', 38447, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Ninetales', 1040, 61, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Cloyster', 1040, 63, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Jolteon', 1040, 65, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Cloyster', 1040, 61, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
+        new GymPokemon('Magneton', 1040, 63, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
+        new GymPokemon('Flareon', 1040, 65, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
     ],
     BadgeEnums.Elite_KantoChampion,
     10000,

--- a/src/scripts/gym/GymList.ts
+++ b/src/scripts/gym/GymList.ts
@@ -241,30 +241,30 @@ GymList['Champion Blue'] = new Gym(
         new GymPokemon('Gyarados', 57520, 59, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
         new GymPokemon('Arcanine', 65340, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
         new GymPokemon('Venusaur', 70000, 63, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Sandslash', 38447, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Alakazam', 38447, 59, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Exeggutor', 38447, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Ninetales', 1040, 61, new MultiRequirement([
+        new GymPokemon('Sandslash', 52340, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Alakazam', 56320, 59, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Exeggutor', 58340, 61, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Ninetales', 57520, 61, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Cloyster', 1040, 63, new MultiRequirement([
+        new GymPokemon('Cloyster', 57520, 63, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Jolteon', 1040, 65, new MultiRequirement([
+        new GymPokemon('Jolteon', 65340, 65, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Cloyster', 1040, 61, new MultiRequirement([
+        new GymPokemon('Cloyster', 65340, 61, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
-        new GymPokemon('Magneton', 1040, 63, new MultiRequirement([
+        new GymPokemon('Magneton', 70000, 63, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
-        new GymPokemon('Flareon', 1040, 65, new MultiRequirement([
+        new GymPokemon('Flareon', 70000, 65, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),

--- a/src/scripts/gym/GymList.ts
+++ b/src/scripts/gym/GymList.ts
@@ -258,15 +258,15 @@ GymList['Champion Blue'] = new Gym(
         ])),
         new GymPokemon('Cloyster', 65340, 61, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Magneton', 70000, 63, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Flareon', 70000, 65, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
     ],
     BadgeEnums.Elite_KantoChampion,

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -38,13 +38,13 @@ TemporaryBattleList['Blue 2'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Spearow', 1040, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Spearow', 3650, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Abra', 3230, 16, new OneFromManyRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Sandshrew', 1040, 15, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Sandshrew', 3230, 15, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Rattata', 3370, 15),
         new GymPokemon('Charmander', 3791, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Squirtle', 3791, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
@@ -68,19 +68,19 @@ TemporaryBattleList['Blue 3'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Spearow', 1040, 19, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Spearow', 12998, 19, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Raticate', 11902, 16, new OneFromManyRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Rattata', 1040, 16, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Rattata', 11902, 16, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Kadabra', 12094, 18, new OneFromManyRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Sandshrew', 1040, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Sandshrew', 12094, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charmeleon', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Wartortle', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Ivysaur', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
@@ -103,26 +103,26 @@ TemporaryBattleList['Blue 4'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Fearow', 1040, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Fearow', 30398, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Exeggcute', 28878, 23, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Growlithe', 28878, 23, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Gyarados', 28878, 23, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Shellder', 1040, 23, new MultiRequirement([
+        new GymPokemon('Shellder', 28878, 23, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Magnemite', 1040, 23, new MultiRequirement([
+        new GymPokemon('Magnemite', 28878, 23, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Gyarados', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Growlithe', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Vulpix', 1040, 23, new MultiRequirement([
+        new GymPokemon('Vulpix', 28878, 23, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Shellder', 1040, 23, new MultiRequirement([
+        new GymPokemon('Shellder', 28878, 23, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
@@ -131,6 +131,7 @@ TemporaryBattleList['Blue 4'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
+        new GymPokemon('Sandshrew', 30398, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charmeleon', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Wartortle', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Ivysaur', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
@@ -209,26 +210,26 @@ TemporaryBattleList['Blue 5'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Sandslash', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Sandslash', 41482, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Exeggcute', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Growlithe', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Gyarados', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Ninetales', 1040, 35, new MultiRequirement([
+        new GymPokemon('Ninetales', 38447, 35, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Cloyster', 1040, 35, new MultiRequirement([
+        new GymPokemon('Cloyster', 38447, 35, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Gyarados', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Growlithe', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Cloyster', 1040, 37, new MultiRequirement([
+        new GymPokemon('Cloyster', 38447, 37, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Magneton', 1040, 37, new MultiRequirement([
+        new GymPokemon('Magneton', 38447, 37, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
@@ -237,15 +238,15 @@ TemporaryBattleList['Blue 5'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Kadabra', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Kadabra', 41482, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charizard', 44113, 40, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Blastoise', 44113, 40, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Venusaur', 44113, 40, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Jolteon', 1040, 35, new MultiRequirement([
+        new GymPokemon('Jolteon', 44113, 35, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Flareon', 1040, 35, new MultiRequirement([
+        new GymPokemon('Flareon', 44113, 35, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
@@ -345,32 +346,32 @@ TemporaryBattleList['Blue 6'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Sandslash', 38447, 47, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Sandslash', 84840, 47, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Rhyhorn', 82269, 45, new OneFromManyRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Exeggcute', 38447, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Exeggcute', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Exeggcute', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Growlithe', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Gyarados', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Ninetales', 1040, 45, new MultiRequirement([
+        new GymPokemon('Ninetales', 82269, 45, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Cloyster', 1040, 45, new MultiRequirement([
+        new GymPokemon('Cloyster', 82269, 45, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Gyarados', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Growlithe', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Cloyster', 1040, 47, new MultiRequirement([
+        new GymPokemon('Cloyster', 82269, 47, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Magneton', 1040, 47, new MultiRequirement([
+        new GymPokemon('Magneton', 82269, 47, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),
@@ -379,15 +380,15 @@ TemporaryBattleList['Blue 6'] = new TemporaryBattle(
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
         ])),
-        new GymPokemon('Kadabra', 38447, 50, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Kadabra', 84840, 50, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charizard', 92553, 53, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Blastoise', 92553, 53, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Venusaur', 92553, 53, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Jolteon', 1040, 53, new MultiRequirement([
+        new GymPokemon('Jolteon', 92553, 53, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1'),
         ])),
-        new GymPokemon('Flareon', 1040, 53, new MultiRequirement([
+        new GymPokemon('Flareon', 92553, 53, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
             new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
         ])),

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -113,7 +113,7 @@ TemporaryBattleList['Blue 4'] = new TemporaryBattle(
         ])),
         new GymPokemon('Magnemite', 28878, 23, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Gyarados', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
@@ -124,7 +124,7 @@ TemporaryBattleList['Blue 4'] = new TemporaryBattle(
         ])),
         new GymPokemon('Shellder', 28878, 23, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Kadabra', 30398, 20, new OneFromManyRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
@@ -220,7 +220,7 @@ TemporaryBattleList['Blue 5'] = new TemporaryBattle(
         ])),
         new GymPokemon('Cloyster', 38447, 35, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Gyarados', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
@@ -231,7 +231,7 @@ TemporaryBattleList['Blue 5'] = new TemporaryBattle(
         ])),
         new GymPokemon('Magneton', 38447, 37, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Alakazam', 41482, 35, new OneFromManyRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
@@ -248,7 +248,7 @@ TemporaryBattleList['Blue 5'] = new TemporaryBattle(
         ])),
         new GymPokemon('Flareon', 44113, 35, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
     ],
     'I\'m moving on up and ahead! I\'m going to the Pokémon League to boot out the Elite Four! I\'ll become the world\'s most powerful Trainer! Well, good luck to you! Don\'t sweat it! Smell ya!',
@@ -362,7 +362,7 @@ TemporaryBattleList['Blue 6'] = new TemporaryBattle(
         ])),
         new GymPokemon('Cloyster', 82269, 45, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Gyarados', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
@@ -373,7 +373,7 @@ TemporaryBattleList['Blue 6'] = new TemporaryBattle(
         ])),
         new GymPokemon('Magneton', 82269, 47, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
         new GymPokemon('Alakazam', 84840, 47, new OneFromManyRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
@@ -390,7 +390,7 @@ TemporaryBattleList['Blue 6'] = new TemporaryBattle(
         ])),
         new GymPokemon('Flareon', 92553, 53, new MultiRequirement([
             new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
-            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+            new TemporaryBattleRequirement('Blue 1', 1, GameConstants.AchievementOption.less),
         ])),
     ],
     'That loosened me up. I\'m ready for the Pokémon League! You need more practice! But hey, you know that! I\'m out of here. Smell ya!',

--- a/src/scripts/temporaryBattle/TemporaryBattleList.ts
+++ b/src/scripts/temporaryBattle/TemporaryBattleList.ts
@@ -6,11 +6,16 @@ const TemporaryBattleList: { [battleName: string]: TemporaryBattle } = {};
 TemporaryBattleList['Blue 1'] = new TemporaryBattle(
     'Blue 1',
     [
-        new GymPokemon('Pidgey', 1040, 9),
+        new GymPokemon('Pidgey', 1040, 9, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Spearow', 1040, 9, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charmander', 1678, 9, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Squirtle', 1678, 9, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Bulbasaur', 1678, 9, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Bulbasaur', 1678, 9, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Eevee', 1678, 8, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
     ],
     'I heard the Pokémon League is crawling with tough Trainers. I have to figure out how to get past them. You should quit dawdling and get a move on!',
     [
@@ -28,13 +33,23 @@ TemporaryBattleList['Blue 1'] = new TemporaryBattle(
 TemporaryBattleList['Blue 2'] = new TemporaryBattle(
     'Blue 2',
     [
-        new GymPokemon('Pidgeotto', 3650, 17),
-        new GymPokemon('Abra', 3230, 16),
+        new GymPokemon('Pidgeotto', 3650, 17, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Spearow', 1040, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Abra', 3230, 16, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Sandshrew', 1040, 15, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Rattata', 3370, 15),
         new GymPokemon('Charmander', 3791, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Squirtle', 3791, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Bulbasaur', 3791, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Bulbasaur', 3791, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Eevee', 3791, 17, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
     ],
     'Hey! Take it easy! You won already!',
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 4)],
@@ -48,13 +63,28 @@ TemporaryBattleList['Blue 2'] = new TemporaryBattle(
 TemporaryBattleList['Blue 3'] = new TemporaryBattle(
     'Blue 3',
     [
-        new GymPokemon('Pidgeotto', 12998, 19),
-        new GymPokemon('Raticate', 11902, 16),
-        new GymPokemon('Kadabra', 12094, 18),
+        new GymPokemon('Pidgeotto', 12998, 19, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Spearow', 1040, 19, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Raticate', 11902, 16, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Rattata', 1040, 16, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Kadabra', 12094, 18, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Sandshrew', 1040, 18, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charmeleon', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Wartortle', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Ivysaur', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Ivysaur', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Eevee', 13437, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
     ],
     'Humph! At least you\'re raising your Pokémon!',
     [new RouteKillRequirement(10, GameConstants.Region.kanto, 6)],
@@ -68,20 +98,43 @@ TemporaryBattleList['Blue 3'] = new TemporaryBattle(
 TemporaryBattleList['Blue 4'] = new TemporaryBattle(
     'Blue 4',
     [
-        new GymPokemon('Pidgeotto', 30398, 25),
+        new GymPokemon('Pidgeotto', 30398, 25, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Fearow', 1040, 20, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Exeggcute', 28878, 23, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Growlithe', 28878, 23, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Gyarados', 28878, 23, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Gyarados', 28878, 23, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Shellder', 1040, 23, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Magnemite', 1040, 23, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
         new GymPokemon('Gyarados', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Growlithe', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Growlithe', 28878, 22, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Kadabra', 30398, 20),
+        new GymPokemon('Vulpix', 1040, 23, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Shellder', 1040, 23, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
+        new GymPokemon('Kadabra', 30398, 20, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
         new GymPokemon('Charmeleon', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Wartortle', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Ivysaur', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Ivysaur', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Eevee', 33438, 25, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
     ],
     'What? You stinker! I took it easy on you, too!',
     [new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Pokémon Tower'))],
@@ -151,20 +204,51 @@ TemporaryBattleList['Snorlax route 16'] = new TemporaryBattle(
 TemporaryBattleList['Blue 5'] = new TemporaryBattle(
     'Blue 5',
     [
-        new GymPokemon('Pidgeot', 41482, 37),
+        new GymPokemon('Pidgeot', 41482, 37, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Sandslash', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Exeggcute', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Growlithe', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Gyarados', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Gyarados', 38447, 38, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Ninetales', 1040, 35, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Cloyster', 1040, 35, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
         new GymPokemon('Gyarados', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Growlithe', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Growlithe', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Alakazam', 41482, 35),
+        new GymPokemon('Cloyster', 1040, 37, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Magneton', 1040, 37, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
+        new GymPokemon('Alakazam', 41482, 35, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Kadabra', 38447, 35, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charizard', 44113, 40, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Blastoise', 44113, 40, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Venusaur', 44113, 40, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Venusaur', 44113, 40, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Jolteon', 1040, 35, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Flareon', 1040, 35, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
     ],
     'I\'m moving on up and ahead! I\'m going to the Pokémon League to boot out the Elite Four! I\'ll become the world\'s most powerful Trainer! Well, good luck to you! Don\'t sweat it! Smell ya!',
     [new QuestLineStepCompletedRequirement('Team Rocket', 1)],
@@ -256,21 +340,57 @@ TemporaryBattleList['Bill\'s Grandpa'] = new TemporaryBattle(
 TemporaryBattleList['Blue 6'] = new TemporaryBattle(
     'Blue 6',
     [
-        new GymPokemon('Pidgeot', 84840, 47),
-        new GymPokemon('Rhyhorn', 82269, 45),
+        new GymPokemon('Pidgeot', 84840, 47, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Sandslash', 38447, 47, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Rhyhorn', 82269, 45, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Exeggcute', 38447, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Exeggcute', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Growlithe', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Gyarados', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Gyarados', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Ninetales', 1040, 45, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Cloyster', 1040, 45, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
         new GymPokemon('Gyarados', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Exeggcute', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Growlithe', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Growlithe', 82269, 45, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
-        new GymPokemon('Alakazam', 84840, 47),
+        new GymPokemon('Cloyster', 1040, 47, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Magneton', 1040, 47, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
+        new GymPokemon('Alakazam', 84840, 47, new OneFromManyRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire),
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water),
+        ])),
+        new GymPokemon('Kadabra', 38447, 50, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
         new GymPokemon('Charizard', 92553, 53, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Grass)),
         new GymPokemon('Blastoise', 92553, 53, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Fire)),
         new GymPokemon('Venusaur', 92553, 53, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Water)),
-        new GymPokemon('Venusaur', 92553, 53, new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special)),
+        new GymPokemon('Jolteon', 1040, 53, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1'),
+        ])),
+        new GymPokemon('Flareon', 1040, 53, new MultiRequirement([
+            new StarterRequirement(GameConstants.Region.kanto, GameConstants.Starter.Special),
+            new TemporaryBattleRequirement('Blue 1', GameConstants.AchievementOption.less),
+        ])),
     ],
     'That loosened me up. I\'m ready for the Pokémon League! You need more practice! But hey, you know that! I\'m out of here. Smell ya!',
     [


### PR DESCRIPTION
Once upon a time, I changed all of Kanto to use Yellow's encounters. Then, some time later, that was reverted back to FRLG. This is me meeting both approaches halfway.
With this, only Blue will use his yellow team, and only if your starter is Pikachu.
If you have defeated Blue 1, he will use his Jolteon team.
If you haven't, he will use his Flareon team.
He will never use his Vaporeon team. Couldn't think of a way to make that work.