### PR TITLE
Remove 1.1s of waiting in Save file loading

### DIFF
--- a/src/modules/GameConstants.ts
+++ b/src/modules/GameConstants.ts
@@ -22,7 +22,6 @@ export const GYM_TIME = 30 * SECOND;
 export const GYM_COUNTDOWN = 1 * SECOND;
 export const GYM_TICK = 0.1 * SECOND;
 export const ACHIEVEMENT_TICK = 1 * SECOND;
-export const MIN_LOAD_TIME = 0.5 * SECOND;
 export const MAX_LOAD_TIME = 20 * SECOND;
 export const MUTATION_TICK = 1 * SECOND;
 export const WANDER_TICK = 1.5 * SECOND;

--- a/src/scripts/utilities/Preload.ts
+++ b/src/scripts/utilities/Preload.ts
@@ -70,14 +70,11 @@ class Preload {
                     // Preload.loadUndergroundItems(),
                     // Preload.loadMap(),
                     // Preload.loadPokemon(),
-                    Preload.minimumTime(),
+                    new Promise<void>(resolve => setTimeout(resolve, 0)),
                 ]).then(() => {
                     clearTimeout(forceLoad);
                     console.log(`[${GameConstants.formatDate(new Date())}] %cPreloaded images`, 'color:#2ecc71;font-weight:900;');
-                    // Give the progress bar a little bit of time to finish the animation
-                    setTimeout(() => {
-                        resolve();
-                    }, 600);
+                    resolve();
                 }).catch((reason => {
                     console.log(`[${GameConstants.formatDate(new Date())}] %cPreload images failed..`, 'color:#c0392b;font-weight:900;');
                     console.error('Preload images failed:', reason);
@@ -161,14 +158,6 @@ class Preload {
             }));
         });
         return Promise.all(p);
-    }
-
-    private static minimumTime() {
-        return new Promise<void>(resolve => {
-            setTimeout(() => {
-                resolve();
-            }, GameConstants.MIN_LOAD_TIME);
-        });
     }
 
     private static loadMap() {


### PR DESCRIPTION
## Description
Removed a 500ms and 600ms wait, both seemingly for the same issue (a flashing loading bar if it's quick), but A) we don't preload anything B) even if we did preload, the rest of the game loading after Preload ensures the loading icon doesn't flash away instantly

## Motivation 
Speed

## How Has This Been Tested?
Checked loading worked fine. Also checked that the commented out Preload stuff works, if we did ever want it


## Types of changes
- Bug fix
