### PR TITLE
[WIP] Repeatable rewards in BF

### DIFF
--- a/src/components/battleFrontierInfo.html
+++ b/src/components/battleFrontierInfo.html
@@ -38,7 +38,7 @@
             <tbody>
                 <!-- ko foreach: availableMilestones -->
                 <tr>
-                    <th class="tight" data-bind="text: $data.stage.toLocaleString('en-US')"></td>
+                    <th class="tight" data-bind="text: $data.nextStageReward(BattleFrontierRunner.checkpoint()).toLocaleString('en-US')"></td>
                     <td class="text-left">
                         <img width="28px" data-bind="attr:{ src: $data.image }" />
                         <knockout data-bind="text: $data.displayName"></knockout>

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -430,6 +430,7 @@ export const BASE_EP_YIELD = 100;
 export const STONE_EP_YIELD = 1000;
 export const SHOPMON_EP_YIELD = 1000;
 export const SAFARI_EP_YIELD = 1000;
+export const REWARD_EP_YIELD = 1000;
 
 export const SHINY_EP_MODIFIER = 5;
 export const REPEATBALL_EP_MODIFIER = 5;

--- a/src/scripts/Update.ts
+++ b/src/scripts/Update.ts
@@ -2959,6 +2959,11 @@ class Update implements Saveable {
             if (saveData.badgeCase[17]) {
                 Update.startQuestLine(saveData, 'Team Rocket Again');
             }
+
+            // Remove all BF rewards from the save
+            if (saveData.battleFrontier) {
+                delete saveData.battleFrontier.milestones;
+            }
         },
     };
 

