### PR TITLE
Some 0.10.26 bugfixes

### DIFF
--- a/src/components/farmDisplay.html
+++ b/src/components/farmDisplay.html
@@ -168,7 +168,7 @@
                         <img width="100%" height="100%" src=""
                             style="width: 68.75%; max-height: 100%; image-rendering: pixelated;"
                             data-bind="attr: { src: FarmController.getImage($index()) },
-                                css: { 'wither-warning': $data.stage() == PlotStage.Berry && $data.calcTimeLeft() <= GameConstants.WITHER_WARNING_TIME }">
+                                css: { 'wither-warning': !$data.isAffectedByPetaya() && $data.stage() == PlotStage.Berry && $data.calcTimeLeft() <= GameConstants.WITHER_WARNING_TIME }">
                         </div>
                     <!-- /ko -->
                     <!-- ko if: $data.isSafeLocked -->

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -48,15 +48,17 @@
                                                 FarmController.selectedBerry($data);
                                                 FarmController.selectedFarmTool(FarmingTool.Berry);
                                             }, css: { 'active': FarmController.selectedBerry() === $data && FarmController.selectedFarmTool() == FarmingTool.Berry },
-                                            tooltip: App.game.farming.unlockedBerries[$data]() ? {
+                                            tooltip: {
                                                 html: true,
-                                                title: `<u>Growth Duration</u>: ${GameConstants.formatSecondsToTime(BerryList[$data].growthTime[3])}<br/>
+                                                title: App.game.farming.unlockedBerries[$data]() ?
+                                                    `<u>Growth Duration</u>: ${GameConstants.formatSecondsToTime(BerryList[$data].growthTime[3])}<br/>
                                                     ${BerryList[$data].harvestAmount.toLocaleString('en-US')} <img width='12px' alt='${BerryType[$data]}' src='${FarmController.getBerryImage($data)}' /> per harvest<br/>
-                                                    ${BerryList[$data].farmValue.toLocaleString('en-US')} <img width='12px' alt='Farm Points' src='assets/images/currency/farmPoint.svg' /> per harvest`,
+                                                    ${BerryList[$data].farmValue.toLocaleString('en-US')} <img width='12px' alt='Farm Points' src='assets/images/currency/farmPoint.svg' /> per harvest`
+                                                    : '',
                                                 placement: 'right',
                                                 trigger: 'hover',
                                                 animation: false,
-                                            } : {}">
+                                            }">
                                             <img src="" height="28px"
                                                 data-bind="attr:{ src: FarmController.getBerryImage($data) },
                                                 css: {'berryLocked': !App.game.farming.unlockedBerries[$data]() }">

--- a/src/components/farmModal.html
+++ b/src/components/farmModal.html
@@ -217,7 +217,7 @@
                                                 <img width="100%" height="100%" src=""
                                                     style="width: 68.75%; max-height: 100%; image-rendering: pixelated;"
                                                     data-bind="attr: { src: FarmController.getImage($index()) },
-                                                        css: { 'wither-warning': $data.stage() == PlotStage.Berry && $data.calcTimeLeft() <= GameConstants.WITHER_WARNING_TIME }">
+                                                        css: { 'wither-warning': !$data.isAffectedByPetaya() && $data.stage() == PlotStage.Berry && $data.calcTimeLeft() <= GameConstants.WITHER_WARNING_TIME }">
                                             </div>
                                             <!-- ko if: $data.isSafeLocked -->
                                             <img class ="plotSafeLockIcon" src= "assets/images/farm/plotSafeLock.svg" >

--- a/src/components/safariBattleModal.html
+++ b/src/components/safariBattleModal.html
@@ -58,12 +58,16 @@
                         <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split active" data-bind="text: '&nbsp;'" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         </button>
                         <div class="dropdown-menu dropdown-menu-right" data-bind="foreach: GameHelper.enumStrings(BaitType)">
-                            <button class="dropdown-item" type="button" data-bind="click: function(){SafariBattle.selectedBait(BaitList[$data])}, text: BaitList[$data].btnName,
-                                tooltip: {
-                                    title: BaitList[$data].description,
-                                    trigger: 'hover',
-                                    placement: 'left',
-                                }"></button>
+                            <div class="dropdown-item d-flex justify-content-between align-items-center">
+                                <button class="dropdown-item p-0" type="button" data-bind="click: function(){SafariBattle.selectedBait(BaitList[$data])}, text: BaitList[$data].btnName"></button>
+                                <span class="p-0 pl-2"
+                                    data-bind="click: function(bait, event){ event.stopPropagation(); },
+                                    tooltip: {
+                                        title: BaitList[$data].description,
+                                        trigger: 'hover',
+                                        placement: 'top',
+                                    }">ⓘ</span>
+                            </div>
                         </div>
                     </div>
                     <button type="button" class="btn btn-primary btn-block col-6 m-0" onclick="this.blur();SafariBattle.throwRock()" data-bind="disable: SafariBattle.busy()">

--- a/src/scripts/farming/Plot.ts
+++ b/src/scripts/farming/Plot.ts
@@ -213,7 +213,7 @@ class Plot implements Saveable {
 
                 const timeBoostType = Settings.getSetting('farmBoostDisplay').observableValue();
                 // Petaya Effect
-                if (App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && this.berry !== BerryType.Petaya && this.stage() == PlotStage.Berry) {
+                if (this.isAffectedByPetaya() && this.stage() == PlotStage.Berry) {
                     tooltip.push('∞ until death');
                     if (timeBoostType) {
                         tooltip.push(`(altered from ${this.formattedBaseStageTimeLeft()})`);
@@ -339,7 +339,7 @@ class Plot implements Saveable {
                 change = true;
             }
 
-            if (!this._hasWarnedAboutToWither && this.stage() == PlotStage.Berry && this.age + GameConstants.WITHER_WARNING_TIME >= this.berryData.growthTime[PlotStage.Berry]) {
+            if (!this._hasWarnedAboutToWither && !this.isAffectedByPetaya() && this.stage() == PlotStage.Berry && this.age + GameConstants.WITHER_WARNING_TIME >= this.berryData.growthTime[PlotStage.Berry]) {
                 this.notifications.push(FarmNotificationType.AboutToWither);
                 this._hasWarnedAboutToWither = true;
             }
@@ -573,6 +573,10 @@ class Plot implements Saveable {
             this.mulchTimeLeft = 0;
         }
         return wasMulched;
+    }
+
+    private isAffectedByPetaya(): boolean {
+        return App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && this.berry !== BerryType.Petaya;
     }
 
     fromJSON(json: Record<string, any>): void {


### PR DESCRIPTION
## Description
Updated Safari bait tooltip so it handles nicer on mobile and doesn't block narrow screens selecting baits (fixes #6347)
Fixed berry tooltips not rendering the HTML when the berry was newly unlocked, before the element got re-rendered (fixes #6349)
Updated the wither notification and flashing so that it doesn't take effect when a Petaya is stopping the berry from withering. Once the Petaya effect is removed the flashing starts/notification pops

## Screenshots (optional):
<img width="279" height="220" alt="image" src="https://github.com/user-attachments/assets/b2082100-d663-4009-a09f-1486448a8a2c" />


## Types of changes
- Bug fix
