### PR TITLE
Add quest slot unlock text to quest modal

### DIFF
--- a/src/components/questModal.html
+++ b/src/components/questModal.html
@@ -19,7 +19,7 @@
                     <!-- Quests -->
                     <div class="tab-pane active" id="questsModalQuestsPane">
                         <div class="container">
-                            <div class="form-row my-3">
+                            <div class="form-row mt-3 mb-2">
                                 <div class="col-3 align-self-center">
                                     <h5>
                                         <span class='' data-bind='text: "Quests (" + App.game.quests.currentQuests().length + "/" + App.game.quests.questSlots() + ")"'></span>
@@ -37,6 +37,9 @@
                                 <div class="col-3 align-self-center">
                                     <span data-bind="template: { name: 'currencyTemplate', data: {'amount': App.game.wallet.currencies[GameConstants.Currency.questPoint](), 'currency': GameConstants.Currency.questPoint}}"></span>
                                 </div>
+                            </div>
+                            <div class="text-center mb-2" data-bind="visible: App.game.quests.questSlots() < GameConstants.MAX_QUEST_SLOTS">
+                                <div class="small">Unlock additional quest slots at levels 5, 10, and 15!</div>
                             </div>
                         </div>
 

--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -425,6 +425,8 @@ export const QUEST_CLICKS_PER_SECOND = 5;
 
 export const QUESTS_PER_SET = 10;
 
+export const MAX_QUEST_SLOTS = 4;
+
 // EVs
 export const BASE_EP_YIELD = 100;
 export const STONE_EP_YIELD = 1000;

--- a/src/scripts/quests/Quests.ts
+++ b/src/scripts/quests/Quests.ts
@@ -23,7 +23,7 @@ class Quests implements Saveable {
     });
     public questSlots: KnockoutComputed<number> = ko.pureComputed((): number => {
         // Minimum of 1, Maximum of 4
-        return Math.min(4, Math.max(1, Math.floor((this.level() + 5) / 5)));
+        return Math.min(GameConstants.MAX_QUEST_SLOTS, Math.max(1, Math.floor((this.level() + 5) / 5)));
     });
 
     // Get current quests by status


### PR DESCRIPTION
## Description
Adds text to the quest modal to inform the player additional quest slots are unlocked based on quest level. Text is hidden upon reaching quest level 15 / max quest slots

## Screenshots (optional):
<img width="795" height="701" alt="image" src="https://github.com/user-attachments/assets/120cf59f-370e-429b-ac12-931c96edd8bd" />

## Types of changes
- UI improvement