--- a/src/scripts/battleFrontier/BattleFrontier.ts
+++ b/src/scripts/battleFrontier/BattleFrontier.ts
@@ -32,7 +32,7 @@ class BattleFrontier implements Feature {
 
     toJSON(): Record<string, any> {
         return {
-            milestones: this.milestones.milestoneRewards.filter(m => m.obtained()).map(m => [m.stage, m.description]),
+            milestones: this.milestones.milestoneRewards.map(r => r.toJSON()),
             checkpoint: BattleFrontierRunner.checkpoint(),
         };
     }
@@ -42,8 +42,8 @@ class BattleFrontier implements Feature {
             return;
         }
 
-        json.milestones?.forEach(([stage, description]) => {
-            this.milestones.milestoneRewards.find(m => m.stage == stage && m.description == description)?.obtained(true);
+        json.milestones?.forEach((data, index) => {
+            this.milestones.milestoneRewards[index].fromJSON(data);
         });
 
         BattleFrontierRunner.checkpoint(json.checkpoint);

--- a/src/scripts/battleFrontier/BattleFrontierMilestone.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestone.ts
@@ -1,23 +1,89 @@
 class BattleFrontierMilestone {
-    public obtained = ko.observable(false);
+    public obtained = ko.observable(0);
+    public stageCount = ko.observable(0);
 
     constructor (
         public stage: number,
         public rewardFunction: () => void,
         public requirement?: Requirement,
         public _image?: string,
-        private _description?: string
+        private _description?: string,
+        public repeatStage = Math.max(100, stage)
     ) { }
 
-    public isUnlocked(): boolean {
-        return this.requirement ? this.requirement.isCompleted() : true;
+    public isRepeatable(): boolean {
+        return !!this.repeatStage;
     }
 
-    gain () {
-        if (!this.obtained()) {
-            this.rewardFunction();
-            this.obtained(true);
+    public isObtainable(): boolean {
+        return (this.isRepeatable() || !this.obtained()) && (this.requirement?.isCompleted() ?? true);
+    }
+
+    private gain(defeatedStage: number) {
+        Notifier.notify({
+            title: 'Battle Frontier',
+            message: `You've successfully defeated stage ${defeatedStage.toLocaleString('en-US')} and earned:\n<span><img src="${this.image}" height="24px"/> ${this.description}</span>!`,
+            type: NotificationConstants.NotificationOption.info,
+            setting: NotificationConstants.NotificationSetting.General.battle_frontier,
+            timeout: (this.stage) / 10 * GameConstants.SECOND,
+        });
+        App.game.logbook.newLog(
+            LogBookTypes.FRONTIER,
+            createLogContent.gainBattleFrontierReward({
+                reward: this.description,
+                stage: defeatedStage.toLocaleString('en-US'),
+            })
+        );
+        this.rewardFunction();
+        GameHelper.incrementObservable(this.obtained);
+        this.stageCount(0);
+    }
+
+    public nextStageReward(stage: number): number {
+        if (!this.isObtainable()) {
+            return 0;
         }
+        if (!this.obtained()) {
+            return stage <= this.stage ? this.stage : 0;
+        }
+        return Math.max(stage, this.minStage()) + this.repeatStage - this.stageCount() - 1;
+    }
+
+    public minStage() {
+        return this.obtained() <= 1 ? this.stage : this.stage + (this.obtained() - 1) * 10;
+    }
+
+    clear(stage: number) {
+        if (!this.isObtainable()) {
+            return;
+        }
+        if (!this.obtained()) {
+            if (stage == this.stage) {
+                this.gain(stage);
+            }
+            return;
+        }
+        if (stage > this.minStage()) {
+            GameHelper.incrementObservable(this.stageCount);
+            if (this.stageCount() == this.repeatStage) {
+                this.gain(stage);
+            }
+        }
+    }
+
+    public fromJSON(json: Array<number>) {
+        if (!json) {
+            return;
+        }
+        this.obtained(json[0]);
+        this.stageCount(json[1]);
+    }
+
+    public toJSON() {
+        if (this.obtained()) {
+            return [this.obtained(), this.stageCount()];
+        }
+        return 0;
     }
 
     get image() {

--- a/src/scripts/battleFrontier/BattleFrontierMilestoneItem.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestoneItem.ts
@@ -2,12 +2,12 @@ class BattleFrontierMilestoneItem extends BattleFrontierMilestone {
     itemName: string;
     amount: number;
 
-    constructor (stage: number, itemName: string, amount: number, requirement?: Requirement ) {
+    constructor (stage: number, itemName: ItemNameType, amount: number, requirement?: Requirement, repeatStage?: number) {
         super(stage, () => {
             if (ItemList[itemName]) {
                 ItemList[itemName].gain(amount);
             }
-        });
+        }, requirement, undefined, undefined, repeatStage);
         this.requirement = requirement;
         this.itemName = itemName;
         this.amount = amount;
@@ -18,6 +18,6 @@ class BattleFrontierMilestoneItem extends BattleFrontierMilestone {
     }
 
     get description() {
-        return `${this.amount.toLocaleString('en-US')} x ${ItemList[this.itemName].displayName}`;
+        return `${this.amount.toLocaleString('en-US')} × ${ItemList[this.itemName].displayName}`;
     }
 }

--- a/src/scripts/battleFrontier/BattleFrontierMilestonePokemon.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestonePokemon.ts
@@ -1,13 +1,18 @@
 class BattleFrontierMilestonePokemon extends BattleFrontierMilestone {
-    constructor (stage: number, public pokemonName: string, requirement?: Requirement, image = `assets/images/items/pokemonItem/${pokemonName}.png`) {
+    constructor (stage: number, public pokemonName: PokemonNameType, requirement?: Requirement, image = `assets/images/items/pokemonItem/${pokemonName}.png`, repeatStage?: number) {
         super(
             stage,
             () => {
-                App.game.party.gainPokemonById(pokemonMap[pokemonName].id, PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_BATTLEFRONTIER));
+                const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_BATTLEFRONTIER);
+                App.game.party.gainPokemonById(pokemonMap[pokemonName].id, shiny);
+                const partyPokemon = App.game.party.getPokemonByName(pokemonName);
+                const stageEPModifier = this.repeatStage / 1000;
+                partyPokemon.effortPoints += App.game.party.calculateEffortPoints(partyPokemon, shiny, GameConstants.ShadowStatus.None, GameConstants.REWARD_EP_YIELD * stageEPModifier);
             },
             requirement,
             image,
-            pokemonName
+            pokemonName,
+            repeatStage
         );
     }
 

--- a/src/scripts/battleFrontier/BattleFrontierMilestones.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestones.ts
@@ -7,117 +7,37 @@ class BattleFrontierMilestones {
 
     public static addMilestone(milestone: BattleFrontierMilestone) {
         this.milestoneRewards.push(milestone);
-        // Sort the milestones by lowest to highest stage incase they are added out of order
-        this.milestoneRewards.sort((a, b) => a.stage - b.stage);
-    }
-
-    public static nextMileStone() {
-        // Get next reward that is unlocked, not obtained, and earned past the latest stage beaten in the active run.
-        return this.milestoneRewards.find(r => r.isUnlocked() && !r.obtained() && (r.stage > (BattleFrontierRunner.checkpoint() - 1)));
     }
 
     public static availableMilestones() {
-        return BattleFrontierMilestones.milestoneRewards.filter(r => r.isUnlocked() && !r.obtained() && r.stage > (BattleFrontierRunner.checkpoint() - 1));
-    }
-
-    public static nextMileStoneStage(): number {
-        // Return the stage number the next reward is unlocked at
-        const reward = this.nextMileStone();
-        if (reward) {
-            return reward.stage;
-        } else {
-            return Infinity;
-        }
-    }
-
-    public static nextMileStoneRewardDescription(): string {
-        // Return the description of the next reward
-        const reward = this.nextMileStone();
-        if (reward) {
-            return reward.description;
-        } else {
-            return 'Nothing';
-        }
+        const stage = BattleFrontierRunner.checkpoint();
+        return BattleFrontierMilestones.milestoneRewards.filter(r => r.nextStageReward(stage) >= stage).sort((a, b) => a.nextStageReward(stage) - b.nextStageReward(stage))
     }
 
     public static gainReward(defeatedStage: number): void {
-        const reward = this.nextMileStone();
-        if (reward && reward.stage == defeatedStage) {
-            Notifier.notify({
-                title: 'Battle Frontier',
-                message: `You've successfully defeated stage ${defeatedStage.toLocaleString('en-US')} and earned:\n<span><img src="${reward.image}" height="24px"/> ${reward.description}</span>!`,
-                type: NotificationConstants.NotificationOption.info,
-                setting: NotificationConstants.NotificationSetting.General.battle_frontier,
-                timeout: 1e4,
-            });
-            App.game.logbook.newLog(
-                LogBookTypes.FRONTIER,
-                createLogContent.gainBattleFrontierReward({
-                    reward: reward.description,
-                    stage: defeatedStage.toLocaleString('en-US'),
-                })
-            );
-            reward.gain();
-        }
+        this.milestoneRewards.forEach(r => r.clear(defeatedStage));
     }
 }
 
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(5, 'Pokeball', 25));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(10, 'Pokeball', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(20, 'Greatball', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(30, 'Ultraball', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(35, 'xClick', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(40, 'xAttack', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(50, 'SmallRestore', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(75, 'Rare_Candy', 5));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(100, 'Deoxys', new QuestLineStepCompletedRequirement('Mystery of Deoxys', 2)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(110, 'Water_stone', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(120, 'Leaf_stone', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(130, 'Thunder_stone', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(140, 'Fire_stone', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(150, 'MediumRestore', 200));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(110, 'Water_stone', 1));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(120, 'Leaf_stone', 1));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(130, 'Thunder_stone', 1));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(140, 'Fire_stone', 1));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(151, 'Deoxys (Attack)', new ObtainedPokemonRequirement('Deoxys')));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(160, 'Lucky_egg', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(170, 'Lucky_incense', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(180, 'Dowsing_machine', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(190, 'Mystery_egg', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(200, 'LargeRestore', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(210, 'Water_stone', 40));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(220, 'Leaf_stone', 40));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(230, 'Thunder_stone', 40));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(240, 'Moon_stone', 40));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(250, 'Ultraball', 6400));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(177, 'Soul_Dew', 999, undefined, 0));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(240, 'Moon_stone', 1));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(251, 'Deoxys (Defense)', new ObtainedPokemonRequirement('Deoxys')));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(275, 'Rare_Candy', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(300, 'Linking_cord', 100));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(310, 'Dragon_scale', 20));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(320, 'Sun_stone', 40));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(330, 'Kings_rock', 20));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(340, 'Metal_coat', 20));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(350, 'Upgrade', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(375, 'Rare_Candy', 15));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(275, 'Rare_Candy', 1));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(320, 'Sun_stone', 1));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(350, 'Upgrade', 1));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(386, 'Deoxys (Speed)', new ObtainedPokemonRequirement('Deoxys')));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(400, 'Soothe_bell', 40));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(410, 'Deepsea_tooth', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(420, 'Shiny_stone', 40));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(430, 'Deepsea_scale', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(440, 'Dusk_stone', 40, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(450, 'Prism_scale', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(460, 'Dawn_stone', 40, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(470, 'Razor_claw', 10, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(480, 'Razor_fang', 10, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(490, 'Dubious_disc', 10, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(500, 'Ultraball', 10000));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(525, 'Magmarizer', 15, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(550, 'Electirizer', 15, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(575, 'Protector', 15, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(600, 'Reaper_cloth', 15, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(660, 'Sachet', 15, new MaxRegionRequirement(GameConstants.Region.kalos)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(666, 'Vivillon (Poké Ball)', new QuestLineStepCompletedRequirement('The Great Vivillon Hunt!', 34)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(670, 'Whipped_dream', 15, new MaxRegionRequirement(GameConstants.Region.kalos)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(690, 'Lopunnite', 1, new MultiRequirement([new MaxRegionRequirement(GameConstants.Region.kalos), new ObtainedPokemonRequirement('Lopunny')])));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(700, 'Ice_stone', 40, new MaxRegionRequirement(GameConstants.Region.alola)));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(750, 'Rare_Candy', 20));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(400, 'Soothe_bell', 1));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(490, 'Dubious_disc', 1, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(525, 'Magmarizer', 1, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(550, 'Electirizer', 1, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(575, 'Protector', 1, new MaxRegionRequirement(GameConstants.Region.sinnoh)));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(666, 'Vivillon (Poké Ball)', new QuestLineStepCompletedRequirement('The Great Vivillon Hunt!', 34), undefined, 0));
+BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(690, 'Lopunnite', 1, new MultiRequirement([new MaxRegionRequirement(GameConstants.Region.kalos), new ObtainedPokemonRequirement('Lopunny')]), 0));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(1000, 'Masterball', 10));
-BattleFrontierMilestones.addMilestone(new BattleFrontierMilestoneItem(1500, 'Rare_Candy', 25));
 BattleFrontierMilestones.addMilestone(new BattleFrontierMilestonePokemon(2000, 'Mismagius (Illusion)', new ObtainedPokemonRequirement('Mismagius')));

--- a/src/scripts/battleFrontier/BattleFrontierMilestones.ts
+++ b/src/scripts/battleFrontier/BattleFrontierMilestones.ts
@@ -11,7 +11,7 @@ class BattleFrontierMilestones {
 
     public static availableMilestones() {
         const stage = BattleFrontierRunner.checkpoint();
-        return BattleFrontierMilestones.milestoneRewards.filter(r => r.nextStageReward(stage) >= stage).sort((a, b) => a.nextStageReward(stage) - b.nextStageReward(stage))
+        return BattleFrontierMilestones.milestoneRewards.filter(r => r.nextStageReward(stage) >= stage).sort((a, b) => a.nextStageReward(stage) - b.nextStageReward(stage));
     }
 
     public static gainReward(defeatedStage: number): void {

--- a/src/scripts/battleFrontier/BattleFrontierRunner.ts
+++ b/src/scripts/battleFrontier/BattleFrontierRunner.ts
@@ -43,6 +43,7 @@ class BattleFrontierRunner {
 
         this.started(true);
         this.stage(useCheckpoint ? this.checkpoint() : 1);
+        this.checkpoint(this.stage());
         this.highest(App.game.statistics.battleFrontierHighestStageCompleted());
         BattleFrontierBattle.pokemonIndex(0);
         BattleFrontierBattle.generateNewEnemy();

--- a/src/scripts/pokemons/PokemonLocations.ts
+++ b/src/scripts/pokemons/PokemonLocations.ts
@@ -356,16 +356,16 @@ class PokemonLocations {
         return (evolutionPokemon as PokemonListData)?.evolutions?.find(e => e.evolvedPokemon == pokemonName);
     }
 
-    public static getPokemonBattleFrontier(pokemonName: PokemonNameType): Array<number> {
-        const cache = this.getCache<number[]>(this.getPokemonBattleFrontier.name);
+    public static getPokemonBattleFrontier(pokemonName: PokemonNameType): Array<BattleFrontierMilestone> {
+        const cache = this.getCache<BattleFrontierMilestone[]>(this.getPokemonBattleFrontier.name);
         if (cache[pokemonName]) {
             return cache[pokemonName];
         }
-        const cacheLine = this.initCacheLine(cache, Array<number>);
+        const cacheLine = this.initCacheLine(cache, Array<BattleFrontierMilestone>);
         pokemonList.forEach(p => cacheLine[p.name] = []);
         BattleFrontierMilestones.milestoneRewards.filter(m => m instanceof BattleFrontierMilestonePokemon).forEach(milestone => {
             if (this.pokemonNames.includes(milestone._description)) {
-                cacheLine[milestone._description].push(milestone.stage);
+                cacheLine[milestone._description].push(milestone);
             }
         });
         return cacheLine[pokemonName];
@@ -777,7 +777,8 @@ class PokemonLocations {
             locations[PokemonLocationType.ShadowPokemon] ||
             locations[PokemonLocationType.DreamOrb] ||
             locations[PokemonLocationType.BattleCafe] ||
-            locations[PokemonLocationType.SafariItem];
+            locations[PokemonLocationType.SafariItem] ||
+            (locations[PokemonLocationType.BattleFrontier]?.some(milestone => milestone.repeatStage));
         return !isEvable && Object.keys(locations).length > 0;
     };
 }


### PR DESCRIPTION
## Description
Prototype for now. Will probably need feedback from a beta test before putting the actual stuffs in it.
Basically, you obtain a reward at stage X, then need to do X cumulative stages above X to get it again.
Pokémon rewards can now be EV-trained in there.

## Motivation and Context
BF feels empty past stage 700.

## How Has This Been Tested?
Made sure repeatable rewards could be obtained several times, and one-time rewards couldn't.

## Types of changes
- Feature improvement
