### PR TITLE
Changes on hatchery helpers

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -698,11 +698,11 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                         <p><i>(unlocked after hatching 100 total Pokémon)</i></p>
                         <p>Hatchery Helpers will help out by automatically breeding your Pokémon for you.</p>
                         <p>The cost displayed is how much you will be charged per hatch.</p>
-                        <p>They will only breed Pokémon based on your current Hatchery filters.</p>
-                        <p>All of the Helpers have different step efficiencies and will hatch eggs faster or slower depending on their value.</p>
-                        <p>They each also have different attack efficiencies, which will determine how much attack you gain compared to manually hatching the Pokémon yourself.</p>
-                        <p>These efficiencies will gain a bonus based on how many times you've used the helper to hatch eggs.</p>
-                        <p><i>More Hatchery Helpers can be unlocked through shops and hatching more Pokémon</i></p>
+                        <p>As a default, they will breed Pokémon based on your current Hatchery filters.</p>
+                        <p>Or you can tell a Hatchery Helper to breed Pokémon from specific categories, only or in addition to your filters.</p>
+                        <p>All of the Helpers have different efficiencies, which will determine how much attack you gain compared to manually hatching the Pokémon yourself.</p>
+                        <p>They also gain levels based on the number of eggs hatched. Each level increases the efficiency according to their specific bonus.</p>
+                        <p><i>More Hatchery Helpers can be unlocked through shops or from progressing through the game</i></p>
                     </div>
 
                 </div>

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -514,15 +514,15 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                 <td class="text-right" data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.cost.amount, 'currency': $data.cost.currency, 'reducedThreshold': 1e10}}"></td>
                                             </tr>
                                             <tr>
-                                                <td class="text-left">Step Efficiency:</td>
+                                                <td class="text-left">Efficiency:</td>
                                                 <td class="text-right">
-                                                    <knockout data-bind="text: `${$data.stepEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                    <knockout data-bind="text: `${$data.efficiency().toLocaleString('en-US')}%`">100%</knockout>
                                                 </td>
                                             </tr>
                                             <tr>
-                                                <td class="text-left text-nowrap">Attack Efficiency:</td>
+                                                <td class="text-left text-nowrap">Bonus per Level:</td>
                                                 <td class="text-right">
-                                                    <knockout data-bind="text: `${$data.attackEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                    <knockout data-bind="text: `${$data.levelBonus.toLocaleString('en-US')}%`">100%</knockout>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -532,26 +532,26 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                 </td>
                                             </tr>
                                             <tr>
-                                                <td class="text-left text-nowrap">Bonus to Efficiency:</td>
+                                                <td class="text-left text-nowrap">Level:</td>
                                                 <td class="text-right">
-                                                    <knockout data-bind="text: `+ ${$data.hatchBonus().toLocaleString('en-US')}%`">0%</knockout>
+                                                    <knockout data-bind="text: $data.level().toLocaleString('en-US')">0</knockout>
                                                 </td>
                                             </tr>
                                             <tr>
                                                 <td colspan="2" class="p-0">
                                                     <div class="progress">
-                                                        <!-- ko if: $data.hatchBonus() < 50 -->
-                                                        <div class="progress-bar bg-primary" role="progressbar"
-                                                            data-bind="attr:{ style: 'width:' + (($data.hatched() - $data.prevBonus()) / ($data.nextBonus() - $data.prevBonus())) * 100 + '%' }"
+                                                        <!-- ko if: $data.level() < HatcheryHelper.MAX_LEVEL -->
+                                                        <div class="progress-bar bg-info" role="progressbar"
+                                                            data-bind="attr:{ style: 'width:' + (($data.hatched() - $data.currentLevelHatched()) / ($data.nextLevelHatched() - $data.currentLevelHatched())) * 100 + '%' }"
                                                             aria-valuemin="0" aria-valuemax="100">
