### PR TITLE
Added a "perfumer" who trades scents

### DIFF
--- a/src/modules/deal/GenericDeal.ts
+++ b/src/modules/deal/GenericDeal.ts
@@ -429,12 +429,12 @@ export default class GenericDeal {
         ]);
         GenericDeal.list.ScentTrader = ko.observableArray([
             new GenericDeal({
-                costs: [{ type: DealCostOrProfitType.Item, item: ItemList.Joy_Scent, amount: 4 }],
+                costs: [{ type: DealCostOrProfitType.Item, item: ItemList.Joy_Scent, amount: 12 }],
                 profits: [{ type: DealCostOrProfitType.Item, item: ItemList.Excite_Scent, amount: 1 }],
                 tradeButtonOverride: 'Refine',
             }),
             new GenericDeal({
-                costs: [{ type: DealCostOrProfitType.Item, item: ItemList.Excite_Scent, amount: 4 }],
+                costs: [{ type: DealCostOrProfitType.Item, item: ItemList.Excite_Scent, amount: 12 }],
                 profits: [{ type: DealCostOrProfitType.Item, item: ItemList.Vivid_Scent, amount: 1 }],
                 tradeButtonOverride: 'Refine',
             }),

--- a/src/modules/deal/GenericDeal.ts
+++ b/src/modules/deal/GenericDeal.ts
@@ -16,7 +16,8 @@ export type GenericTraderShopIdentifier =
     'FossilOreburghMiningMuseum' |
     'FossilNacreneMuseum' |
     'FossilAmbretteFossilLab' |
-    'FossilMasterGalarRoute6';
+    'FossilMasterGalarRoute6' |
+    'ScentTrader';
 
 /* eslint-disable @typescript-eslint/no-shadow */
 export enum DealCostOrProfitType {
@@ -424,6 +425,18 @@ export default class GenericDeal {
                 ],
                 profits: [{ type: DealCostOrProfitType.Item, item: ItemList.Arctovish, amount: 1, hidePlayerInventory: true }],
                 tradeButtonOverride: 'Revive',
+            }),
+        ]);
+        GenericDeal.list.ScentTrader = ko.observableArray([
+            new GenericDeal({
+                costs: [{ type: DealCostOrProfitType.Item, item: ItemList.Joy_Scent, amount: 4 }],
+                profits: [{ type: DealCostOrProfitType.Item, item: ItemList.Excite_Scent, amount: 1 }],
+                tradeButtonOverride: 'Refine',
+            }),
+            new GenericDeal({
+                costs: [{ type: DealCostOrProfitType.Item, item: ItemList.Excite_Scent, amount: 4 }],
+                profits: [{ type: DealCostOrProfitType.Item, item: ItemList.Vivid_Scent, amount: 1 }],
+                tradeButtonOverride: 'Refine',
             }),
         ]);
     }

