### PR TITLE
Scaling prices

### DIFF
--- a/src/modules/items/BattleItem.ts
+++ b/src/modules/items/BattleItem.ts
@@ -4,6 +4,7 @@ import MultiplierType from '../multiplier/MultiplierType';
 import NotificationConstants from '../notifications/NotificationConstants';
 import Notifier from '../notifications/Notifier';
 import Item from './Item';
+import { ShopOptions } from './types';
 
 export default class BattleItem extends Item {
     type: BattleItemType;
@@ -13,11 +14,12 @@ export default class BattleItem extends Item {
         description: string,
         basePrice: number,
         currency: Currency = Currency.money,
+        options?: ShopOptions,
         displayName?: string,
         public multiplierType?: keyof typeof MultiplierType,
         public multiplyBy?: number,
     ) {
-        super(BattleItemType[type], basePrice, currency, undefined, displayName, description, 'battleItem');
+        super(BattleItemType[type], basePrice, currency, options, displayName, description, 'battleItem');
         this.type = type;
     }
 

--- a/src/modules/items/Item.ts
+++ b/src/modules/items/Item.ts
@@ -25,6 +25,7 @@ export default class Item {
     _displayName: string;
     imageDirectory?: string;
     visible?: Requirement;
+    badgeMult?: boolean;
 
     constructor(
         public name: string,
@@ -41,6 +42,7 @@ export default class Item {
         displayName?: string,
         description?: string,
         imageDirectory?: string,
+        badgeMult?: false,
     ) {
         // Base price needs to be positive, items that can't be purchased via currency should be priced at Infinity
         if (this.basePrice <= 0) {
@@ -82,7 +84,13 @@ export default class Item {
         const maxCost = (this.basePrice * 100 * (targetAmount - incAmount));
         const total = incCost + maxCost;
 
-        return Math.max(0, Math.round(total));
+        if (this.badgeMult = false) {
+            return Math.max(0, Math.round(total));
+        }
+
+        const badgeMultTotal = total + (total * App.game.badgeCase.badgeCount());
+
+        return Math.max(0, Math.round(badgeMultTotal));
     }
 
     buy(amt: number) {

--- a/src/modules/items/Item.ts
+++ b/src/modules/items/Item.ts
@@ -73,7 +73,7 @@ export default class Item {
         }
 
         if (this.multiplier === 1) {
-            return Math.max(0, this.basePrice + ( this.basePrice * targetAmount * App.game.badgeCase.badgeCount() ));
+            return Math.max(0, this.basePrice * targetAmount * ( App.game.badgeCase.badgeCount() + 1 ) );
         }
 
         // multiplier should be capped at 100, so work out how many to buy at increasing price and how many at max
@@ -93,7 +93,7 @@ export default class Item {
             return Math.max(0, Math.round(total));
         }
 
-        const badgeMultTotal = total + (total * App.game.badgeCase.badgeCount());
+        const badgeMultTotal = ( total * ( App.game.badgeCase.badgeCount() + 1 ) );
 
         return Math.max(0, Math.round(badgeMultTotal));
     }

--- a/src/modules/items/Item.ts
+++ b/src/modules/items/Item.ts
@@ -68,8 +68,12 @@ export default class Item {
     totalPrice(amount: number): number {
         const targetAmount = Math.min(amount, this.maxAmount);
 
-        if (this.multiplier === 1) {
+        if (this.multiplier === 1 && !this.badgeMult) {
             return Math.max(0, this.basePrice * targetAmount);
+        }
+
+        if (this.multiplier === 1 && this.badgeMult === true) {
+            return Math.max(0, this.basePrice + ( this.basePrice * targetAmount * App.game.badgeCase.badgeCount() ));
         }
 
         // multiplier should be capped at 100, so work out how many to buy at increasing price and how many at max

--- a/src/modules/items/Item.ts
+++ b/src/modules/items/Item.ts
@@ -19,13 +19,13 @@ export default class Item {
     multiplier: number;
     multiplierDecrease: boolean;
     multiplierDecreaser: MultiplierDecreaser;
+    badgeMult: boolean;
 
     maxAmount: number;
     _description?: string;
     _displayName: string;
     imageDirectory?: string;
     visible?: Requirement;
-    badgeMult?: boolean;
 
     constructor(
         public name: string,
@@ -37,12 +37,12 @@ export default class Item {
             multiplier = ITEM_PRICE_MULTIPLIER,
             multiplierDecrease = true,
             multiplierDecreaser = MultiplierDecreaser.Battle,
+            badgeMult = false,
             visible = undefined,
         } : ShopOptions = {},
         displayName?: string,
         description?: string,
         imageDirectory?: string,
-        badgeMult?: false,
     ) {
         // Base price needs to be positive, items that can't be purchased via currency should be priced at Infinity
         if (this.basePrice <= 0) {
@@ -57,6 +57,7 @@ export default class Item {
         this.multiplier = Math.max(1, multiplier || ITEM_PRICE_MULTIPLIER);
         this.multiplierDecrease = this.multiplier > 1 ? multiplierDecrease : false;
         this.multiplierDecreaser = multiplierDecreaser || MultiplierDecreaser.Battle;
+        this.badgeMult = badgeMult;
         this.visible = visible;
 
         this._displayName = displayName;
@@ -84,7 +85,7 @@ export default class Item {
         const maxCost = (this.basePrice * 100 * (targetAmount - incAmount));
         const total = incCost + maxCost;
 
-        if (this.badgeMult = false) {
+        if (!this.badgeMult) {
             return Math.max(0, Math.round(total));
         }
 

--- a/src/modules/items/Item.ts
+++ b/src/modules/items/Item.ts
@@ -72,7 +72,7 @@ export default class Item {
             return Math.max(0, this.basePrice * targetAmount);
         }
 
-        if (this.multiplier === 1 && this.badgeMult === true) {
+        if (this.multiplier === 1) {
             return Math.max(0, this.basePrice + ( this.basePrice * targetAmount * App.game.badgeCase.badgeCount() ));
         }
 

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -85,7 +85,7 @@ ItemList.Amaze_Mulch = new MulchItem(MulchType.Amaze_Mulch, 200, 'Amaze Mulch', 
 ItemList.Freeze_Mulch = new MulchItem(MulchType.Freeze_Mulch, 350, 'Freeze Mulch', 'Stops Berry growth and auras. Mutations will still occur while berries are frozen.');
 ItemList.Gooey_Mulch = new MulchItem(MulchType.Gooey_Mulch, 100, 'Gooey Mulch', 'Helps attract rarer species. Gooed Pokémon are more likely to be caught.');
 
-ItemList.Pokeball   = new PokeballItem(Pokeball.Pokeball, 100, undefined, { multiplier: 1 }, 'Poké Ball');
+ItemList.Pokeball   = new PokeballItem(Pokeball.Pokeball, 100, undefined, { multiplier: 1, badgeMult?: true }, 'Poké Ball');
 ItemList.Greatball  = new PokeballItem(Pokeball.Greatball, 500, undefined, undefined, 'Great Ball');
 ItemList.Ultraball  = new PokeballItem(Pokeball.Ultraball, 2000, undefined, undefined, 'Ultra Ball');
 ItemList.Masterball = new PokeballItem(Pokeball.Masterball, 2500, Currency.questPoint, undefined, 'Master Ball');

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -86,8 +86,8 @@ ItemList.Freeze_Mulch = new MulchItem(MulchType.Freeze_Mulch, 350, 'Freeze Mulch
 ItemList.Gooey_Mulch = new MulchItem(MulchType.Gooey_Mulch, 100, 'Gooey Mulch', 'Helps attract rarer species. Gooed Pokémon are more likely to be caught.');
 
 ItemList.Pokeball   = new PokeballItem(Pokeball.Pokeball, 100, undefined, { multiplier: 1, badgeMult: true }, 'Poké Ball');
-ItemList.Greatball  = new PokeballItem(Pokeball.Greatball, 500, undefined, undefined, 'Great Ball');
-ItemList.Ultraball  = new PokeballItem(Pokeball.Ultraball, 2000, undefined, undefined, 'Ultra Ball');
+ItemList.Greatball  = new PokeballItem(Pokeball.Greatball, 125, undefined, { badgeMult: true }, 'Great Ball');
+ItemList.Ultraball  = new PokeballItem(Pokeball.Ultraball, 400, undefined, { badgeMult: true }, 'Ultra Ball');
 ItemList.Masterball = new PokeballItem(Pokeball.Masterball, 2500, Currency.questPoint, undefined, 'Master Ball');
 // Not sold in shops
 ItemList.Fastball = new PokeballItem(Pokeball.Fastball, Infinity, Currency.farmPoint, undefined, 'Fast Ball');

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -85,7 +85,7 @@ ItemList.Amaze_Mulch = new MulchItem(MulchType.Amaze_Mulch, 200, 'Amaze Mulch', 
 ItemList.Freeze_Mulch = new MulchItem(MulchType.Freeze_Mulch, 350, 'Freeze Mulch', 'Stops Berry growth and auras. Mutations will still occur while berries are frozen.');
 ItemList.Gooey_Mulch = new MulchItem(MulchType.Gooey_Mulch, 100, 'Gooey Mulch', 'Helps attract rarer species. Gooed Pokémon are more likely to be caught.');
 
-ItemList.Pokeball   = new PokeballItem(Pokeball.Pokeball, 100, undefined, { multiplier: 1, badgeMult?: true }, 'Poké Ball');
+ItemList.Pokeball   = new PokeballItem(Pokeball.Pokeball, 100, undefined, { multiplier: 1, badgeMult: true }, 'Poké Ball');
 ItemList.Greatball  = new PokeballItem(Pokeball.Greatball, 500, undefined, undefined, 'Great Ball');
 ItemList.Ultraball  = new PokeballItem(Pokeball.Ultraball, 2000, undefined, undefined, 'Ultra Ball');
 ItemList.Masterball = new PokeballItem(Pokeball.Masterball, 2500, Currency.questPoint, undefined, 'Master Ball');

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -46,12 +46,12 @@ import AttackGainConsumable from './AttackGainConsumable';
 // eslint-disable-next-line import/prefer-default-export
 export const ItemList: { [name: string]: Item } = {};
 
-ItemList.xAttack         = new BattleItem(BattleItemType.xAttack, '+50% Bonus to Pokémon attack for 30 seconds', 600, undefined, 'X Attack', 'pokemonAttack', 1.5);
-ItemList.xClick          = new BattleItem(BattleItemType.xClick, '+50% Bonus to click attack for 30 seconds', 400, undefined, 'X Click', 'clickAttack', 1.5);
-ItemList.Lucky_egg       = new BattleItem(BattleItemType.Lucky_egg, '+50% Bonus to experience gained for 30 seconds', 800, undefined, 'Lucky Egg', 'exp', 1.5);
-ItemList.Token_collector = new BattleItem(BattleItemType.Token_collector, '+50% Bonus to Dungeon Tokens gained for 30 seconds', 1000, undefined, 'Token Collector', 'dungeonToken', 1.5);
-ItemList.Dowsing_machine = new BattleItem(BattleItemType.Dowsing_machine, 'Increases chance for Pokémon to drop rare hold items and chance to multiply loot from dungeon chests, for 30 seconds.', 1500, undefined, 'Dowsing Machine');
-ItemList.Lucky_incense   = new BattleItem(BattleItemType.Lucky_incense, '+50% Bonus to Pokédollars gained for 30 seconds', 2000, undefined, 'Lucky Incense', 'money', 1.5);
+ItemList.xAttack         = new BattleItem(BattleItemType.xAttack, '+50% Bonus to Pokémon attack for 30 seconds', 600, undefined, { badgeMult: true }, 'X Attack', 'pokemonAttack', 1.5);
+ItemList.xClick          = new BattleItem(BattleItemType.xClick, '+50% Bonus to click attack for 30 seconds', 400, undefined, { badgeMult: true }, 'X Click', 'clickAttack', 1.5);
+ItemList.Lucky_egg       = new BattleItem(BattleItemType.Lucky_egg, '+50% Bonus to experience gained for 30 seconds', 400, undefined, { badgeMult: true }, 'Lucky Egg', 'exp', 1.5);
+ItemList.Token_collector = new BattleItem(BattleItemType.Token_collector, '+50% Bonus to Dungeon Tokens gained for 30 seconds', 250, undefined, { badgeMult: true }, 'Token Collector', 'dungeonToken', 1.5);
+ItemList.Dowsing_machine = new BattleItem(BattleItemType.Dowsing_machine, 'Increases chance for Pokémon to drop rare hold items and chance to multiply loot from dungeon chests, for 30 seconds.', 375, undefined, { badgeMult: true }, 'Dowsing Machine');
+ItemList.Lucky_incense   = new BattleItem(BattleItemType.Lucky_incense, '+50% Bonus to Pokédollars gained for 30 seconds', 500, undefined, { badgeMult: true }, 'Lucky Incense', 'money', 1.5);
 
 ItemList.ChopleBerry     = new BerryItem(BerryType.Chople, 10000, Currency.farmPoint, BerryType.Spelon);
 ItemList.KebiaBerry      = new BerryItem(BerryType.Kebia, 10000, Currency.farmPoint, BerryType.Pamtre);

--- a/src/modules/items/types.ts
+++ b/src/modules/items/types.ts
@@ -17,5 +17,6 @@ export interface ShopOptions {
     multiplier?: number,
     multiplierDecrease?: boolean,
     multiplierDecreaser?: MultiplierDecreaser,
+    badgeMult?: boolean;
     visible?: Requirement,
 }


### PR DESCRIPTION
Unpopular PR alert.
Pokédollars quickly lose value. A couple of deep sinks is a bandaid, nice to have, I am not opposed to their existence, but doesn't fix this long term.
This PR makes the cost of balls and battle items found in the department store scale with badge count. To clarify, the effect of this PR is limited to items that _can_ be found in the department store, but it changes their value _everywhere_. The current plan is to exclude restores from this.

ToDo: Make the badge count ignore optional badges. Orange Islands, Magikarp Jump.

(Image shows prices at 130 badges. The prices seen here do _not_ ignore the optional badges, the end result should be lower.)
<img width="781" height="350" alt="image" src="https://github.com/user-attachments/assets/122a41bd-9922-4a9e-a52b-970566358ed8" />