-                                                            <span data-bind="text: `${$data.hatchBonus()}%`" class="text-left pl-1">0%</span>
-                                                            <span data-bind="text: ($data.hatched() - $data.prevBonus()) + ' / ' + ($data.nextBonus() - $data.prevBonus()) + ' hatches'"></span>
-                                                            <span data-bind="text: `${($data.hatchBonus() + 0.1).toFixed(1)}%`" class="text-right pr-1">0.1%</span>
+                                                            <span data-bind="text: `+${$data.bonusEfficiency()}%`" class="text-left pl-1">0%</span>
+                                                            <span data-bind="text: ($data.hatched() - $data.currentLevelHatched()) + ' / ' + ($data.nextLevelHatched() - $data.currentLevelHatched()) + ' hatches'"></span>
+                                                            <span data-bind="text: `+${$data.levelToLevelBonus($data.level() + 1)}%`" class="text-right pr-1">0.1%</span>
                                                         </div>
                                                         <!-- /ko -->
-                                                        <!-- ko if: $data.hatchBonus() >= 50 -->
-                                                        <div class="progress-bar bg-primary" role="progressbar" style="width: 100%">
-                                                            <span>MAX BONUS!</span>
+                                                        <!-- ko if: $data.level() == HatcheryHelper.MAX_LEVEL -->
+                                                        <div class="progress-bar bg-info" role="progressbar" style="width: 100%">
+                                                            <span>MAX LEVEL!</span>
                                                         </div>
                                                         <!-- /ko -->
                                                     </div>
@@ -648,15 +648,15 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                     <td class="text-right" data-bind="template: { name: 'currencyTemplate', data: {'amount': $data.cost.amount, 'currency': $data.cost.currency, 'reducedThreshold': 1e10}}"></td>
                                                 </tr>
                                                 <tr>
-                                                    <td class="text-left">Step Efficiency:</td>
+                                                    <td class="text-left">Efficiency:</td>
                                                     <td class="text-right">
-                                                        <knockout data-bind="text: `${$data.stepEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                        <knockout data-bind="text: `${$data.efficiency().toLocaleString('en-US')}%`">100%</knockout>
                                                     </td>
                                                 </tr>
                                                 <tr>
-                                                    <td class="text-left text-nowrap">Attack Efficiency:</td>
+                                                    <td class="text-left text-nowrap">Bonus per Level:</td>
                                                     <td class="text-right">
-                                                        <knockout data-bind="text: `${$data.attackEfficiencyBase.toLocaleString('en-US')}%`">100%</knockout>
+                                                        <knockout data-bind="text: `${$data.levelBonus.toLocaleString('en-US')}%`">100%</knockout>
                                                     </td>
                                                 </tr>
                                                 <tr>

--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -544,9 +544,9 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                         <div class="progress-bar bg-info" role="progressbar"
                                                             data-bind="attr:{ style: 'width:' + (($data.hatched() - $data.currentLevelHatched()) / ($data.nextLevelHatched() - $data.currentLevelHatched())) * 100 + '%' }"
                                                             aria-valuemin="0" aria-valuemax="100">
-                                                            <span data-bind="text: `+${$data.bonusEfficiency()}%`" class="text-left pl-1">0%</span>
+                                                            <span data-bind="text: `+${$data.bonusEfficiency().toFixed(1)}%`" class="text-left pl-1">0%</span>
                                                             <span data-bind="text: ($data.hatched() - $data.currentLevelHatched()) + ' / ' + ($data.nextLevelHatched() - $data.currentLevelHatched()) + ' hatches'"></span>
-                                                            <span data-bind="text: `+${$data.levelToLevelBonus($data.level() + 1)}%`" class="text-right pr-1">0.1%</span>
+                                                            <span data-bind="text: `+${$data.levelToLevelBonus($data.level() + 1).toFixed(1)}%`" class="text-right pr-1">0.1%</span>
                                                         </div>
                                                         <!-- /ko -->
                                                         <!-- ko if: $data.level() == HatcheryHelper.MAX_LEVEL -->

