### PR TITLE
Make Treasures menu settings sticky on scroll

### DIFF
--- a/src/styles/underground.less
+++ b/src/styles/underground.less
@@ -389,6 +389,16 @@
     box-shadow: inset 0 0 6px 2px var(--danger);
 }
 
+@media (min-width: 992px) {
+  #underground-treasure-filter-container {
+    align-self: flex-start;
+    position: sticky;
+    top: 1rem;
+    max-height: calc(100vh - 200px);
+    overflow-y: auto;
+  }
+}
+
 @container (max-width: 100px) {
     .treasure-item {
         .treasure-item-name {


### PR DESCRIPTION
## Description
Updates the "Filters and Settings" sidebar in the Underground Treasures menu to be sticky when scrolling



## Motivation and Context
It's inconvenient that it scrolls out of view when viewing shards/fossils/etc.

## How Has This Been Tested?
Checked that it looks correct across various screen sizes

## Screenshots (optional):
Before:
<img width="807" height="574" alt="image" src="https://github.com/user-attachments/assets/984a6569-6421-4378-858f-86f81d54e6bc" />
After:
<img width="805" height="638" alt="image" src="https://github.com/user-attachments/assets/7c3eabb8-b483-4c3b-a5fa-25d0e9cdc8d2" />
It can also scroll independently if the menu is too small:
<img width="804" height="454" alt="image" src="https://github.com/user-attachments/assets/2a4ad733-0aaa-41d4-81a1-9a774f269ce1" />

The expandable mobile version is unaffected, hence the media query wrapping it to be large only

## Types of changes
- UI improvement
