### PR TITLE
dungeonPokerusEVs function moved

### DIFF
--- a/src/components/dungeonView.html
+++ b/src/components/dungeonView.html
@@ -118,7 +118,7 @@
                   <!--Pokérus image-->
                   <knockout data-bind="if: RouteHelper.minPokerusCheck(DungeonRunner.dungeon.allAvailablePokemon())">
                       <img data-bind="attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(DungeonRunner.dungeon.allAvailablePokemon())] + '.png' },
-                      tooltip: { title: RouteHelper.dungeonPokerusEVs(DungeonRunner.dungeon), trigger: 'hover', placement: 'bottom', html: true }"
+                      tooltip: { title: Dungeon.dungeonPokerusEVs(DungeonRunner.dungeon), trigger: 'hover', placement: 'bottom', html: true }"
                     src=""/>
                   </knockout>
 

--- a/src/components/townView.html
+++ b/src/components/townView.html
@@ -18,7 +18,7 @@
                                 <img src="" data-bind="
                                 attr:{ src: 'assets/images/breeding/pokerus/' + GameConstants.Pokerus[RouteHelper.minPokerus(player.town.dungeon.allAvailablePokemon())] + '.png'},
                                 tooltip: {
-                                    title: RouteHelper.dungeonPokerusEVs(player.town.dungeon),
+                                    title: Dungeon.dungeonPokerusEVs(player.town.dungeon),
                                     placement: 'bottom',
                                     trigger: 'hover',
                                     html: true

--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -9,6 +9,7 @@
 ///<reference path="../../declarations/requirements/BerryUnlockedRequirement.d.ts"/>
 ///<reference path="../../declarations/utilities/SeededDateRand.d.ts"/>
 ///<reference path="./DungeonTrainer.ts"/>
+///<reference path="../wildBattle/RouteHelper.ts"/>
 
 interface EnemyOptions {
     weight?: number,
@@ -279,6 +280,16 @@ class Dungeon {
 
     public getCaughtMimics(): PokemonNameType[] {
         return this.mimicList.filter(p => App.game.party.alreadyCaughtPokemonByName(p));
+    }
+
+    public static dungeonPokerusEVs(dungeon: Dungeon): string {
+        const possiblePokemon: PokemonNameType[] = [...new Set(dungeon.allAvailablePokemon())];
+        if (RouteHelper.minPokerus(possiblePokemon) == GameConstants.Pokerus.Resistant) {
+            return 'All Pokémon in this dungeon are resistant!';
+        }
+        const currentEVs = RouteHelper.getEvs(possiblePokemon);
+        return `EVs until all Pokémon are resistant in this dungeon: ${currentEVs}&nbsp;/&nbsp;${50 * possiblePokemon.length}.`;
+
     }
 
     public getRandomLootTier(clears: number, debuffed = false, onlyDebuffable = false): LootTier {

--- a/src/scripts/wildBattle/RouteHelper.ts
+++ b/src/scripts/wildBattle/RouteHelper.ts
@@ -75,17 +75,7 @@ class RouteHelper {
         return `EVs until all Pokémon are resistant on this route: ${currentEVs}&nbsp;/&nbsp;${50 * possiblePokemon.length}.`;
     }
 
-    public static dungeonPokerusEVs(dungeon: Dungeon): string {
-        const possiblePokemon: PokemonNameType[] = [...new Set(dungeon.allAvailablePokemon())];
-        if (this.minPokerus(possiblePokemon) == GameConstants.Pokerus.Resistant) {
-            return 'All Pokémon in this dungeon are resistant!';
-        }
-        const currentEVs = this.getEvs(possiblePokemon);
-        return `EVs until all Pokémon are resistant in this dungeon: ${currentEVs}&nbsp;/&nbsp;${50 * possiblePokemon.length}.`;
-
-    }
-
-    private static getEvs(possiblePokemon: PokemonNameType[]): number {
+    public static getEvs(possiblePokemon: PokemonNameType[]): number {
         let currentEVs = 0;
         possiblePokemon.forEach(pkmn => {
             const partyPokemon: PartyPokemon = App.game.party.getPokemonByName(pkmn);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->
- Moved dungeonPokerusEvs() from RouteHelper.ts to dungeon.ts, I felt this was more appropriate than the prior suggested places since this is where we also do the AllShadowsCaught() checks aswell. EG DungeonRunner.ts seems more related to the actual functions that occur when in a dungeon and PokemonHelper.ts felt more like it was related to party, pokedex and statistics functions.
- Editted the relevant html files to point to dungeon.dungeonPokerusEVs
- made getEVs a public so can be called by dungeonPokerusEVs() without duplicating code
- added reference back to RouteHelper (didnt know if this was necessary) 


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->
Minor/Beginner level code rework with minimal edits required (still quite new to the repo)
Quite an old approved pr that Closes #4207


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested in Veridian Forest with a save file needing only a single EV to complete, it accurately updated and displayed the correct icon and related text when all pokemon had at least 50EVs.
Tested navigating the selected dungeon with helpers to ensure no unexpected effects were present.
Made the relevant changes to the HTML templates which were the only other files affected by this change.


## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->



## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- Code rework / moving snippet