--- a/src/modules/requirements/HatcheryHelperRequirement.ts
+++ b/src/modules/requirements/HatcheryHelperRequirement.ts
@@ -2,19 +2,19 @@ import * as GameConstants from '../GameConstants';
 import AchievementRequirement from './AchievementRequirement';
 
 export default class HatcheryHelperRequirement extends AchievementRequirement {
-    constructor(helpersUnlocked: number, public bonusRequired: number) {
+    constructor(helpersUnlocked: number, public levelRequired: number) {
         super(helpersUnlocked, GameConstants.AchievementOption.more, GameConstants.AchievementType.Hatchery);
     }
 
     public getProgress() {
-        return Math.min(App.game.breeding.hatcheryHelpers.available().filter((h) => h.hatchBonus() >= this.bonusRequired).length, this.requiredValue);
+        return Math.min(App.game.breeding.hatcheryHelpers.available().filter((h) => h.level() >= this.levelRequired).length, this.requiredValue);
     }
 
     public hint(): string {
-        return `${this.requiredValue} Hatchery Helpers need at least ${this.bonusRequired} bonus.`;
+        return `${this.requiredValue} Hatchery Helpers need to be at level ${this.levelRequired} or more.`;
     }
 
     public toString(): string {
-        return `${super.toString()} ${this.bonusRequired}`;
+        return `${super.toString()} ${this.levelRequired}`;
     }
 }

--- a/src/scripts/achievements/AchievementHandler.ts
+++ b/src/scripts/achievements/AchievementHandler.ts
@@ -378,10 +378,10 @@ class AchievementHandler {
 
         AchievementHandler.addAchievement('Some Nice Help for the Day Care', 'Unlock 5 Hatchery Helpers.', new HatcheryHelperRequirement(5, 0), 0.1);
         AchievementHandler.addAchievement('Why Do They Have To Work in Shifts?', 'Unlock 11 Hatchery Helpers.', new HatcheryHelperRequirement(11, 0), 0.3);
-        AchievementHandler.addAchievement('My Loyal Helpers', 'Get 3 Hatchery Helpers to 10% bonus efficiency.', new HatcheryHelperRequirement(3, 10), 0.4);
-        AchievementHandler.addAchievement('Let\'s Try Some Other Helpers Too?', 'Get 5 Hatchery Helpers to 10% bonus efficiency.', new HatcheryHelperRequirement(5, 10), 0.5);
-        AchievementHandler.addAchievement('Sam Just Wants To Help', 'Get 10 Hatchery Helpers to 10% bonus efficiency.', new HatcheryHelperRequirement(10, 10), 1);
-        AchievementHandler.addAchievement('When Are You Going to Breed Yourself?', 'Get 10 Hatchery Helpers to 25% bonus efficiency.', new HatcheryHelperRequirement(10, 25), 1.3);
+        AchievementHandler.addAchievement('My Loyal Helpers', 'Get 3 Hatchery Helpers to level 10.', new HatcheryHelperRequirement(3, 10), 0.4);
+        AchievementHandler.addAchievement('Let\'s Try Some Other Helpers Too?', 'Get 5 Hatchery Helpers to level 10.', new HatcheryHelperRequirement(5, 10), 0.5);
+        AchievementHandler.addAchievement('Sam Just Wants To Help', 'Get 10 Hatchery Helpers to level 10.', new HatcheryHelperRequirement(10, 10), 1);
+        AchievementHandler.addAchievement('When Are You Going to Breed Yourself?', 'Get 10 Hatchery Helpers to level 25.', new HatcheryHelperRequirement(10, 25), 1.3);
 
         AchievementHandler.addAchievement('My New Dirty Hobby', 'Unlock 3 Plots in the Farm.', new FarmPlotsUnlockedRequirement(3), 0.05);
         AchievementHandler.addAchievement('Allotment Gardener', 'Unlock 9 Plots in the Farm.', new FarmPlotsUnlockedRequirement(9), 0.15);

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -244,8 +244,8 @@ HatcheryHelpers.add(new HatcheryHelper('Leslie', new Amount(1571751, GameConstan
 HatcheryHelpers.add(new HatcheryHelper('Parker', new Amount(3000, GameConstants.Currency.dungeonToken), 25, 0.5, new HatchRequirement(1000)));
 HatcheryHelpers.add(new HatcheryHelper('Dakota', new Amount(10000, GameConstants.Currency.dungeonToken), 50, 1, new UniqueItemOwnedRequirement('HatcheryHelperDakota', 'purchase', 'Purchased in the Johto region.')));
 HatcheryHelpers.add(new HatcheryHelper('Cameron', new Amount(100, GameConstants.Currency.farmPoint), 55, 2, new UniqueItemOwnedRequirement('HatcheryHelperCameron', 'purchase', 'Purchased in the Hoenn region.')));
-HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(10, GameConstants.Currency.questPoint), 50, 2, new QuestRequirement(200)));
-HatcheryHelpers.add(new HatcheryHelper('Carey', new Amount(20, GameConstants.Currency.questPoint), 75, 2, new UniqueItemOwnedRequirement('HatcheryHelperCarey', 'purchase', 'Purchased in the Johto region.')));
-HatcheryHelpers.add(new HatcheryHelper('Aiden', new Amount(30, GameConstants.Currency.diamond), 100, 2.5, new UndergroundLayersMinedRequirement(100)));
-HatcheryHelpers.add(new HatcheryHelper('Kris', new Amount(60, GameConstants.Currency.diamond), 150, 3, new UniqueItemOwnedRequirement('HatcheryHelperKris', 'purchase', 'Purchased in the Kanto region.')));
+HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(10, GameConstants.Currency.questPoint), 100, 2.5, new QuestRequirement(200)));
+HatcheryHelpers.add(new HatcheryHelper('Carey', new Amount(20, GameConstants.Currency.questPoint), 150, 3, new UniqueItemOwnedRequirement('HatcheryHelperCarey', 'purchase', 'Purchased in the Johto region.')));
+HatcheryHelpers.add(new HatcheryHelper('Aiden', new Amount(30, GameConstants.Currency.diamond), 50, 2, new UndergroundLayersMinedRequirement(100)));
+HatcheryHelpers.add(new HatcheryHelper('Kris', new Amount(60, GameConstants.Currency.diamond), 75, 2, new UniqueItemOwnedRequirement('HatcheryHelperKris', 'purchase', 'Purchased in the Kanto region.')));
 HatcheryHelpers.add(new HatcheryHelper('Noel', new Amount(25, GameConstants.Currency.battlePoint), 200, 3.5, new UniqueItemOwnedRequirement('HatcheryHelperNoel', 'purchase', 'Purchased in the Hoenn region.')));

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -1,27 +1,5 @@
-const HatcheryHelperSkills = [
-    'energy',
-    'efficiency',
-    'accuracy',
-    'cost',
-];
-
-const HatcheryHelperCalcHatchBonus = (hatched) => Math.min(50, Math.floor(Math.sqrt(hatched / 50) * 10) / 10);
-
-const HatcheryHelperMinBonusMap: Record<number, number> = {};
-// Generate our bonus amounts map
-(() => {
-    let bonus = -1;
-    for (let hatched = 0; bonus < 50; hatched++) {
-        const b = HatcheryHelperCalcHatchBonus(hatched);
-        if (b > bonus) {
-            HatcheryHelperMinBonusMap[b] = hatched;
-            bonus = b;
-        }
-    }
-})();
-
-
 class HatcheryHelper {
+    public static MAX_LEVEL = 50;
     public trainerSprite = 0;
     public hired: KnockoutObservable<boolean> = ko.observable(false).extend({ boolean: null });
     public tooltip: KnockoutComputed<string>;
@@ -29,50 +7,44 @@ class HatcheryHelper {
     public sortOption: KnockoutObservable<SortOptions> = ko.observable(SortOptions.id).extend({ numeric: 0 });
     public sortDirection: KnockoutObservable<boolean> = ko.observable(false).extend({ boolean: null });
     public hatched: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 0 });
-    public hatchBonus: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 1 });
-    public stepEfficiency: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 1 });
-    public attackEfficiency: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 1 });
-    public prevBonus: KnockoutObservable<number> = ko.observable(0).extend({ numeric: 0 });
-    public nextBonus: KnockoutObservable<number> = ko.observable(1).extend({ numeric: 0 });
     public categories: KnockoutObservableArray<number> = ko.observableArray([]);
     public useHatcheryFilters: KnockoutObservable<boolean> = ko.observable(true);
