### PR TITLE
[Veteran Shop] Allow purchasing the Pokérus Virus multiple times

### DIFF
--- a/src/modules/TemporaryScriptTypes.ts
+++ b/src/modules/TemporaryScriptTypes.ts
@@ -352,6 +352,7 @@ export type TmpPartyType = {
     alreadyCaughtPokemonByName: (name: PokemonNameType, shiny?: boolean) => boolean;
     alreadyCaughtPokemon: (id: number, shiny?: boolean, shadow?: boolean, purified?: boolean) => boolean;
     calculateClickAttack: (useItem?: boolean) => number;
+    infectFirstUninfectedPokemon: () => void;
 };
 
 export type TmpPartyControllerType = {

--- a/src/modules/items/buyKeyItem.ts
+++ b/src/modules/items/buyKeyItem.ts
@@ -19,13 +19,18 @@ export default class BuyKeyItem extends Item {
         return this.basePrice * amt;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     gain(amt: number) {
-        App.game.keyItems.gainKeyItem(this.item, this.silent);
+        for (let i = 0; i < amt; i++) {
+            App.game.keyItems.gainKeyItem(this.item, this.silent);
+        }
     }
 
     isSoldOut(): boolean {
-        return App.game.keyItems.hasKeyItem(this.item);
+        return App.game.keyItems.hasKeyItem(this.item) && !App.game.keyItems.itemList.find(k => k.id === this.item)?.allowMultipleUnlocks;
+    }
+
+    showBagAmount() {
+        return false;
     }
 
     get image(): string {

--- a/src/modules/keyItems/KeyItem.ts
+++ b/src/modules/keyItems/KeyItem.ts
@@ -13,15 +13,22 @@ export default class KeyItem {
     public unlockReq: KnockoutComputed<boolean>;
     public unlocker: KnockoutSubscription;
     public isUnlocked: KnockoutObservable<boolean>;
+    public allowMultipleUnlocks: boolean;
 
-    constructor(id: KeyItemType, description: string, unlockReq?: () => boolean, isUnlocked = false,
+    constructor(id: KeyItemType,
+        description: string,
+        unlockReq?: () => boolean,
+        isUnlocked = false,
         public unlockRewardOnClose = () => {},
         displayName?: string,
-        public unlockRewardOnUnlock = () => {}) {
+        public unlockRewardOnUnlock = () => {},
+        allowMultipleUnlocks = false,
+    ) {
         this.id = id;
         this.displayName = displayName ?? GameConstants.humanifyString(KeyItemType[this.id]);
         this.description = description;
         this.isUnlocked = ko.observable(isUnlocked ?? false);
+        this.allowMultipleUnlocks = allowMultipleUnlocks;
 
         if (this.isUnlocked() || typeof unlockReq !== 'function') {
             this.unlockReq = null;

--- a/src/modules/keyItems/KeyItems.ts
+++ b/src/modules/keyItems/KeyItems.ts
@@ -4,7 +4,7 @@ import Information from '../utilities/Information';
 import KeyItemController from './KeyItemController';
 import { Feature } from '../DataStore/common/Feature';
 import {
-    getDungeonIndex, Region, RegionalStarters, ROUTE_KILLS_NEEDED, Pokerus,
+    getDungeonIndex, Region, ROUTE_KILLS_NEEDED,
 } from '../GameConstants';
 
 export default class KeyItems implements Feature {
@@ -71,12 +71,9 @@ export default class KeyItems implements Feature {
                     });
                 },
                 'Pokérus Virus',
-                () => {
-                    const patientZero = App.game.party.getPokemon(
-                        RegionalStarters[Region.kanto][player.regionStarters[Region.kanto]()],
-                    ) || App.game.party.caughtPokemon[0];
-                    patientZero.pokerus = Pokerus.Contagious;
-                }),
+                () => App.game.party.infectFirstUninfectedPokemon(),
+                true,
+            ),
             /*new KeyItem(KeyItemType['Z-Power_Ring'],
                 // Using a Z-Crystal boosts the power of all your Pokémon of a shared type for a short while, after which some time is needed to recharge.'
                 'A gift from Melemele\'s kahuna that enables the use of Z-Crystals. What they do is still under development.',
@@ -93,8 +90,8 @@ export default class KeyItems implements Feature {
     }
 
     gainKeyItem(item: KeyItemType, silent = false): void {
-        if (!this.hasKeyItem(item)) {
-            const keyItem = this.itemList.find(k => k.id === item);
+        const keyItem = this.itemList.find(k => k.id === item);
+        if (keyItem && (!this.hasKeyItem(item) || keyItem.allowMultipleUnlocks)) {
             keyItem.unlock();
             keyItem.unlockRewardOnUnlock();
             if (!silent) {
@@ -103,7 +100,6 @@ export default class KeyItems implements Feature {
         }
     }
 
-    // eslint-disable-next-line class-methods-use-this
     canAccess(): boolean {
         return true;
     }

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -286,6 +286,35 @@ class Party implements Feature, TmpPartyType {
         return this._caughtPokemonLookup().get(pokemonMap[name].id);
     }
 
+    private _suppressPokerusNoEligibleNotify = false;
+
+    public infectFirstUninfectedPokemon(): void {
+        // Prioritise the kantoStarter before the first dex entry
+        const kantoStarter = App.game.party.getPokemon(GameConstants.RegionalStarters[GameConstants.Region.kanto][player.regionStarters[GameConstants.Region.kanto]()]);
+        const potentialPokemon = [...(kantoStarter ? [kantoStarter] : []), ...this.caughtPokemon];
+        const firstUninfected = potentialPokemon.find(p => p.pokerus === GameConstants.Pokerus.Uninfected);
+        if (firstUninfected) {
+            this._suppressPokerusNoEligibleNotify = false;
+            firstUninfected.pokerus = GameConstants.Pokerus.Contagious;
+            Notifier.notify({
+                message: `${firstUninfected.displayName} has been infected with Pokérus!`,
+                pokemonImage: PokemonHelper.getImage(firstUninfected.id),
+                type: NotificationConstants.NotificationOption.success,
+                sound: NotificationConstants.NotificationSound.General.pokerus,
+                setting: NotificationConstants.NotificationSetting.General.pokerus,
+            });
+        } else if (!this._suppressPokerusNoEligibleNotify) {
+            Notifier.notify({
+                message: 'No more Pokémon to infect.',
+                type: NotificationConstants.NotificationOption.danger,
+            });
+            this._suppressPokerusNoEligibleNotify = true;
+            setTimeout(() => {
+                this._suppressPokerusNoEligibleNotify = false;
+            }, 100);
+        }
+    }
+
     public partyPokemonActiveInSubRegion(region: GameConstants.Region, subregion: GameConstants.SubRegions): Array<PartyPokemon> {
         let caughtPokemon = this.caughtPokemon as Array<PartyPokemon>;
         if (region == GameConstants.Region.alola && subregion == GameConstants.AlolaSubRegions.MagikarpJump) {

--- a/src/scripts/shop/Shop.ts
+++ b/src/scripts/shop/Shop.ts
@@ -20,7 +20,7 @@ class Shop extends TownContent {
     public tooltip = 'Visit shops to buy items.';
     constructor(
         public items: Item[],
-        public name = undefined,
+        public name: string | undefined = undefined,
         requirements: (Requirement | OneFromManyRequirement)[] = [],
         private hideBeforeUnlocked = false
     ) {

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -267,6 +267,7 @@ const veteranShop = new VeteranShop([
             new VeteranUnlockRequirement(GameConstants.VeteranUnlock.PokerusVirus),
             new CaughtPokemonRequirement(1),
         ]),
+        maxAmount: 10000,
     }, 'Pokérus Virus', true),
     new BuyKeyItem(KeyItemType.Event_calendar, 10000, GameConstants.Currency.questPoint, {
         visible: new VeteranUnlockRequirement(GameConstants.VeteranUnlock.EventCalendar),


### PR DESCRIPTION
## Description
Allows purchasing the Pokérus Virus multiple times to continue infecting through your entire party

Opening as a draft to see if this is wanted, and if so, if there might not be an obviously better way to achieve the same outcome

## Motivation and Context
Current implementation of early Pokérus isn't particularly useful pre-Giovanni, and some files cannot infect through their Party due to not having matching types

## Screenshots (optional):
<img width="363" height="265" alt="image" src="https://github.com/user-attachments/assets/b8525bf1-9cf6-480f-b03b-342667c52dd0" />

<img width="360" height="121" alt="image" src="https://github.com/user-attachments/assets/d0627fbf-9914-471c-9db3-89cca7ba155d" />

## Types of changes
- New feature
