### PR TITLE
Some translations again : Notifications (and more)

### DIFF
--- a/src/modules/items/PokemonItem.ts
+++ b/src/modules/items/PokemonItem.ts
@@ -52,7 +52,7 @@ export default class PokemonItem extends PokerusIndicatingItem {
         if (shiny || !App.game.party.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(pokemonName).id)) {
             const newCatch = !(shiny && App.game.party.alreadyCaughtPokemon(PokemonHelper.getPokemonByName(pokemonName).id, true));
             Notifier.notify({
-                message: `${(shiny) ? `✨ You obtained a shiny ${pokemonName}! ✨` : `You obtained ${GameHelper.anOrA(pokemonName)} ${pokemonName}!`}`,
+                message: `${(shiny) ? `✨ You obtained a shiny ${PokemonHelper.displayName(pokemonName)}! ✨` : `You obtained ${GameHelper.anOrA(PokemonHelper.displayName(pokemonName))} ${PokemonHelper.displayName(pokemonName)}!`}`,
                 pokemonImage: PokemonHelper.getImage(pokemonID, shiny, undefined, ShadowStatus.None),
                 type: (shiny ? NotificationConstants.NotificationOption.warning : NotificationConstants.NotificationOption.success),
                 setting: NotificationConstants.NotificationSetting.General.new_catch,

--- a/src/modules/requirements/ObtainedPokemonRequirement.ts
+++ b/src/modules/requirements/ObtainedPokemonRequirement.ts
@@ -12,7 +12,7 @@ export default class ObtainedPokemonRequirement extends Requirement {
     }
 
     public hint(): string {
-		const name = App.translation.get(this.pokemon, 'pokemon')();
+        const name = App.translation.get(this.pokemon, 'pokemon')();
         return this.option === AchievementOption.more
             ? `${name} needs to be owned.`
             : `${name} cannot be owned yet.`;

--- a/src/modules/requirements/ObtainedPokemonRequirement.ts
+++ b/src/modules/requirements/ObtainedPokemonRequirement.ts
@@ -1,7 +1,6 @@
 import { AchievementOption } from '../GameConstants';
 import Requirement from './Requirement';
 import { PokemonNameType } from '../pokemons/PokemonNameType';
-import { displayName } from '../pokemons/PokemonHelper';
 
 export default class ObtainedPokemonRequirement extends Requirement {
     constructor(public pokemon: PokemonNameType, uncaught = false) {
@@ -13,8 +12,9 @@ export default class ObtainedPokemonRequirement extends Requirement {
     }
 
     public hint(): string {
+		const name = App.translation.get(this.pokemon, 'pokemon')();
         return this.option === AchievementOption.more
-            ? `${displayName(this.pokemon)} needs to be owned.`
-            : `${displayName(this.pokemon)} cannot be owned yet.`;
+            ? `${name} needs to be owned.`
+            : `${name} cannot be owned yet.`;
     }
 }

--- a/src/modules/requirements/ObtainedPokemonRequirement.ts
+++ b/src/modules/requirements/ObtainedPokemonRequirement.ts
@@ -1,6 +1,7 @@
 import { AchievementOption } from '../GameConstants';
 import Requirement from './Requirement';
 import { PokemonNameType } from '../pokemons/PokemonNameType';
+import { displayName } from '../pokemons/PokemonHelper';
 
 export default class ObtainedPokemonRequirement extends Requirement {
     constructor(public pokemon: PokemonNameType, uncaught = false) {
@@ -13,7 +14,7 @@ export default class ObtainedPokemonRequirement extends Requirement {
 
     public hint(): string {
         return this.option === AchievementOption.more
-            ? `${this.pokemon} needs to be owned.`
-            : `${this.pokemon} cannot be owned yet.`;
+            ? `${displayName(this.pokemon)} needs to be owned.`
+            : `${displayName(this.pokemon)} cannot be owned yet.`;
     }
 }

--- a/src/scripts/discord/DiscordPokemonCode.ts
+++ b/src/scripts/discord/DiscordPokemonCode.ts
@@ -14,7 +14,8 @@ class DiscordPokemonCode extends DiscordCode {
             App.game.party.gainPokemonById(pokemon.id, shiny, true);
             // Notify that the code was activated successfully
             Notifier.notify({
-                message: `You obtained a${shiny ? ' shiny' : ''} ${pokemon.name}!`,
+                message: `You obtained a${shiny ? ' shiny' : ''} ${PokemonHelper.displayName(pokemon.name)}!`,
+                pokemonImage: PokemonHelper.getImage(PokemonHelper.getPokemonByName(pokemon.name).id, shiny),
                 type: NotificationConstants.NotificationOption.success,
                 timeout: 1e4,
             });

--- a/src/scripts/encountersInfo/DungeonInfo.ts
+++ b/src/scripts/encountersInfo/DungeonInfo.ts
@@ -53,7 +53,7 @@ class DungeonInfo {
                 return `${input} Berry`;
             case pokemonMap[input].name == input:
                 const caught = App.game.party.alreadyCaughtPokemonByName(input);
-                return caught ? input : 'Unknown Mimic';
+                return caught ? PokemonHelper.displayName(input) : 'Unknown Mimic';
             default:
                 return GameConstants.camelCaseToString(GameConstants.humanifyString(input.toLowerCase()));
         }

--- a/src/scripts/farming/Farming.ts
+++ b/src/scripts/farming/Farming.ts
@@ -744,7 +744,7 @@ class Farming implements Feature {
                 // Only notify for one wanderer, randomly picked, shiny priorized; there will rarely be more than one
                 const shinyList = wanderList.filter(w => w.shiny);
                 const displayWanderer = shinyList.length ? Rand.fromArray(shinyList) : Rand.fromArray(wanderList);
-                message = `A wild ${(displayWanderer.shiny ? 'shiny ' : '')}${displayWanderer.name} has wandered onto the farm!`;
+                message = `A wild ${(displayWanderer.shiny ? 'shiny ' : '')}${PokemonHelper.displayName(displayWanderer.name)} has wandered onto the farm!`;
                 image = PokemonHelper.getImage(PokemonHelper.getPokemonByName(displayWanderer.name).id, displayWanderer.shiny, undefined, GameConstants.ShadowStatus.None);
                 type = displayWanderer.shiny ? NotificationConstants.NotificationOption.warning : NotificationConstants.NotificationOption.success;
                 sound = displayWanderer.shiny ? NotificationConstants.NotificationSound.General.shiny_long : NotificationConstants.NotificationSound.Farming.wandering_pokemon;

--- a/src/scripts/party/PartyPokemon.ts
+++ b/src/scripts/party/PartyPokemon.ts
@@ -96,7 +96,7 @@ class PartyPokemon implements Saveable, TmpPartyPokemonType {
 
                     // Log and notify player
                     Notifier.notify({
-                        message: `${this.name} has become Resistant to Pokérus.`,
+                        message: `${PokemonHelper.displayName(this.name)} has become Resistant to Pokérus.`,
                         pokemonImage: PokemonHelper.getImage(this.id),
                         type: NotificationConstants.NotificationOption.info,
                         sound: NotificationConstants.NotificationSound.General.pokerus,

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -51,7 +51,7 @@ class PokemonFactory {
         }
         if (roaming) {
             Notifier.notify({
-                message: `You encountered a roaming ${name}!`,
+                message: `You encountered a roaming ${PokemonHelper.displayName(name)}!`,
                 pokemonImage: PokemonHelper.getImage(id, shiny, basePokemon.gender, GameConstants.ShadowStatus.None),
                 type: NotificationConstants.NotificationOption.warning,
                 sound: NotificationConstants.NotificationSound.General.roaming,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Please fill out this form, so that we have all the info needed to review your changes -->
<!-- Any text inside of the angle brackets will not show up in the final comment. Check the Preview tab to confirm -->

## Description
<!-- Describe your changes in detail -->
<!-- If you are adding new content, please let us know if it is based on some canon, and provide a reference to it -->

Translation of Pokémon names in notification of : 
- Roaming Pokémon
- Wandering Pokémon
- Pokérus Resisted
- Bought of Pokémon Item
- Discord Code Pokémon + Image of the Pokémon (missing)

Translation of Pokémon names in :
- Status Requirement when the Pokémon have to be catched (for instance : the Pokémons in Friend Safari)
- Mimic Pokémons in view of Dungeons

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Please also link to any related issues or PRs here. -->
<!-- You can link an issue to be auto-closed when this is merged by writing 'Closes #1234' or 'Fixes #1234' -->

Help improve the game. I’ve already done some translations; whenever I spot missing ones, I enjoy fixing them and submitting them to the developers. I can't make major changes, so I just make small tweaks here and there—nothing too complicated!

Duplicata of #5678 and #5451 but closed. It has been two years since the original PR was written, and for the sake of non-English-speaking players, I would like to see it integrated into the game. I think it is high time. Thanks in advance to the developers.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Waiting the notification comes and see the Pokémon name in French (my maternal langage).
Go in Friend Safari and see the Pokémon name of non-catched Pokémon.
View a Mimic catched Pokémon and see his name (Relic Castle in Unova for instance).

## Screenshots (optional):
<!-- Drag a screenshot into this textbox to upload your image -->
![image](https://github.com/user-attachments/assets/32ecdc1c-1dca-4f7f-8ab8-6014b90807b3)
![image](https://github.com/user-attachments/assets/09a54837-6e36-4789-9eee-b44b31c31fb7)
![image](https://github.com/user-attachments/assets/d16585f2-ccec-4990-bcb9-baca31f180c1)
![image](https://github.com/user-attachments/assets/499d436e-14de-4a79-b7f5-eb5460d578d7)
<img width="250" height="101" alt="{1A6C9BA6-0B29-4028-AFFB-CFDB6680DB34}" src="https://github.com/user-attachments/assets/fee36021-9230-4604-9e82-48e9d31539f1" />
<img width="776" height="142" alt="{1D4A4F5B-FC74-4346-8901-D67D2DEFC1F7}" src="https://github.com/user-attachments/assets/cd66000c-c161-4a73-a317-d1a880c6ac01" />

## Types of changes
<!-- What types of changes does your code introduce? Delete any that don't apply, and/or add more you think would be useful -->
- UI improvement : Some Translations + Image