-    // public level: number;
     // public experience: number;
 
     constructor(
         public name: string,
         public cost: Amount,
-        public stepEfficiencyBase: number, // 1 - 200
-        public attackEfficiencyBase: number,
+        public efficiencyBase: number,
+        public levelBonus: number,
         public unlockRequirement?: Requirement | MultiRequirement | OneFromManyRequirement
     ) {
         SeededRand.seed(parseInt(this.name, 36));
         this.trainerSprite = SeededRand.intBetween(0, 118);
 
-        this.tooltip = ko.pureComputed(() => `<strong>${this.name}</strong><br/>
+        this.tooltip = ko.pureComputed(() => `<strong>${this.name} Lv.${this.level()}</strong><br/>
             Cost: <img src="assets/images/currency/${GameConstants.Currency[this.cost.currency]}.svg" width="20px">&nbsp;${(this.cost.amount).toLocaleString('en-US')}/hatch<br/>
-            Step Efficiency: ${this.stepEfficiency()}%<br/>
-            Attack Efficiency: ${this.attackEfficiency()}%<br/>
+            Efficiency: ${this.efficiency()}%<br/>
             Hatched: ${this.hatched().toLocaleString('en-US')}<br/>`
         );
-
-        // Update our bonus values
-        this.updateBonus();
-        // Update our bonus values whenever our hatched amount changes
-        this.hatched.subscribe((hatched) => {
-            if (hatched >= this.nextBonus() || hatched <= this.prevBonus()) {
-                this.updateBonus();
-            }
-        });
     }
 
-    updateBonus(): void {
-        this.hatchBonus(HatcheryHelperCalcHatchBonus(this.hatched()));
-        this.stepEfficiency(this.stepEfficiencyBase + this.hatchBonus());
-        this.attackEfficiency(this.attackEfficiencyBase + this.hatchBonus());
-        this.prevBonus(HatcheryHelperMinBonusMap[this.hatchBonus()] || 0);
-        this.nextBonus(HatcheryHelperMinBonusMap[((this.hatchBonus() * 10) + 1) / 10] || 1);
+    private hatchedToLevel(hatched: number): number {
+        return Math.floor(Math.min(HatcheryHelper.MAX_LEVEL, Math.sqrt(hatched * 2) / 10));
     }
+
+    private levelToHatched(level: number): number {
+        return (level * 10) ** 2 / 2;
+    }
+
+    private levelToLevelBonus(level: number): number {
+        return this.levelBonus * level;
+    }
+
+    public level = ko.pureComputed(() => this.hatchedToLevel(this.hatched()));
+    public bonusEfficiency = ko.pureComputed(() => this.levelToLevelBonus(this.level()));
+    public efficiency = ko.pureComputed(() => this.efficiencyBase + this.bonusEfficiency());
+    public currentLevelHatched = ko.pureComputed(() => this.levelToHatched(this.level()));
+    public nextLevelHatched = ko.pureComputed(() => this.level() < HatcheryHelper.MAX_LEVEL ? this.levelToHatched(this.level() + 1) : Infinity);
 
     isUnlocked(): boolean {
         return this.unlockRequirement?.isCompleted() ?? true;
@@ -196,15 +168,14 @@ class HatcheryHelpers {
         // Add steps and attack based on efficiency
         this.hired().forEach((helper, index) => {
             // Calculate how many steps should be applied
-            const steps = Math.max(1, Math.round(amount * (helper.stepEfficiency() / 100)));
 
             // Add steps to the egg we are managing
             let egg = this.hatchery.eggList[index]();
-            egg.addSteps(steps, multiplier, true);
+            egg.addSteps(amount, multiplier, true);
 
             // Check if the egg is ready to hatch
             if (egg.canHatch()) {
-                const hatched = egg.hatch(helper.attackEfficiency(), true);
+                const hatched = egg.hatch(helper.efficiency(), true);
                 if (hatched) {
                     // Reset egg
                     this.hatchery.eggList[index](new Egg());
@@ -266,15 +237,15 @@ class HatcheryHelpers {
 }
 
 // Note: Mostly Gender-neutral names used as the trainer sprite is (seeded) randomly generated, or check the sprite
-HatcheryHelpers.add(new HatcheryHelper('Sam', new Amount(1000, GameConstants.Currency.money), 10, 10, new HatchRequirement(100)));
-HatcheryHelpers.add(new HatcheryHelper('Blake', new Amount(10000, GameConstants.Currency.money), 10, 20, new HatchRequirement(500)));
-HatcheryHelpers.add(new HatcheryHelper('Jasmine', new Amount(50000, GameConstants.Currency.money), 15, 50, new UniqueItemOwnedRequirement('HatcheryHelperJasmine', 'purchase', 'Purchased in the Hoenn region.')));
-HatcheryHelpers.add(new HatcheryHelper('Leslie', new Amount(777777, GameConstants.Currency.money), 150, 50, new UniqueItemOwnedRequirement('HatcheryHelperLeslie', 'purchase', 'Obtain and redeem a code from the PokéClicker Discord server.')));
-HatcheryHelpers.add(new HatcheryHelper('Parker', new Amount(1000, GameConstants.Currency.dungeonToken), 15, 25, new HatchRequirement(1000)));
-HatcheryHelpers.add(new HatcheryHelper('Dakota', new Amount(10000, GameConstants.Currency.dungeonToken), 50, 50, new UniqueItemOwnedRequirement('HatcheryHelperDakota', 'purchase', 'Purchased in the Johto region.')));
-HatcheryHelpers.add(new HatcheryHelper('Cameron', new Amount(75, GameConstants.Currency.farmPoint), 75, 75, new UniqueItemOwnedRequirement('HatcheryHelperCameron', 'purchase', 'Purchased in the Hoenn region.')));
-HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(10, GameConstants.Currency.questPoint), 100, 50, new QuestRequirement(200)));
-HatcheryHelpers.add(new HatcheryHelper('Carey', new Amount(20, GameConstants.Currency.questPoint), 50, 125, new UniqueItemOwnedRequirement('HatcheryHelperCarey', 'purchase', 'Purchased in the Johto region.')));
-HatcheryHelpers.add(new HatcheryHelper('Aiden', new Amount(20, GameConstants.Currency.diamond), 100, 100, new UndergroundLayersMinedRequirement(100)));
-HatcheryHelpers.add(new HatcheryHelper('Kris', new Amount(40, GameConstants.Currency.diamond), 100, 150, new UniqueItemOwnedRequirement('HatcheryHelperKris', 'purchase', 'Purchased in the Kanto region.')));
-HatcheryHelpers.add(new HatcheryHelper('Noel', new Amount(25, GameConstants.Currency.battlePoint), 100, 200, new UniqueItemOwnedRequirement('HatcheryHelperNoel', 'purchase', 'Purchased in the Hoenn region.')));
+HatcheryHelpers.add(new HatcheryHelper('Sam', new Amount(3000, GameConstants.Currency.money), 10, 0.2, new HatchRequirement(100)));
+HatcheryHelpers.add(new HatcheryHelper('Blake', new Amount(10000, GameConstants.Currency.money), 20, 0.4, new HatchRequirement(500)));
+HatcheryHelpers.add(new HatcheryHelper('Jasmine', new Amount(50000, GameConstants.Currency.money), 35, 0.8, new UniqueItemOwnedRequirement('HatcheryHelperJasmine', 'purchase', 'Purchased in the Hoenn region.')));
+HatcheryHelpers.add(new HatcheryHelper('Leslie', new Amount(1571751, GameConstants.Currency.money), 75, 2.5, new UniqueItemOwnedRequirement('HatcheryHelperLeslie', 'purchase', 'Obtain and redeem a code from the PokéClicker Discord server.')));
+HatcheryHelpers.add(new HatcheryHelper('Parker', new Amount(1000, GameConstants.Currency.dungeonToken), 25, 0.5, new HatchRequirement(1000)));
+HatcheryHelpers.add(new HatcheryHelper('Dakota', new Amount(10000, GameConstants.Currency.dungeonToken), 50, 1, new UniqueItemOwnedRequirement('HatcheryHelperDakota', 'purchase', 'Purchased in the Johto region.')));
+HatcheryHelpers.add(new HatcheryHelper('Cameron', new Amount(100, GameConstants.Currency.farmPoint), 75, 2, new UniqueItemOwnedRequirement('HatcheryHelperCameron', 'purchase', 'Purchased in the Hoenn region.')));
+HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(15, GameConstants.Currency.questPoint), 50, 2, new QuestRequirement(200)));
+HatcheryHelpers.add(new HatcheryHelper('Carey', new Amount(20, GameConstants.Currency.questPoint), 75, 2, new UniqueItemOwnedRequirement('HatcheryHelperCarey', 'purchase', 'Purchased in the Johto region.')));
+HatcheryHelpers.add(new HatcheryHelper('Aiden', new Amount(45, GameConstants.Currency.diamond), 100, 2.5, new UndergroundLayersMinedRequirement(100)));
+HatcheryHelpers.add(new HatcheryHelper('Kris', new Amount(60, GameConstants.Currency.diamond), 150, 3, new UniqueItemOwnedRequirement('HatcheryHelperKris', 'purchase', 'Purchased in the Kanto region.')));
+HatcheryHelpers.add(new HatcheryHelper('Noel', new Amount(35, GameConstants.Currency.battlePoint), 200, 3.5, new UniqueItemOwnedRequirement('HatcheryHelperNoel', 'purchase', 'Purchased in the Hoenn region.')));

--- a/src/scripts/breeding/HatcheryHelper.ts
+++ b/src/scripts/breeding/HatcheryHelper.ts
@@ -238,14 +238,14 @@ class HatcheryHelpers {
 
 // Note: Mostly Gender-neutral names used as the trainer sprite is (seeded) randomly generated, or check the sprite
 HatcheryHelpers.add(new HatcheryHelper('Sam', new Amount(3000, GameConstants.Currency.money), 10, 0.2, new HatchRequirement(100)));
-HatcheryHelpers.add(new HatcheryHelper('Blake', new Amount(10000, GameConstants.Currency.money), 20, 0.4, new HatchRequirement(500)));
-HatcheryHelpers.add(new HatcheryHelper('Jasmine', new Amount(50000, GameConstants.Currency.money), 35, 0.8, new UniqueItemOwnedRequirement('HatcheryHelperJasmine', 'purchase', 'Purchased in the Hoenn region.')));
+HatcheryHelpers.add(new HatcheryHelper('Blake', new Amount(20000, GameConstants.Currency.money), 20, 0.4, new HatchRequirement(500)));
+HatcheryHelpers.add(new HatcheryHelper('Jasmine', new Amount(50000, GameConstants.Currency.money), 35, 0.6, new UniqueItemOwnedRequirement('HatcheryHelperJasmine', 'purchase', 'Purchased in the Hoenn region.')));
 HatcheryHelpers.add(new HatcheryHelper('Leslie', new Amount(1571751, GameConstants.Currency.money), 75, 2.5, new UniqueItemOwnedRequirement('HatcheryHelperLeslie', 'purchase', 'Obtain and redeem a code from the PokéClicker Discord server.')));
-HatcheryHelpers.add(new HatcheryHelper('Parker', new Amount(1000, GameConstants.Currency.dungeonToken), 25, 0.5, new HatchRequirement(1000)));
+HatcheryHelpers.add(new HatcheryHelper('Parker', new Amount(3000, GameConstants.Currency.dungeonToken), 25, 0.5, new HatchRequirement(1000)));
 HatcheryHelpers.add(new HatcheryHelper('Dakota', new Amount(10000, GameConstants.Currency.dungeonToken), 50, 1, new UniqueItemOwnedRequirement('HatcheryHelperDakota', 'purchase', 'Purchased in the Johto region.')));
-HatcheryHelpers.add(new HatcheryHelper('Cameron', new Amount(100, GameConstants.Currency.farmPoint), 75, 2, new UniqueItemOwnedRequirement('HatcheryHelperCameron', 'purchase', 'Purchased in the Hoenn region.')));
-HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(15, GameConstants.Currency.questPoint), 50, 2, new QuestRequirement(200)));
+HatcheryHelpers.add(new HatcheryHelper('Cameron', new Amount(100, GameConstants.Currency.farmPoint), 55, 2, new UniqueItemOwnedRequirement('HatcheryHelperCameron', 'purchase', 'Purchased in the Hoenn region.')));
+HatcheryHelpers.add(new HatcheryHelper('Justice', new Amount(10, GameConstants.Currency.questPoint), 50, 2, new QuestRequirement(200)));
 HatcheryHelpers.add(new HatcheryHelper('Carey', new Amount(20, GameConstants.Currency.questPoint), 75, 2, new UniqueItemOwnedRequirement('HatcheryHelperCarey', 'purchase', 'Purchased in the Johto region.')));
-HatcheryHelpers.add(new HatcheryHelper('Aiden', new Amount(45, GameConstants.Currency.diamond), 100, 2.5, new UndergroundLayersMinedRequirement(100)));
+HatcheryHelpers.add(new HatcheryHelper('Aiden', new Amount(30, GameConstants.Currency.diamond), 100, 2.5, new UndergroundLayersMinedRequirement(100)));
 HatcheryHelpers.add(new HatcheryHelper('Kris', new Amount(60, GameConstants.Currency.diamond), 150, 3, new UniqueItemOwnedRequirement('HatcheryHelperKris', 'purchase', 'Purchased in the Kanto region.')));
-HatcheryHelpers.add(new HatcheryHelper('Noel', new Amount(35, GameConstants.Currency.battlePoint), 200, 3.5, new UniqueItemOwnedRequirement('HatcheryHelperNoel', 'purchase', 'Purchased in the Hoenn region.')));
+HatcheryHelpers.add(new HatcheryHelper('Noel', new Amount(25, GameConstants.Currency.battlePoint), 200, 3.5, new UniqueItemOwnedRequirement('HatcheryHelperNoel', 'purchase', 'Purchased in the Hoenn region.')));

--- a/src/scripts/items/HatcheryHelperItem.ts
+++ b/src/scripts/items/HatcheryHelperItem.ts
@@ -13,8 +13,7 @@ class HatcheryHelperItem extends Item {
     get description(): string {
         const hatcheryHelper = this.hatcheryHelper;
         return `Cost: <img src="assets/images/currency/${GameConstants.Currency[hatcheryHelper?.cost?.currency]}.svg" width="20px">&nbsp;${(hatcheryHelper?.cost?.amount ?? 0).toLocaleString('en-US')}/hatch<br/>
-        Step Efficiency: ${(hatcheryHelper?.stepEfficiencyBase ?? 0).toLocaleString('en-US')}%<br/>
-        Attack Efficiency: ${(hatcheryHelper?.attackEfficiencyBase ?? 0).toLocaleString('en-US')}%`;
+        Efficiency: ${(hatcheryHelper?.efficiencyBase ?? 0).toLocaleString('en-US')}%`;
     }
 
     isAvailable(): boolean {


### PR DESCRIPTION
## Description
Hatchers now have a proper level system which improves their only stat *efficiency* as per a *bonus per level*, up to level 50. No more step efficiency, everyone is at 100%.
I increased the price on most helpers to better reflect their cost. Initial and final overall efficiencies remain the same except for some (the first, shitty ones are buffed basically).
Current progress isn't lost : hatches for +X% (as integer) convert to level X.

## Motivation and Context
The current system has flaws :
- Step efficiency and attack efficiency confuse players as to how efficient it is, truly.
- The 500 pseudo levels are a needlessly too precise progress system; no one is going to benefit from +0.1% eggsteps.
- The bonus being +50% on both stats and for every helper makes it hard to balance between helpers and even between initial and final stats on one helper. Sam becomes 36 times better, lmao.

## How Has This Been Tested?
Got a few hatchery helpers to various levels and ensured the bonuses were as expected, in the display as well as when hatching a Pokémon.

## Notes
- ~~I still need to upate the help tab.~~ Done.
- attack bonuses are rounded, making half the efficiency points pointless. Another PR will tackle this.
- Values are thought to be final but can be changed if needed.

## Types of changes
- Feature improvement
