### PR TITLE
Fix rare bug causing player sprite to be incorrect in dungeons

### DIFF
--- a/src/modules/profile/Profile.ts
+++ b/src/modules/profile/Profile.ts
@@ -50,6 +50,7 @@ export default class Profile implements Saveable {
         this.name = ko.observable(name);
         this.trainer = ko.observable(trainer).extend({ numeric: 0 });
         this.trainer.subscribe((t) => document.documentElement.style.setProperty('--trainer-image', `url('../assets/images/profile/trainer-${t}.png')`));
+        document.documentElement.style.setProperty('--trainer-image', `url('../assets/images/profile/trainer-${trainer}.png')`);
         this.pokemon = ko.observable(pokemon).extend({ numeric: 2 });
         this.pokemonShiny = ko.observable(false).extend({ boolean: null });
         this.pokemonShadow = ko.observable(false).extend({ boolean: null });


### PR DESCRIPTION
## Description
Fixes a rare bug that caused the player sprite in dungeons to appear as the `trainer-0` sprite.

## Motivation and Context
In Profile.ts:

```ts
this.trainer = ko.observable(trainer).extend({ numeric: 0 });
this.trainer.subscribe((t) => document.documentElement.style.setProperty('--trainer-image', `url('../assets/images/profile/trainer-${t}.png')`));
```

The constructor's default `trainer` parameter is `Rand.floor(Profile.MAX_TRAINER)` - a random number from 0 to 163.

KO subscribers do not fire on creation, and our numeric extender doesn't update if the values are the same.

So if the randomly generated `trainer` value happens to be the same one the player has selected as their sprite, on load the above subscriber is never called as the value doesn't change, so the CSS `--trainer-image` var is never updated and remains `trainer-0`.

Fixed by explicitly setting the CSS var in the Profile constructor.

## How Has This Been Tested?
Hardcoded my selected profile sprite value in the constructor and verified the correct sprite was visible in dungeons

## Types of changes
- Bug fix
