### PR TITLE
Nerf Slow EV Challenge (or buff, depending on how you look at it)

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -441,7 +441,7 @@ export const BASE_WANDERER_EP_MODIFIER = 2;
 export const WANDERER_EP_MODIFIER = 10;
 
 export const EP_EV_RATIO = 1000;
-export const EP_CHALLENGE_MODIFIER = 10;
+export const EP_CHALLENGE_MODIFIER = 4;
 
 // Mega Evolution
 export const MEGA_REQUIRED_ATTACK_MULTIPLIER = 500;

--- a/src/modules/challenges/Challenges.ts
+++ b/src/modules/challenges/Challenges.ts
@@ -15,7 +15,7 @@ export default class Challenges implements Saveable {
         disableOakItems: new Challenge('No Oak Items', 'Disables the usage of all Oak Items'),
         disableGems: new Challenge('No Gem Upgrades', 'Disables the usage of Gems to increase type effectiveness'),
         disableVitamins: new Challenge('No Vitamins', 'Disables the usage of Vitamins'),
-        slowEVs: new Challenge('Slow EVs', 'Gain EVs 10x slower'),
+        slowEVs: new Challenge('Slow EVs', 'Gain EVs 4x slower'),
         realEvolutions: new Challenge('Real Evolution', 'Your Pokémon go away when they evolve'),
     };
 


### PR DESCRIPTION
EVs have a Slow challenge, instead of a disable challenge. The point of this is that a challenge is supposed to be... well... _challenging_, and disabling mechanics entirely kinda... isn't... that. The issue is that, based on feedback, the challenge slows down EV gain so severely that, in practice, it kinda disables the mechanic anyway. In which case the original point is lost.
This PR changes the Slow EV Challenge modifier from 10 to 4. Basically, reducing EV gain down to 25%, up from 10%.