### PR TITLE
Updated regex to also remove whitespace before digit when winning/losing a Gym Battle

### DIFF
--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -90,7 +90,7 @@ class GymRunner {
         if (GymRunner.running()) {
             GymRunner.running(false);
             Notifier.notify({
-                message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName.replace(/\d/g, '')}.`,
+                message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName.replace(/\s\d/g, '')}.`,
                 type: NotificationConstants.NotificationOption.danger,
             });
             App.game.gameState = GameConstants.GameState.town;
@@ -101,7 +101,7 @@ class GymRunner {
         if (GymRunner.running()) {
             GymRunner.running(false);
             Notifier.notify({
-                message: `Congratulations, you defeated ${GymBattle.gym.leaderName.replace(/\d/g, '')}!`,
+                message: `Congratulations, you defeated ${GymBattle.gym.leaderName.replace(/\s\d/g, '')}!`,
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.General.gym_won,
             });

--- a/src/scripts/gym/GymRunner.ts
+++ b/src/scripts/gym/GymRunner.ts
@@ -90,7 +90,7 @@ class GymRunner {
         if (GymRunner.running()) {
             GymRunner.running(false);
             Notifier.notify({
-                message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName.replace(/\s\d/g, '')}.`,
+                message: `It appears you are not strong enough to defeat ${GymBattle.gym.leaderName.replace(/\s?\d/g, '')}.`,
                 type: NotificationConstants.NotificationOption.danger,
             });
             App.game.gameState = GameConstants.GameState.town;
@@ -101,7 +101,7 @@ class GymRunner {
         if (GymRunner.running()) {
             GymRunner.running(false);
             Notifier.notify({
-                message: `Congratulations, you defeated ${GymBattle.gym.leaderName.replace(/\s\d/g, '')}!`,
+                message: `Congratulations, you defeated ${GymBattle.gym.leaderName.replace(/\s?\d/g, '')}!`,
                 type: NotificationConstants.NotificationOption.success,
                 setting: NotificationConstants.NotificationSetting.General.gym_won,
             });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
The regex that removes the digits from the end of Gym Leader names when winning/losing a Gym Battle now removes the trailing space also.

For example:
Before: Kareign 2 -> "Congratulations, you defeated Kareign !"
After: Kareign 2 -> "Congratulations, you defeated Kareign!"


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
This tiny bug annoyed a friend of mine.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Loaded friend's saves and won and lost against:
- Fast League Kareign (Kareign 2)
- Ultra League Jump Champ (Jump Champ 2)
- Elite 4 Jump Champ (Jump Champ 3)

Messages are fixed in all cases.



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix

