### PR TITLE
Allow route/dungeon shortcut navigation while Info modal is open

### DIFF
--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -100,6 +100,8 @@ class GameController {
         $purifyChamberModal.on('hidden.bs.modal shown.bs.modal', _ => $purifyChamberModal.data('disable-toggle', false));
         // Ship
         const $shipModal = $('#ShipModal');
+        // Route Info
+        const $routeInfoModal = $('#routeInfoModal');
         // Modal Collapse
         $(GameConstants.ModalCollapseList).map(function() {
             const id = `#${this}`;
@@ -296,10 +298,9 @@ class GameController {
                 }
             }
 
-            // Only run if no modals are open
-            if (visibleModals === 0) {
-                // Route Battles
-                if (App.game.gameState === GameConstants.GameState.fighting && !GameController.keyHeld.Control?.()) {
+            // Route Battles
+            if (App.game.gameState === GameConstants.GameState.fighting && !GameController.keyHeld.Control?.()) {
+                if (visibleModals === 0 || $routeInfoModal.data('bs.modal')?._isShown) {
                     const cycle = Routes.getRoutesByRegion(player.region).filter(r => r.isUnlocked()).map(r => r.number);
                     if (cycle.length > 1) {
                         const idx = cycle.findIndex(r => r == player.route);
@@ -313,7 +314,10 @@ class GameController {
                         }
                     }
                 }
+            }
 
+            // Only run if no modals are open
+            if (visibleModals === 0) {
                 // Dungeons
                 if (App.game.gameState === GameConstants.GameState.dungeon) {
                     switch (key) {

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -102,6 +102,8 @@ class GameController {
         const $shipModal = $('#ShipModal');
         // Route Info
         const $routeInfoModal = $('#routeInfoModal');
+        // Dungeon Info
+        const $dungeonInfoModal = $('#dungeonInfoModal');
         // Modal Collapse
         $(GameConstants.ModalCollapseList).map(function() {
             const id = `#${this}`;
@@ -316,6 +318,21 @@ class GameController {
                 }
             }
 
+            // Dungeon Navigation
+            if (App.game.gameState === GameConstants.GameState.town && player.town instanceof DungeonTown && !GameController.keyHeld.Control?.()) {
+                if (visibleModals === 0 || $dungeonInfoModal.data('bs.modal')?._isShown) {
+                    const cycle = Object.values(TownList).filter(t => t instanceof DungeonTown && t.region == player.region && t.isUnlocked());
+                    const idx = cycle.findIndex(d => d.name == player.town.name);
+                    switch (key) {
+                        case '=' :
+                        case '+' : MapHelper.moveToTown(cycle[(idx + 1) % cycle.length].name);
+                            return e.preventDefault();
+                        case '-' : MapHelper.moveToTown(cycle[(idx + cycle.length - 1) % cycle.length].name);
+                            return e.preventDefault();
+                    }
+                }
+            }
+
             // Only run if no modals are open
             if (visibleModals === 0) {
                 // Dungeons
@@ -363,16 +380,6 @@ class GameController {
                             NPCController.openDialog(filteredNPCs[numberKey - filteredContent.length]);
                         }
                         return e.preventDefault();
-                    } else if (player.town instanceof DungeonTown && !GameController.keyHeld.Control?.()) {
-                        const cycle = Object.values(TownList).filter(t => t instanceof DungeonTown && t.region == player.region && t.isUnlocked());
-                        const idx = cycle.findIndex(d => d.name == player.town.name);
-                        switch (key) {
-                            case '=' :
-                            case '+' : MapHelper.moveToTown(cycle[(idx + 1) % cycle.length].name);
-                                return e.preventDefault();
-                            case '-' : MapHelper.moveToTown(cycle[(idx + cycle.length - 1) % cycle.length].name);
-                                return e.preventDefault();
-                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
Unblocks the +/- navigation shortcuts when the Info Modal is open

## Motivation and Context
Allows quicker comparison of different routes/dungeons, and more convenient navigation in general

## How Has This Been Tested?
Checked the hotkey worked as expected and all the data shown was correct and in sync, and that the hotkeys continued to not work when other modals were open

## Types of changes
- UI improvement