### PR TITLE
Change EON twin roamer requirements

### DIFF
--- a/src/modules/pokemons/RoamingPokemonList.ts
+++ b/src/modules/pokemons/RoamingPokemonList.ts
@@ -24,6 +24,7 @@ import MoonCyclePhaseRequirement from '../requirements/MoonCyclePhaseRequirement
 import MoonCyclePhase from '../moonCycle/MoonCyclePhase';
 import StatisticRequirement from '../requirements/StatisticRequirement';
 import { getPokemonByName } from './PokemonHelper';
+import OneFromManyRequirement from '../requirements/OneFromManyRequirement';
 
 export default class RoamingPokemonList {
     public static roamerGroups: RoamingGroup[][] = [
@@ -108,8 +109,8 @@ RoamingPokemonList.add(Region.johto, 0, new RoamingPokemon('Raikou', new QuestLi
 RoamingPokemonList.add(Region.johto, 0, new RoamingPokemon('Entei', new QuestLineStepCompletedRequirement('The Legendary Beasts', 3)));
 
 // Hoenn
-RoamingPokemonList.add(Region.hoenn, 0, new RoamingPokemon('Latios', new QuestLineStepCompletedRequirement('The Eon Duo', 3)));
-RoamingPokemonList.add(Region.hoenn, 0, new RoamingPokemon('Latias', new QuestLineStepCompletedRequirement('The Eon Duo', 3)));
+RoamingPokemonList.add(Region.hoenn, 0, new RoamingPokemon('Latios', new OneFromManyRequirement([new MultiRequirement([new QuestLineStepCompletedRequirement('The Eon Duo', 3), new ObtainedPokemonRequirement('Latias')]), new QuestLineCompletedRequirement('The Eon Duo')])));
+RoamingPokemonList.add(Region.hoenn, 0, new RoamingPokemon('Latias', new OneFromManyRequirement([new MultiRequirement([new QuestLineStepCompletedRequirement('The Eon Duo', 3), new ObtainedPokemonRequirement('Latios')]), new QuestLineCompletedRequirement('The Eon Duo')])));
 RoamingPokemonList.add(Region.hoenn, 0, new RoamingPokemon('Jirachi', new QuestLineStepCompletedRequirement('Wish Maker', 8)));
 // Orre
 RoamingPokemonList.add(Region.hoenn, 1, new RoamingPokemon('Ho-Oh', new QuestLineCompletedRequirement('Shadows in the Desert')));


### PR DESCRIPTION
This makes finishing The EON Duo questline easier by adding only one of them to the roamer pool, the one that didn't join your party on Southern Island.
If you are on the right quest step and own Latias, then Latios will roam. If you are on the right quest step and own Latios, then Latias will roam. If you have completed the questline, they will both roam. This last check seems redundant, but it's there to catch situations where the player loses one of the twins later on, like when mega evolving them with the real evolution challenge active. Wouldn't want that to result in a roamer vanishing.
<img width="748" height="422" alt="image" src="https://github.com/user-attachments/assets/f861901d-21bf-4b29-83f6-40853f702480" />
<img width="831" height="409" alt="image" src="https://github.com/user-attachments/assets/cb66b5bf-b88f-4fd7-ac5f-138553bc314b" />