### PR TITLE
Various small CSS/theme fixes

### DIFF
--- a/src/modules/SaveSelector.ts
+++ b/src/modules/SaveSelector.ts
@@ -30,7 +30,7 @@ export default class SaveSelector {
             $('#saveSelectorContextMenu').html(`
                 <a class="dropdown-item bg-success" href="#" onclick="Save.key = '${key}'; SaveSelector.Download('${key}')">Download (backup)</a>
                 <a class="dropdown-item bg-info" href="#" onclick="Save.key = '${key}'; document.querySelector('#saveSelector').remove(); App.start();">Load</a>
-                <a class="dropdown-item bg-warning p-0 w-100" href="#"><label class="clickable my-0" style="padding:.75rem;" for="import-save" onclick="Save.key = '${key}';">Import (overwrite)</label></a>
+                <a class="dropdown-item bg-warning p-0 w-100" href="#"><label class="clickable my-0 px-4" style="padding:.75rem;" for="import-save" onclick="Save.key = '${key}';">Import (overwrite)</label></a>
                 <a class="dropdown-item bg-danger" href="#" onclick="Save.key = '${key}'; Save.delete();">Delete</a>
             `).css({
                 display: 'block',

--- a/src/styles/farm.less
+++ b/src/styles/farm.less
@@ -139,6 +139,23 @@
                 drop-shadow(0.2px -0.2px 0 black)
                 drop-shadow(-0.2px -0.2px 0 black);
       }
+
+      .wandererSprite, .wandererCapture {
+        height: 60%;
+        width: 60%;
+        position: absolute;
+        pointer-events: none;
+        top: -10%;
+        left: -10%;
+      }
+
+      .wandererSprite {
+        image-rendering: pixelated;
+      }
+
+      .wandererCapture {
+        padding: 10%;
+      }
   }
 
   .plotButton {
@@ -163,16 +180,6 @@
           height: 12px;
           width: 12px;
           filter: none;
-      }
-
-
-      .wandererSprite, .wandererCapture {
-        height: 60%;
-        width: 60%;
-        position: absolute;
-        pointer-events: none;
-        top: -10%;
-        left: -10%;
       }
   }
 }
@@ -251,19 +258,6 @@
   .list-inline-item:nth-child(n+6) {
     margin-top: 14px;
   }
-}
-
-.wandererSprite, .wandererCapture {
-  height: 80px;
-  width: 80px;
-  position: absolute;
-  pointer-events: none;
-  top: -16px;
-  left: -16px;
-}
-
-.wandererSprite {
-  image-rendering: pixelated;
 }
 
 @keyframes flash {

--- a/src/styles/pokedex.less
+++ b/src/styles/pokedex.less
@@ -138,6 +138,15 @@
   color:#444 !important;
 }
 
+/* Override styles inherited from .btn on our .custom-select */
+.btn-dropdown.custom-select {
+  box-shadow: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+}
+
 .scrolling-div-pokedex .form-group {
     margin-bottom: 0.75rem;
 }

--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -479,3 +479,26 @@
         }
     }
 }
+
+/* Overrides for the .custom-select to make it look like native select */
+.btn-dropdown.custom-select {
+    .lumen & {
+        border-width: 1px;
+    }
+
+    .sketchy & {
+        font-weight: 700;
+    }
+
+    .journal &, .minty & {
+        font: inherit;
+    }
+
+    .lux &, .sandstone & {
+        font-size: 14px;
+    }
+
+    .slate & {
+        border: 1px solid #ced4da;
+    }
+}

--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -58,6 +58,20 @@
   }
 }
 
+/* Fixes text-success on .bg-secondary being unreadable for theme specific colour themes */
+.flatly, .journal, .litera, .solar, .spacelab, .united {
+  .bg-secondary .text-success {
+    color: #1a6e2d !important;
+  }
+}
+
+/* Fixes unreadable text due to identical colors for .bg-secondary */
+.cosmo, .solar {
+  .bg-secondary {
+    color: #fff;
+  }
+}
+
 /* Individual themes */
 .cerulean {
   /* Evolution items */

--- a/src/styles/themes.less
+++ b/src/styles/themes.less
@@ -332,9 +332,9 @@
     margin: 0 !important
   }
 
-  //Fixes save containers having a white table
-  .save-container table td {
-    background-color:unset !important;
+  //Fixes save containers/tooltips having a white table
+  .save-container table td, .tooltip-inner table td, .tooltip-inner table th {
+    background-color: unset !important;
   }
 
   .modal-header {


### PR DESCRIPTION
## Description
Fixed various CSS issues and theme discrepancies

(All screenshots are pre-fix)
Wanderers scale/position differently in modal vs module:
<img width="735" height="445" alt="image" src="https://github.com/user-attachments/assets/f45da722-e527-4720-b97f-bfa6a9e53616" />  

Wanderer catch animation much smaller in module:
<img width="465" height="348" alt="image" src="https://github.com/user-attachments/assets/c1fb1da5-0d92-4b0e-b140-f58c54b7fc6a" />

Save context menu misaligned:
<img width="188" height="194" alt="image" src="https://github.com/user-attachments/assets/4c8e6ea4-cd98-49cf-878b-2013cbf124e7" />  

Pokédex/Hatchery custom selects look completely different to normal selects on some themes:
<img width="277" height="223" alt="image" src="https://github.com/user-attachments/assets/e0b46888-37d6-4370-ba15-f1c020d761e8" />  

Underground tool durability mostly unreadable, "Info" completely unreadable on some themes:
<img width="323" height="208" alt="image" src="https://github.com/user-attachments/assets/3066124f-4901-4dfe-a6fb-720147be08df" />  

Sketchy flute info unreadable:
<img width="162" height="162" alt="image" src="https://github.com/user-attachments/assets/82099246-dfed-4b50-8f4d-5f30e6e2c010" />

