### PR TITLE
Add Blitzle to land Pokémon in Unova Route 3

### DIFF
--- a/src/modules/routes/RouteData.ts
+++ b/src/modules/routes/RouteData.ts
@@ -1578,11 +1578,10 @@ Routes.add(new RegionRoute(
 Routes.add(new RegionRoute(
     'Unova Route 3', Region.unova, 3,
     new RoutePokemon({
-        land: ['Yanma', 'Yanmega', 'Watchog', 'Herdier', 'Purrloin', 'Tranquill'],
+        land: ['Yanma', 'Yanmega', 'Watchog', 'Herdier', 'Purrloin', 'Tranquill', 'Blitzle'],
         special:
         [
             new SpecialRoutePokemon(['Zebstrika'], new ObtainedPokemonRequirement('Zebstrika')),
-            new SpecialRoutePokemon(['Blitzle'], new ObtainedPokemonRequirement('Blitzle')),
         ],
     }),
     [new ClearDungeonRequirement(1, getDungeonIndex('Pinwheel Forest'))],


### PR DESCRIPTION
## Description
Blitzle is not so special a Pokemon that it should only be obtainable through eggs, IMO. While it's true it was not obtainable any other way in BW2, it is obtainable on route 3 in BW. This PR moves it to be a freely obtainable Pokemon on route 3, but keeps the restriction on Zebstrika just so that the player is forced to evolve their Blitzle.



## Motivation and Context
This aligns the game more closely with the source material, but my real motivation is something else. Fun fact: If you play with the Require Complete Pokedex challenge inactive, Blitzle (and therefore also Zebstrika) is the only Pokemon that requires the use of random elemental eggs to acquire. Every other Pokemon has an alternative acquisition method available, whether that's berry wandering or waiting for a later region (usually Galar). I find this kind of silly, seeing as Blitzle is obtainable on the route normally in BW, so I wanted to see what other people thought.



## How Has This Been Tested?
Ran the game locally, caught a blitzle



## Types of changes
- Pokemon availability tweak
