### PR TITLE
Made catching pokemon in the safari zone count as a use of Magic Ball

### DIFF
--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -154,6 +154,7 @@ class SafariBattle {
                 if (!isgameOver) {
                     Safari.spawnItemCheck();
                 }
+                App.game.oakItems.use(OakItemType.Magic_Ball);
                 $('#safariBall').css('filter', 'brightness(0.4) grayscale(100%)');
                 SafariBattle.delay(SafariBattle.Speed.enemyCaught * (1 + SafariBattle.getTierMultiplier()) / 2, false)
                     .then(() => {

--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -154,7 +154,6 @@ class SafariBattle {
                 if (!isgameOver) {
                     Safari.spawnItemCheck();
                 }
-                App.game.oakItems.use(OakItemType.Magic_Ball);
                 $('#safariBall').css('filter', 'brightness(0.4) grayscale(100%)');
                 SafariBattle.delay(SafariBattle.Speed.enemyCaught * (1 + SafariBattle.getTierMultiplier()) / 2, false)
                     .then(() => {
@@ -176,6 +175,7 @@ class SafariBattle {
 
     private static capturePokemon() {
         SafariBattle.text(`GOTCHA!<br>${SafariBattle.enemy.displayName} was caught!`);
+        App.game.oakItems.use(OakItemType.Magic_Ball);
         GameHelper.incrementObservable(App.game.statistics.safariPokemonCaptured, 1);
         if (SafariBattle.enemy.shiny) {
             GameHelper.incrementObservable(App.game.statistics.safariShinyPokemonCaptured, 1);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

This makes it so that whenever a Pokemon is caught in the Safari Zone, it counts as a use of the Magic Ball if it's equipped.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

Fixes #6124 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

When running a Magic Ball quest, whilst in the safari zone, I caught a pokemon with and without the Magic Ball equipped, and the former counted for the quest, and the latter didn't.


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix