### PR TITLE
Add Vitamins Modal Shortcut and Hotkey

### DIFF
--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -126,7 +126,7 @@
                                             mapAreaStateOrder.set(mapAreaStateOrder.defaultValue);
                                         }">Reset Order</button>
                                         <button type="button" class="btn btn-primary" data-bind="click: () => {
-                                            Settings.getSetting('mapAreaStateOrder').value.map(status => 
+                                            Settings.getSetting('mapAreaStateOrder').value.map(status =>
                                                 Settings.getSetting(`--${areaStatus[status]}`)
                                             ).forEach(setting => setting.set(setting.defaultValue));
                                         }">Reset Colors</button>
@@ -257,7 +257,9 @@
                                 <!-- ko if: Settings.getSetting('hotkey.purifyChamber').isUnlocked() -->
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.purifyChamber')}"></tr>
                                 <!-- /ko -->
+                                <!-- ko if: VitaminController.shortcutVisible -->
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.vitamins')}"></tr>
+                                <!-- /ko -->
                             </tbody>
                             <thead>
                                 <tr><th colspan="2">Farm</th></tr>

--- a/src/components/settingsModal.html
+++ b/src/components/settingsModal.html
@@ -257,6 +257,7 @@
                                 <!-- ko if: Settings.getSetting('hotkey.purifyChamber').isUnlocked() -->
                                 <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.purifyChamber')}"></tr>
                                 <!-- /ko -->
+                                <tr data-bind="template: { name: 'KeyChoiceSettingTemplate', data: Settings.getSetting('hotkey.vitamins')}"></tr>
                             </tbody>
                             <thead>
                                 <tr><th colspan="2">Farm</th></tr>

--- a/src/components/shortcutsContainer.html
+++ b/src/components/shortcutsContainer.html
@@ -33,6 +33,15 @@
               </button>
             </td>
           </tr>
+          <tr data-bind="visible: VitaminController.shortcutVisible">
+            <td class="p-0">
+              <button class="btn btn-block btn-primary m-0" onclick="VitaminController.openVitaminExpandedModal()">
+                Vitamins
+                <knockout data-bind="text: `[${Settings.getSetting('hotkey.vitamins').observableValue()}]`,
+                    visible: Settings.getSetting('hotkey.vitamins').observableValue() != 'None'"></knockout>
+              </button>
+            </td>
+          </tr>
           <tr data-bind="visible: WeatherApp.shortcutVisible">
             <td class="p-0">
               <button class="btn btn-block btn-primary m-0" onclick="WeatherApp.openWeatherAppModal()">
@@ -49,15 +58,6 @@
                 <knockout data-bind="text: `(${(Math.min(1, Math.trunc((App.game.purifyChamber.currentFlow() / App.game.purifyChamber.flowNeeded()) * 10 ** 4) / 10 ** 4)).toLocaleString('en-US', { style: 'percent', maximumFractionDigits: 4 })})`"></knockout>
                 <knockout data-bind="text: `[${Settings.getSetting('hotkey.purifyChamber').observableValue()}]`,
                     visible: Settings.getSetting('hotkey.purifyChamber').observableValue() != 'None'"></knockout>
-              </button>
-            </td>
-          </tr>
-          <tr data-bind="visible: VitaminController.shortcutVisible">
-            <td class="p-0">
-              <button class="btn btn-block btn-primary m-0" onclick="VitaminController.openVitaminExpandedModal()">
-                Vitamins
-                <knockout data-bind="text: `[${Settings.getSetting('hotkey.vitamins').observableValue()}]`,
-                    visible: Settings.getSetting('hotkey.vitamins').observableValue() != 'None'"></knockout>
               </button>
             </td>
           </tr>

--- a/src/components/shortcutsContainer.html
+++ b/src/components/shortcutsContainer.html
@@ -52,6 +52,15 @@
               </button>
             </td>
           </tr>
+          <tr data-bind="visible: VitaminController.shortcutVisible">
+            <td class="p-0">
+              <button class="btn btn-block btn-primary m-0" onclick="VitaminController.openVitaminExpandedModal()">
+                Vitamins
+                <knockout data-bind="text: `[${Settings.getSetting('hotkey.vitamins').observableValue()}]`,
+                    visible: Settings.getSetting('hotkey.vitamins').observableValue() != 'None'"></knockout>
+              </button>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/src/modules/items/VitaminController.ts
+++ b/src/modules/items/VitaminController.ts
@@ -1,5 +1,7 @@
 import '../koExtenders';
-import { VitaminType } from '../GameConstants';
+import { getDungeonIndex, VitaminType } from '../GameConstants';
+import Notifier from '../notifications/Notifier';
+import NotificationConstants from '../notifications/NotificationConstants';
 
 export default class VitaminController {
     public static currentlySelected = ko.observable(VitaminType.Protein).extend({ numeric: 0 });
@@ -22,5 +24,20 @@ export default class VitaminController {
     public static getImage(vitaminType) {
         const vitaminName = VitaminType[vitaminType ?? this.currentlySelected()];
         return `assets/images/items/vitamin/${vitaminName}.png`;
+    }
+
+    public static shortcutVisible = ko.pureComputed((): boolean => {
+        return App.game.statistics.dungeonsCleared[getDungeonIndex('Victory Road')]() > 0;
+    });
+
+    public static openVitaminExpandedModal() {
+        if( VitaminController.shortcutVisible()) {
+             $('#pokemonVitaminExpandedModal').modal('show');
+        } else {
+            Notifier.notify({
+                message: 'You need to defeat Victory Road to unlock this feature.',
+                type: NotificationConstants.NotificationOption.warning,
+            });
+        }
     }
 }

--- a/src/modules/items/VitaminController.ts
+++ b/src/modules/items/VitaminController.ts
@@ -10,7 +10,7 @@ export default class VitaminController {
     public static multiplierIndex = ko.observable(0);
 
     public static shortcutVisible = ko.pureComputed((): boolean => {
-        return App.game.statistics.dungeonsCleared[getDungeonIndex('Victory Road')]() > 0;
+        return App.game.statistics.dungeonsCleared[getDungeonIndex('Victory Road')]() > 0 && App.game.challenges.list.disableVitamins.active() === false;
     });
 
     public static incrementMultiplier() {

--- a/src/modules/items/VitaminController.ts
+++ b/src/modules/items/VitaminController.ts
@@ -9,6 +9,10 @@ export default class VitaminController {
     public static multiplier = ['×1', '×5', '×10', 'Max'];
     public static multiplierIndex = ko.observable(0);
 
+    public static shortcutVisible = ko.pureComputed((): boolean => {
+        return App.game.statistics.dungeonsCleared[getDungeonIndex('Victory Road')]() > 0;
+    });
+
     public static incrementMultiplier() {
         this.multiplierIndex((this.multiplierIndex() + 1) % this.multiplier.length);
     }
@@ -26,13 +30,9 @@ export default class VitaminController {
         return `assets/images/items/vitamin/${vitaminName}.png`;
     }
 
-    public static shortcutVisible = ko.pureComputed((): boolean => {
-        return App.game.statistics.dungeonsCleared[getDungeonIndex('Victory Road')]() > 0;
-    });
-
     public static openVitaminExpandedModal() {
-        if( VitaminController.shortcutVisible()) {
-             $('#pokemonVitaminExpandedModal').modal('show');
+        if (VitaminController.shortcutVisible()) {
+            $('#pokemonVitaminExpandedModal').modal('show');
         } else {
             Notifier.notify({
                 message: 'You need to defeat Victory Road to unlock this feature.',

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -488,6 +488,7 @@ Settings.add(new HotkeySetting('hotkey.dailyQuests', 'Daily Quests', 'Q'));
 Settings.add(new HotkeySetting('hotkey.pokeballSelection', 'Poké Ball Selection', 'P', { suffix: ' + Number' }));
 Settings.add(new HotkeySetting('hotkey.castformApp', 'Castform App', 'C', {}, new ClearDungeonRequirement(250, getDungeonIndex('Weather Institute'))));
 Settings.add(new HotkeySetting('hotkey.purifyChamber', 'Purify Chamber', 'K', {}, new ShadowPokemonRequirement(1, ShadowStatus.Purified)));
+Settings.add(new HotkeySetting('hotkey.vitamins', 'Vitamins', 'V'));
 
 Settings.add(new HotkeySetting('hotkey.farm.toggleShovel', 'Toggle Shovel', 'S'));
 Settings.add(new HotkeySetting('hotkey.farm.togglePlotSafeLock', 'Toggle Plot Lock', 'L', { suffix: ' or Shift + Click' }));

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -468,7 +468,7 @@ class GameController {
                         PurifyChamber.openPurifyChamberModal();
                         return e.preventDefault();
                     }
-                    break;                
+                    break;
                 case Settings.getSetting('hotkey.vitamins').value:
                     if (VitaminController.shortcutVisible() && !$pokemonVitaminExpandedModal.data('disable-toggle')) {
                         $('.modal').modal('hide');

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -98,6 +98,10 @@ class GameController {
         const $purifyChamberModal = $('#purifyChamberModal');
         $purifyChamberModal.on('hide.bs.modal', _ => $purifyChamberModal.data('disable-toggle', true));
         $purifyChamberModal.on('hidden.bs.modal shown.bs.modal', _ => $purifyChamberModal.data('disable-toggle', false));
+        // Vitamins
+        const $pokemonVitaminExpandedModal = $('#pokemonVitaminExpandedModal');
+        $pokemonVitaminExpandedModal.on('hide.bs.modal', _ => $pokemonVitaminExpandedModal.data('disable-toggle', true));
+        $pokemonVitaminExpandedModal.on('hidden.bs.modal shown.bs.modal', _ => $pokemonVitaminExpandedModal.data('disable-toggle', false));
         // Ship
         const $shipModal = $('#ShipModal');
         // Modal Collapse
@@ -462,6 +466,13 @@ class GameController {
                     if (PurifyChamber.shortcutVisible() && !$purifyChamberModal.data('disable-toggle')) {
                         $('.modal').modal('hide');
                         PurifyChamber.openPurifyChamberModal();
+                        return e.preventDefault();
+                    }
+                    break;                
+                case Settings.getSetting('hotkey.vitamins').value:
+                    if (VitaminController.shortcutVisible() && !$pokemonVitaminExpandedModal.data('disable-toggle')) {
+                        $('.modal').modal('hide');
+                        VitaminController.openVitaminExpandedModal();
                         return e.preventDefault();
                     }
                     break;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
Added shortcut to vitamins modal and added hotkey 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Makes it more convenient to change vitamins by reducing number of clicks required to access menu
I've put it above the weather tracker and purify chamber as it is unlocked before them


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Opened and closed vitamins modal with hotkey
Opened modal with shortcut button
Tested rebinding hotkey


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
<img width="272" height="170" alt="image" src="https://github.com/user-attachments/assets/3c877540-8126-409d-a4aa-3f86cf08ae9b" />


## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement

resolves #6171