### PR TITLE
Update pr-preview-action

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -53,16 +53,17 @@ jobs:
           ln -s ../../libs build/libs
       
       - name: Deploy to GH-Pages
-        uses: redsparr0w/pr-preview-action@e42785b6369079700cfd810f51d14da466ea5cce
+        uses: rossjrw/pr-preview-action@v1
         id: preview_step
         with:
           source-dir: 'build'
           preview-branch: 'master'
           umbrella-dir: 'docs/preview'
-          custom-url: 'dev.pokeclicker.com'
+          pages-base-url: 'dev.pokeclicker.com'
           deploy-repository: 'RedSparr0w/pokeclicker'
           token: ${{ secrets.DEV_PAGE }}
-          pages-base-dir: 'docs/'
+          pages-base-oath: 'docs/'
+          qr-code: false
 
       - name: Preview URL
         run: echo "url => ${{ steps.preview_step.outputs.deployment-url }}"


### PR DESCRIPTION
Update to the latest version of pr-preview-action, which will hopefully fix the PR preview deployments failing.

## Description
The action's main repository now supports setting the deployment path, so we no longer need to use a custom version. I updated the parameters which they've renamed in updates since.

## Motivation and Context
PR preview deployments aren't working. Not clear if this will fix it, but it can't get more broken.

## How Has This Been Tested?
It hasn't; changes to github actions don't take effect until merged to develop. If it doesn't work... well, it's already broken.