--- a/src/scripts/items/HeldItem.ts
+++ b/src/scripts/items/HeldItem.ts
@@ -178,12 +178,12 @@ class ExpGainedBonusHeldItem extends HeldItem {
 
 ItemList.Wonder_Chest = new ExpGainedBonusHeldItem('Wonder_Chest', 10000, GameConstants.Currency.money, undefined, 'Wonder Chest', 1.25, GameConstants.Region.johto);
 ItemList.Miracle_Chest = new ExpGainedBonusHeldItem('Miracle_Chest', 30000, GameConstants.Currency.money, { visible: new MaxRegionRequirement(GameConstants.Region.sinnoh) }, 'Miracle Chest', 1.5, GameConstants.Region.sinnoh);
-ItemList.Joy_Scent = new ExpGainedBonusHeldItem('Joy_Scent', 10000, GameConstants.Currency.money, undefined, 'Joy Scent', 1.75, GameConstants.Region.hoenn, ' the holding Shadow Pokémon',
-    (p) => p.shadow >= GameConstants.ShadowStatus.Shadow );
-ItemList.Excite_Scent = new ExpGainedBonusHeldItem('Excite_Scent', 10000, GameConstants.Currency.money, undefined, 'Excite Scent', 2, GameConstants.Region.hoenn, 'the holding Shadow Pokémon',
-    (p) => p.shadow >= GameConstants.ShadowStatus.Shadow   );
-ItemList.Vivid_Scent = new ExpGainedBonusHeldItem('Vivid_Scent', 10000, GameConstants.Currency.money, undefined, 'Vivid Scent', 2.5, GameConstants.Region.hoenn, 'the holding Shadow Pokémon',
-    (p) => p.shadow >= GameConstants.ShadowStatus.Shadow  );
+ItemList.Joy_Scent = new ExpGainedBonusHeldItem('Joy_Scent', 10000, GameConstants.Currency.money, undefined, 'Joy Scent', 1.75, GameConstants.Region.hoenn, 'the holding Shadow or Purified Pokémon',
+    (p) => p.shadow >= GameConstants.ShadowStatus.Shadow);
+ItemList.Excite_Scent = new ExpGainedBonusHeldItem('Excite_Scent', 10000, GameConstants.Currency.money, undefined, 'Excite Scent', 2, GameConstants.Region.hoenn, 'the holding Shadow or Purified  Pokémon',
+    (p) => p.shadow >= GameConstants.ShadowStatus.Shadow);
+ItemList.Vivid_Scent = new ExpGainedBonusHeldItem('Vivid_Scent', 10000, GameConstants.Currency.money, undefined, 'Vivid Scent', 2.5, GameConstants.Region.hoenn, 'the holding Shadow or Purified  Pokémon',
+    (p) => p.shadow >= GameConstants.ShadowStatus.Shadow);
 ItemList.Muscle_Band = new AttackBonusHeldItem('Muscle_Band', 1000, GameConstants.Currency.battlePoint, undefined, 'Muscle Band', 1.05, GameConstants.Region.hoenn);
 // Pokemon specific items
 ItemList.Light_Ball = new PokemonRestrictedAttackBonusHeldItem('Light_Ball', 10000, GameConstants.Currency.money, undefined, 'Light Ball', 1.3, GameConstants.Region.johto, 'Pikachu',

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -3579,7 +3579,7 @@ TownList['Agate Village'] = new Town(
     'Agate Village',
     GameConstants.Region.hoenn,
     GameConstants.HoennSubRegions.Orre,
-    [AgateVillageShop, new MoveToTown('Relic Stone'), new MoveToDungeon(dungeonList['Relic Cave']), TemporaryBattleList['Cipher Peon Doven'], TemporaryBattleList['Cipher Peon Silton'], TemporaryBattleList['Cipher Peon Kass']],
+    [AgateVillageShop, new MoveToTown('Relic Stone'), new MoveToDungeon(dungeonList['Relic Cave']), TemporaryBattleList['Cipher Peon Doven'], TemporaryBattleList['Cipher Peon Silton'], TemporaryBattleList['Cipher Peon Kass'], new GenericTraderShop('ScentTrader', 'Perfumer')],
     {
         requirements: [new QuestLineStepCompletedRequirement('Shadows in the Desert', 14)],
         npcs: [AgateAthlete],


### PR DESCRIPTION
## Description
New guy in town, helps you upgrade scents you own into better ones at the rate of 12 to 1 (yes, lol).
In Agate Village because that's where you buy scent in the main games.
Additionally, scent descriptions now mention "Purified" alongside "Shadow", because that question often happens in the Discord server.

## Motivation and Context
It's basically a sink. If you do 500 clears in every Orre dungeons, you end up with above 1700 Joy Scents, lmao.
The balance aims at a final amount of 120 Vivid Scents with dungeon loots and crafts (58 otherwise).


## How Has This Been Tested?
Opened the game, traded, closed the game. Checked eggsteps as well just in case. :^)

## Types of changes
- New feature
