### PR TITLE
Hide starter skip during No Click Attack challenge

### DIFF
--- a/src/scripts/StartSequenceRunner.ts
+++ b/src/scripts/StartSequenceRunner.ts
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
                            onclick="StartSequenceRunner.pickStarter(GameConstants.Starter.Special)">
                     </div>`);
             }
-            if (StartSequenceRunner.noStarterCount == 20) {
+            if (StartSequenceRunner.noStarterCount == 20 && !App.game.challenges.list.disableClickAttack.active()) {
                 $('#pickStarterTutorialModal .modal-body').append(`<div class="custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" id="toggleCaptureStarter" onchange="App.game.pokeballFilters.toggleAllFiltersEnabled(this.checked)" checked>
                         <label class="custom-control-label" for="toggleCaptureStarter">Capture Starter</label>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

If starter capture is skipped while No Click Attack is active, the selected starter is recorded without adding a Pokemon to the party. Click attacks are then disabled, while the empty party deals no automatic damage. This leaves progression soft-locked until the challenge is permanently disabled.

This change prevents the Capture Starter option from appearing when No Click Attack is already active.

The conflicting state can still be reached through a less common sequence:

1. Unlock and disable Capture Starter.
2. Select a starter.
3. Enable No Click Attack before defeating the starter.

I considered forcibly re-enabling the capture filters in this case, but that would override an explicit player choice. The state is also recoverable by disabling No Click Attack. Players who want to preserve the challenge can instead restart the save, since this situation can only occur during the initial setup.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->



## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->



## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Bug fix
- New feature
- UI improvement
