### PR TITLE
More balanced CT obtained from National Park

### DIFF
--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -190,7 +190,7 @@ class SafariBattle {
         switch (player.region) {
             case (GameConstants.Region.johto):
                 const shinyModifier = SafariBattle.enemy.shiny ? GameConstants.BUG_SAFARI_SHINY_MODIFIER : 1;
-                const bugReward = Math.floor(partyPokemon.baseAttack / 5) * shinyModifier;
+                const bugReward = Math.round(partyPokemon.baseAttack ** .5 + 16) * shinyModifier;
                 App.game.wallet.gainContestTokens(bugReward);
                 Notifier.notify({
                     title: 'Bug Catching Contest',


### PR DESCRIPTION
## Description
Changed the formula used for CT gained from catching in the BCC.
Still based on attack but the spread is smaller now.
Max is unchanged, min goes from 2 (lmao) to 20 (lmao²) and average doubles, up to 23.

## Motivation and Context
Current formula doesn't make sense. Most bugs are extremely weak, and the strong ones unlock too late. It naturally encourages the player to postpone the grind and only catch a few species in a very large pool of encounters.

## How Has This Been Tested?
Caught some bugs and confirmed that the new values matched these from my maths.

## Types of changes
- Slight balance change I guess
