### PR TITLE
Re-add Categorized button

### DIFF
--- a/src/components/breedingModal.html
+++ b/src/components/breedingModal.html
@@ -197,6 +197,11 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                                 class: 'btn-primary btn-sm',
                                                                 onClick: () => breedingCategoryFilter.set([]),
                                                             },
+                                                            {
+                                                                label: 'Categorized',
+                                                                class: 'btn-primary btn-sm',
+                                                                onClick: () => breedingCategoryFilter.set(PokemonCategories.categories().filter(c => c.id > 0).map(c => c.id)),
+                                                            },
                                                         ],
                                                         bottomButtons: [
                                                             {
@@ -462,9 +467,9 @@ aria-labelledby="breedingModalLabel" aria-hidden="true">
                                                         </div>
                                                         <!-- /ko -->
                                                         <div class="dropdown-divider"></div>
-                                                        <a class="dropdown-item dropdown-text" href="#categoryModal" data-toggle="modal">
-                                                            <i>Edit categories</i>
-                                                        </a>
+                                                        <button class="btn btn-primary btn-sm btn-block font-weight-bold" data-toggle="modal" data-target="#categoryModal">
+                                                            Edit Categories
+                                                        </button>
                                                     </div>
                                                 </div>
                                             </li>

--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -183,6 +183,11 @@ aria-labelledby="pokedexModalLabel">
                                                         class: 'btn-primary btn-sm',
                                                         onClick: () => pokedexCategoryFilter.set([]),
                                                     },
+                                                    {
+                                                        label: 'Categorized',
+                                                        class: 'btn-primary btn-sm',
+                                                        onClick: () => pokedexCategoryFilter.set(PokemonCategories.categories().filter(c => c.id > 0).map(c => c.id)),
+                                                    },
                                                 ],
                                                 bottomButtons: [
                                                     {
@@ -532,9 +537,9 @@ aria-labelledby="pokedexModalLabel">
                                                     </div>
                                                     <!-- /ko -->
                                                     <div class="dropdown-divider"></div>
-                                                    <a class="dropdown-item dropdown-text" href="#categoryModal" data-toggle="modal">
-                                                        <i>Edit categories</i>
-                                                    </a>
+                                                    <button class="btn btn-primary btn-sm btn-block font-weight-bold" data-toggle="modal" data-target="#categoryModal">
+                                                        Edit Categories
+                                                    </button>
                                                 </div>
                                             </div>
                                             <!-- /ko -->

--- a/src/styles/breeding.less
+++ b/src/styles/breeding.less
@@ -290,16 +290,13 @@
   }
   .category-loop(0);
 
-  button {
-    width: 16px;
-    height: 16px;
-    border: 1px #333 solid;
-    border-radius: 50%;
-    vertical-align: top;
-  }
-
   .category-display {
     button {
+      width: 16px;
+      height: 16px;
+      border: 1px #333 solid;
+      border-radius: 50%;
+      vertical-align: top;
       margin-right: -12px;
       transition: margin-right 0.5s ease;
     }


### PR DESCRIPTION
Re-adds the Categorized button in the pokedex & hatchery Category dropdown filters, when clicked it will select all categories other than None. Also normalizes the appearance of the Edit Categories buttons.

closes #6345 