### PR TITLE
Add [Reset All Filters] button to pokedex & hatchery

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -202,6 +202,12 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                 <!-- /ko -->
                                             </div>
 
+                                            <div class="col-12 mt-1">
+                                                <button class="btn btn-primary btn-block btn-sm" data-bind="click: () => BreedingController.resetFilters()">
+                                                    Reset All Filters
+                                                </button>
+                                            </div>
+
                                             <div class="col-12">
                                                 <hr style="border-color:grey;">
                                             </div>
@@ -230,7 +236,7 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                 <!-- /ko -->
                                             </div>
                                             <!-- /ko -->
-                                            <div class="form-group col-lg-12 col-12" style="max-width: 100%; flex-grow: 1">
+                                            <div class="form-group col-lg-12 col-12 mb-0" style="max-width: 100%; flex-grow: 1">
                                                 <!-- ko let: { hatcherySort: Settings.getSetting('hatcherySort') } -->
                                                 <label for="hatchery-setting-sort" data-bind="text: hatcherySort.displayName">Sort</label>
                                                 <div class="input-group">

--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -165,7 +165,7 @@ aria-labelledby="pokedexModalLabel">
 
                                     <!--Rare Hold Item-->
                                     <div class="col-12">
-                                        <div class="form-group my-2">
+                                        <div class="form-group">
                                             <!-- ko let: { pokedexHeldItemFilter: Settings.getSetting('pokedexHeldItemFilter') } -->
                                             <label for="pokedex-filter-held-item" data-bind="text: pokedexHeldItemFilter.displayName">Rare Held Item</label>
                                             <span class="mx-1"
@@ -187,7 +187,7 @@ aria-labelledby="pokedexModalLabel">
 
                                     <!--Hide alternate forms-->
                                     <div class="col-12">
-                                        <div class="form-group my-2">
+                                        <div class="form-group mb-0">
                                             <!-- ko let: { pokedexHideAltFilter: Settings.getSetting('pokedexHideAltFilter') } -->
                                             <label for="pokedex-filter-hide-alternate" data-bind="text: pokedexHideAltFilter.displayName">Hide alternate forms</label>
                                             <label class="form-check-label toggler-wrapper style-1 float-right">
@@ -199,6 +199,12 @@ aria-labelledby="pokedexModalLabel">
                                             </label>
                                             <!-- /ko -->
                                         </div>
+                                    </div>
+
+                                    <div class="col-12 mt-1">
+                                        <button class="btn btn-primary btn-block btn-sm" data-bind="click: () => PokedexHelper.resetFilters()">
+                                            Reset All Filters
+                                        </button>
                                     </div>
 
                                     <div class="col-12">

--- a/src/scripts/breeding/BreedingController.ts
+++ b/src/scripts/breeding/BreedingController.ts
@@ -171,6 +171,14 @@ class BreedingController {
         return odds / regionPoolCount;
     }
 
+    public static resetFilters() {
+        for (const key of breedingFilterSettingKeys) {
+            const setting = Settings.getSetting(key);
+            Settings.setSettingByName(key, setting.defaultValue);
+        }
+        (document.getElementById('breeding-filter-nameID') as HTMLInputElement).value = '';
+    }
+
     // Queue size limit setting
     public static queueSizeLimit = ko.observable(-1);
 

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -256,6 +256,14 @@ class PokedexHelper {
         return (pokemon.type.length === 1 && (type == null || pokemon.type[0] === type));
     }
 
+    public static resetFilters() {
+        for (const key of pokedexFilterSettingKeys) {
+            const setting = Settings.getSetting(key);
+            Settings.setSettingByName(key, setting.defaultValue);
+        }
+        (document.getElementById('pokedex-filter-nameID') as HTMLInputElement).value = '';
+    }
+
     // Flag for the LazyLoader
     public static resetPokedexFlag = ko.computed(() => DisplayObservables.modalState.pokedexModal === 'hidden');
 

--- a/src/styles/breeding.less
+++ b/src/styles/breeding.less
@@ -321,6 +321,10 @@
 .scrolling-div-breeding-list,
 .scrolling-div-breeding-filters {
     overflow-y: auto;
+
+    .form-group {
+        margin-bottom: 0.75rem;
+    }
 }
 
 @media (min-width: 992px) {

--- a/src/styles/pokedex.less
+++ b/src/styles/pokedex.less
@@ -137,3 +137,7 @@
 .btn-dropdown:hover {
   color:#444 !important;
 }
+
+.scrolling-div-pokedex .form-group {
+    margin-bottom: 0.75rem;
+}


### PR DESCRIPTION
## Description
Adds a [Reset All Filters] button to the pokedex & hatchery. Also tightened up some whitespace in the Filters & Settings area of both modals.

## How Has This Been Tested?
I clicked the button. Several times.

## Types of changes
- UI improvement

closes #4303 
closes #5602 

